### PR TITLE
feat: add bulk delete conversations endpoint

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -142,7 +142,7 @@ Pick scenarios from the tables below. Spawn agents that touch **different files*
 - [ ] 10. Webhook notifications on new conversations
 - [ ] 11. Search conversations by content
 - [ ] 12. Conversation tags/labels
-- [ ] 13. Bulk delete conversations
+- [x] 13. Bulk delete conversations
 - [ ] 14. API versioning strategy
 - [ ] 15. Custom domain SSL verification page
 
@@ -162,3 +162,4 @@ Pick scenarios from the tables below. Spawn agents that touch **different files*
 - [x] 42 passing tests
 - [x] Biome linting
 - [x] Single Worker deployment
+- [x] Bulk delete conversations endpoint (POST /v1/conversations/bulk-delete)

--- a/packages/api/src/routes/conversations.ts
+++ b/packages/api/src/routes/conversations.ts
@@ -37,6 +37,10 @@ const ExportSchema = z.object({
   ids: z.array(z.string()).max(100).optional(),
 });
 
+const BulkDeleteSchema = z.object({
+  ids: z.array(z.string()).min(1).max(100),
+});
+
 // ---------------------------------------------------------------------------
 // Helper: serialize metadata to/from JSON text column
 // ---------------------------------------------------------------------------
@@ -471,6 +475,43 @@ router.get("/:id/messages", async (c) => {
       next_cursor: nextCursor,
     },
   });
+});
+
+// ---------------------------------------------------------------------------
+// POST /bulk-delete — Delete multiple conversations at once
+// ---------------------------------------------------------------------------
+
+router.post("/bulk-delete", async (c) => {
+  const body = await c.req.json().catch(() => null);
+  if (body === null) {
+    return c.json({ error: { code: "BAD_REQUEST", message: "Invalid JSON body" } }, 400);
+  }
+
+  const parsed = BulkDeleteSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: { code: "BAD_REQUEST", message: parsed.error.issues[0].message } }, 400);
+  }
+
+  const db = c.get("db");
+  const projectId = c.get("projectId");
+  const ids = parsed.data.ids;
+
+  // Only delete conversations that belong to this project
+  const existing = await db
+    .select({ id: conversations.id })
+    .from(conversations)
+    .where(and(eq(conversations.projectId, projectId), inArray(conversations.id, ids)));
+
+  const existingIds = existing.map((r) => r.id);
+
+  if (existingIds.length > 0) {
+    await db.batch([
+      db.delete(messages).where(inArray(messages.conversationId, existingIds)),
+      db.delete(conversations).where(inArray(conversations.id, existingIds)),
+    ]);
+  }
+
+  return c.json({ deleted: existingIds.length });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/test/conversations.test.ts
+++ b/packages/api/test/conversations.test.ts
@@ -606,6 +606,97 @@ describe("Conversations", () => {
   });
 
   // -------------------------------------------------------------------------
+  // POST /bulk-delete — Bulk delete conversations
+  // -------------------------------------------------------------------------
+
+  describe("POST /v1/conversations/bulk-delete", () => {
+    it("deletes multiple conversations and their messages", async () => {
+      const res1 = await createConversation({
+        title: "Bulk Delete A",
+        messages: [{ role: "user", content: "msg a" }],
+      });
+      const res2 = await createConversation({
+        title: "Bulk Delete B",
+        messages: [{ role: "user", content: "msg b" }],
+      });
+      const c1 = await res1.json<ConversationWithMessages>();
+      const c2 = await res2.json<ConversationWithMessages>();
+
+      const deleteRes = await SELF.fetch("http://localhost/v1/conversations/bulk-delete", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ ids: [c1.id, c2.id] }),
+      });
+      expect(deleteRes.status).toBe(200);
+
+      const body = await deleteRes.json<{ deleted: number }>();
+      expect(body.deleted).toBe(2);
+
+      // Verify both are gone
+      const get1 = await SELF.fetch(`http://localhost/v1/conversations/${c1.id}`, {
+        headers: authHeaders(),
+      });
+      expect(get1.status).toBe(404);
+
+      const get2 = await SELF.fetch(`http://localhost/v1/conversations/${c2.id}`, {
+        headers: authHeaders(),
+      });
+      expect(get2.status).toBe(404);
+
+      // Verify messages were cascaded
+      const msgCount = await env.DB.prepare(
+        `SELECT COUNT(*) as count FROM messages WHERE conversation_id IN (?, ?)`,
+      )
+        .bind(c1.id, c2.id)
+        .first<{ count: number }>();
+      expect(msgCount!.count).toBe(0);
+    });
+
+    it("ignores non-existent IDs and only deletes existing ones", async () => {
+      const res = await createConversation({ title: "Bulk Keep" });
+      const created = await res.json<ConversationWithMessages>();
+
+      const deleteRes = await SELF.fetch("http://localhost/v1/conversations/bulk-delete", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ ids: [created.id, "nonexistent_id_1", "nonexistent_id_2"] }),
+      });
+      expect(deleteRes.status).toBe(200);
+
+      const body = await deleteRes.json<{ deleted: number }>();
+      expect(body.deleted).toBe(1);
+    });
+
+    it("returns 400 when ids array is empty", async () => {
+      const res = await SELF.fetch("http://localhost/v1/conversations/bulk-delete", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ ids: [] }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when ids array exceeds the 100-item limit", async () => {
+      const tooManyIds = Array.from({ length: 101 }, (_, i) => `id-${i}`);
+      const res = await SELF.fetch("http://localhost/v1/conversations/bulk-delete", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ ids: tooManyIds }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 401 without auth", async () => {
+      const res = await SELF.fetch("http://localhost/v1/conversations/bulk-delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ids: ["some_id"] }),
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // POST /export — Bulk export
   // -------------------------------------------------------------------------
 


### PR DESCRIPTION
Add POST /v1/conversations/bulk-delete that accepts { ids: string[] }
(1-100 items) and deletes all matching conversations with their messages
in a single batch operation. Returns { deleted: number } with the count
of actually deleted conversations. Non-existent IDs are silently ignored.

Includes 5 tests covering happy path, partial matches, empty/oversized
arrays, and auth.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>

https://claude.ai/code/session_01XaovzZ5Qf3eXnPrVCRNQG9

## Summary by Sourcery

Add an authenticated bulk deletion endpoint for conversations and cover it with tests.

New Features:
- Introduce POST /v1/conversations/bulk-delete to delete multiple conversations in a single request and return the number of deleted records.

Documentation:
- Update the project plan to mark the bulk delete conversations feature and endpoint as completed.

Tests:
- Add integration tests for bulk deleting conversations, handling non-existent IDs, validating array size constraints, and enforcing authentication.