### PR TITLE
feat: usage analytics dashboard + auth middleware

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
         "next-themes": "^0.4.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "recharts": "^3.8.0",
         "shadcn": "^4.0.8",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
@@ -407,6 +408,8 @@
 
     "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
 
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
+
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
 
     "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.59.0", "", { "os": "android", "cpu": "arm64" }, "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q=="],
@@ -469,6 +472,10 @@
 
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
+
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.2.1", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.31.1", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.1" } }, "sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg=="],
@@ -509,6 +516,24 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -524,6 +549,8 @@
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
+
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
 
@@ -753,6 +780,28 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "damerau-levenshtein": ["damerau-levenshtein@1.0.8", "", {}, "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="],
 
     "dashboard": ["dashboard@workspace:packages/dashboard"],
@@ -766,6 +815,8 @@
     "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "dedent": ["dedent@1.7.2", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA=="],
 
@@ -843,6 +894,8 @@
 
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
 
+    "es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
+
     "esbuild": ["esbuild@0.19.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.19.12", "@esbuild/android-arm": "0.19.12", "@esbuild/android-arm64": "0.19.12", "@esbuild/android-x64": "0.19.12", "@esbuild/darwin-arm64": "0.19.12", "@esbuild/darwin-x64": "0.19.12", "@esbuild/freebsd-arm64": "0.19.12", "@esbuild/freebsd-x64": "0.19.12", "@esbuild/linux-arm": "0.19.12", "@esbuild/linux-arm64": "0.19.12", "@esbuild/linux-ia32": "0.19.12", "@esbuild/linux-loong64": "0.19.12", "@esbuild/linux-mips64el": "0.19.12", "@esbuild/linux-ppc64": "0.19.12", "@esbuild/linux-riscv64": "0.19.12", "@esbuild/linux-s390x": "0.19.12", "@esbuild/linux-x64": "0.19.12", "@esbuild/netbsd-x64": "0.19.12", "@esbuild/openbsd-x64": "0.19.12", "@esbuild/sunos-x64": "0.19.12", "@esbuild/win32-arm64": "0.19.12", "@esbuild/win32-ia32": "0.19.12", "@esbuild/win32-x64": "0.19.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg=="],
 
     "esbuild-register": ["esbuild-register@3.6.0", "", { "dependencies": { "debug": "^4.3.4" }, "peerDependencies": { "esbuild": ">=0.12 <1" } }, "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg=="],
@@ -890,6 +943,8 @@
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
@@ -1031,6 +1086,8 @@
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
@@ -1038,6 +1095,8 @@
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
@@ -1387,9 +1446,17 @@
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
+    "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
+
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
+
+    "recharts": ["recharts@3.8.0", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
@@ -1647,6 +1714,8 @@
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
+    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
+
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
@@ -1736,6 +1805,8 @@
     "@next/eslint-plugin-next/fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
 
     "@poppinss/dumper/supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+
+    "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w=="],
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -5,6 +5,7 @@ import { AGENTS_MD, LLMS_TXT } from "./content/static";
 import { dbMiddleware } from "./middleware/db";
 import { requestIdMiddleware } from "./middleware/request-id";
 import aiRouter from "./routes/ai";
+import analyticsRouter from "./routes/analytics";
 import conversationsRouter from "./routes/conversations";
 import keysRouter from "./routes/keys";
 import projectsRouter from "./routes/projects";
@@ -49,6 +50,8 @@ app.route("/api/v1/conversations", aiRouter);
 app.route("/api/projects", keysRouter);
 // Dashboard-internal project management routes (no API key auth required)
 app.route("/api/v1/projects", projectsRouter);
+// Analytics routes: /api/v1/projects/:id/analytics
+app.route("/api/v1/projects", analyticsRouter);
 // Tags routes: handles /api/v1/conversations/:id/tags and /api/v1/tags
 app.route("/api/v1", tagsRouter);
 

--- a/packages/api/src/routes/analytics.ts
+++ b/packages/api/src/routes/analytics.ts
@@ -1,0 +1,94 @@
+import { and, eq, gte, sql } from "drizzle-orm";
+import { Hono } from "hono";
+import { conversations, messages } from "../db/schema";
+import type { Bindings, Variables } from "../types";
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+// ---------------------------------------------------------------------------
+// GET /v1/projects/:id/analytics — Usage analytics for a project
+// ---------------------------------------------------------------------------
+
+const RANGE_DAYS: Record<string, number> = { "7d": 7, "30d": 30, "90d": 90 };
+
+app.get("/:id/analytics", async (c) => {
+  const db = c.get("db");
+  const projectId = c.req.param("id");
+
+  const rangeParam = c.req.query("range") ?? "30d";
+  const days = RANGE_DAYS[rangeParam] ?? 30;
+  const cutoff = Date.now() - days * 86_400_000;
+
+  // Summary stats — single query with scalar subqueries
+  const [summary] = await db
+    .select({
+      total_conversations: sql<number>`(SELECT COUNT(*) FROM conversations WHERE project_id = ${projectId})`,
+      total_messages: sql<number>`(SELECT COALESCE(SUM(message_count), 0) FROM conversations WHERE project_id = ${projectId})`,
+      total_tokens: sql<number>`(SELECT COALESCE(SUM(token_count), 0) FROM conversations WHERE project_id = ${projectId})`,
+      active_api_keys: sql<number>`(SELECT COUNT(*) FROM api_keys WHERE project_id = ${projectId} AND revoked_at IS NULL)`,
+    })
+    .from(sql`(SELECT 1)`);
+
+  // Conversations per day
+  const conversationsPerDay = await db
+    .select({
+      date: sql<string>`date(${conversations.createdAt} / 1000, 'unixepoch')`.as("date"),
+      count: sql<number>`COUNT(*)`.as("count"),
+    })
+    .from(conversations)
+    .where(and(eq(conversations.projectId, projectId), gte(conversations.createdAt, cutoff)))
+    .groupBy(sql`date`)
+    .orderBy(sql`date`);
+
+  // Messages per day
+  const messagesPerDay = await db
+    .select({
+      date: sql<string>`date(${messages.createdAt} / 1000, 'unixepoch')`.as("date"),
+      count: sql<number>`COUNT(*)`.as("count"),
+    })
+    .from(messages)
+    .innerJoin(conversations, eq(conversations.id, messages.conversationId))
+    .where(and(eq(conversations.projectId, projectId), gte(messages.createdAt, cutoff)))
+    .groupBy(sql`date`)
+    .orderBy(sql`date`);
+
+  // Tokens per day
+  const tokensPerDay = await db
+    .select({
+      date: sql<string>`date(${messages.createdAt} / 1000, 'unixepoch')`.as("date"),
+      total: sql<number>`COALESCE(SUM(${messages.tokenCount}), 0)`.as("total"),
+    })
+    .from(messages)
+    .innerJoin(conversations, eq(conversations.id, messages.conversationId))
+    .where(and(eq(conversations.projectId, projectId), gte(messages.createdAt, cutoff)))
+    .groupBy(sql`date`)
+    .orderBy(sql`date`);
+
+  // Recent conversations (last 10)
+  const recent = await db
+    .select({
+      id: conversations.id,
+      title: conversations.title,
+      message_count: conversations.messageCount,
+      token_count: conversations.tokenCount,
+      updated_at: conversations.updatedAt,
+    })
+    .from(conversations)
+    .where(eq(conversations.projectId, projectId))
+    .orderBy(sql`${conversations.updatedAt} DESC`)
+    .limit(10);
+
+  return c.json({
+    summary,
+    conversations_per_day: conversationsPerDay,
+    messages_per_day: messagesPerDay,
+    tokens_per_day: tokensPerDay,
+    recent_conversations: recent,
+  });
+});
+
+export default app;

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -19,6 +19,7 @@
     "next-themes": "^0.4.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "recharts": "^3.8.0",
     "shadcn": "^4.0.8",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",

--- a/packages/dashboard/src/app/dashboard/analytics/page.tsx
+++ b/packages/dashboard/src/app/dashboard/analytics/page.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AreaChartCard } from "@/components/analytics/area-chart";
+import { RecentActivity } from "@/components/analytics/recent-activity";
+import { SummaryCards } from "@/components/analytics/summary-cards";
+import { TimeRangeSelect, type TimeRange } from "@/components/analytics/time-range-select";
+import { api } from "@/lib/api";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface Project {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+interface AnalyticsData {
+  summary: {
+    total_conversations: number;
+    total_messages: number;
+    total_tokens: number;
+    active_api_keys: number;
+  };
+  conversations_per_day: { date: string; count: number }[];
+  messages_per_day: { date: string; count: number }[];
+  tokens_per_day: { date: string; total: number }[];
+  recent_conversations: {
+    id: string;
+    title: string | null;
+    message_count: number;
+    token_count: number;
+    updated_at: number;
+  }[];
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function AnalyticsPage() {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [selectedProjectId, setSelectedProjectId] = useState("");
+  const [range, setRange] = useState<TimeRange>("30d");
+  const [data, setData] = useState<AnalyticsData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // Fetch projects
+  useEffect(() => {
+    api<{ data: Project[] }>("/v1/projects")
+      .then((res) => {
+        setProjects(res.data);
+        if (res.data.length > 0) {
+          setSelectedProjectId(res.data[0].id);
+        }
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  // Fetch analytics when project or range changes
+  useEffect(() => {
+    if (!selectedProjectId) return;
+    setLoading(true);
+    api<AnalyticsData>(`/v1/projects/${selectedProjectId}/analytics?range=${range}`)
+      .then(setData)
+      .catch(() => setData(null))
+      .finally(() => setLoading(false));
+  }, [selectedProjectId, range]);
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="flex items-start justify-between mb-6 gap-4 flex-wrap">
+        <div>
+          <h1 className="text-lg font-semibold tracking-tight text-foreground">Analytics</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Usage metrics and activity for your project.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          {projects.length > 1 && (
+            <select
+              value={selectedProjectId}
+              onChange={(e) => setSelectedProjectId(e.target.value)}
+              className="text-xs h-8 px-2 rounded-md border border-input bg-background text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+              aria-label="Select project"
+            >
+              {projects.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          )}
+          <TimeRangeSelect value={range} onChange={setRange} />
+        </div>
+      </div>
+
+      {/* Loading */}
+      {loading && !data && (
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            {[1, 2, 3, 4].map((i) => (
+              <div key={i} className="h-20 bg-muted rounded-lg animate-pulse" />
+            ))}
+          </div>
+          <div className="h-56 bg-muted rounded-lg animate-pulse" />
+          <div className="h-56 bg-muted rounded-lg animate-pulse" />
+        </div>
+      )}
+
+      {/* Content */}
+      {data && (
+        <div className="space-y-6">
+          <SummaryCards
+            totalConversations={data.summary.total_conversations}
+            totalMessages={data.summary.total_messages}
+            totalTokens={data.summary.total_tokens}
+            activeApiKeys={data.summary.active_api_keys}
+          />
+
+          <div className="grid gap-6 lg:grid-cols-2">
+            <AreaChartCard
+              title="Conversations"
+              data={data.conversations_per_day.map((d) => ({ date: d.date, value: d.count }))}
+              color="#2563eb"
+              valueLabel="Conversations"
+            />
+            <AreaChartCard
+              title="Messages"
+              data={data.messages_per_day.map((d) => ({ date: d.date, value: d.count }))}
+              color="#16a34a"
+              valueLabel="Messages"
+            />
+          </div>
+
+          <AreaChartCard
+            title="Token Usage"
+            data={data.tokens_per_day.map((d) => ({ date: d.date, value: d.total }))}
+            color="#9333ea"
+            valueLabel="Tokens"
+          />
+
+          <div>
+            <h3 className="text-sm font-medium text-foreground mb-3">Recent activity</h3>
+            <RecentActivity conversations={data.recent_conversations} />
+          </div>
+        </div>
+      )}
+
+      {/* No projects */}
+      {!loading && projects.length === 0 && (
+        <div className="border border-dashed border-border rounded-lg p-12 text-center">
+          <p className="text-sm text-foreground mb-1">No projects yet</p>
+          <p className="text-xs text-muted-foreground">Create a project to see analytics.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/analytics/area-chart.tsx
+++ b/packages/dashboard/src/components/analytics/area-chart.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import {
+  Area,
+  AreaChart as RechartsAreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+interface DataPoint {
+  date: string;
+  value: number;
+}
+
+interface AreaChartCardProps {
+  title: string;
+  data: DataPoint[];
+  color?: string;
+  valueLabel?: string;
+}
+
+function fillDateGaps(data: DataPoint[], days: number): DataPoint[] {
+  if (data.length === 0) {
+    // Generate empty date range
+    const result: DataPoint[] = [];
+    const now = new Date();
+    for (let i = days - 1; i >= 0; i--) {
+      const d = new Date(now);
+      d.setDate(d.getDate() - i);
+      result.push({ date: d.toISOString().slice(0, 10), value: 0 });
+    }
+    return result;
+  }
+
+  const map = new Map(data.map((d) => [d.date, d.value]));
+  const result: DataPoint[] = [];
+
+  // Parse first date and fill forward
+  const start = new Date(data[0].date);
+  const end = new Date(data[data.length - 1].date);
+
+  const current = new Date(start);
+  while (current <= end) {
+    const key = current.toISOString().slice(0, 10);
+    result.push({ date: key, value: map.get(key) ?? 0 });
+    current.setDate(current.getDate() + 1);
+  }
+
+  return result;
+}
+
+function formatDateLabel(dateStr: string): string {
+  const d = new Date(dateStr);
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+export function AreaChartCard({ title, data, color = "#2563eb", valueLabel = "Count" }: AreaChartCardProps) {
+  const filled = fillDateGaps(data, 30);
+
+  return (
+    <div className="border border-border rounded-lg p-5 bg-card">
+      <h3 className="text-sm font-medium text-foreground mb-4">{title}</h3>
+      <div className="h-48">
+        <ResponsiveContainer width="100%" height="100%">
+          <RechartsAreaChart data={filled} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
+            <defs>
+              <linearGradient id={`gradient-${title}`} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor={color} stopOpacity={0.2} />
+                <stop offset="100%" stopColor={color} stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" vertical={false} />
+            <XAxis
+              dataKey="date"
+              tickFormatter={formatDateLabel}
+              tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+              axisLine={false}
+              tickLine={false}
+              interval="preserveStartEnd"
+            />
+            <YAxis
+              tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+              axisLine={false}
+              tickLine={false}
+              width={40}
+              allowDecimals={false}
+            />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: "hsl(var(--card))",
+                border: "1px solid hsl(var(--border))",
+                borderRadius: "8px",
+                fontSize: "12px",
+              }}
+              labelFormatter={(label) => formatDateLabel(String(label))}
+              formatter={(value) => [Number(value).toLocaleString(), valueLabel]}
+            />
+            <Area
+              type="monotone"
+              dataKey="value"
+              stroke={color}
+              strokeWidth={2}
+              fill={`url(#gradient-${title})`}
+            />
+          </RechartsAreaChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/analytics/recent-activity.tsx
+++ b/packages/dashboard/src/components/analytics/recent-activity.tsx
@@ -1,0 +1,76 @@
+import { MessageSquareIcon } from "lucide-react";
+
+interface RecentConversation {
+  id: string;
+  title: string | null;
+  message_count: number;
+  token_count: number;
+  updated_at: number;
+}
+
+interface RecentActivityProps {
+  conversations: RecentConversation[];
+}
+
+function timeAgo(ts: number): string {
+  const seconds = Math.floor((Date.now() - ts) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function RecentActivity({ conversations }: RecentActivityProps) {
+  if (conversations.length === 0) {
+    return (
+      <div className="border border-dashed border-border rounded-lg p-8 text-center">
+        <MessageSquareIcon className="h-5 w-5 text-muted-foreground mx-auto mb-2" />
+        <p className="text-sm text-muted-foreground">No recent conversations</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border border-border rounded-lg overflow-hidden bg-card">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border">
+            <th className="text-left px-4 py-2.5 text-xs text-muted-foreground font-medium">
+              Title
+            </th>
+            <th className="text-left px-4 py-2.5 text-xs text-muted-foreground font-medium hidden sm:table-cell">
+              Messages
+            </th>
+            <th className="text-left px-4 py-2.5 text-xs text-muted-foreground font-medium hidden sm:table-cell">
+              Tokens
+            </th>
+            <th className="text-right px-4 py-2.5 text-xs text-muted-foreground font-medium">
+              Updated
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {conversations.map((conv) => (
+            <tr key={conv.id} className="border-b last:border-b-0 border-border hover:bg-muted/20 transition-colors">
+              <td className="px-4 py-2.5 truncate max-w-[200px]">
+                {conv.title || "Untitled"}
+              </td>
+              <td className="px-4 py-2.5 tabular-nums text-muted-foreground hidden sm:table-cell">
+                {conv.message_count}
+              </td>
+              <td className="px-4 py-2.5 tabular-nums text-muted-foreground hidden sm:table-cell">
+                {conv.token_count.toLocaleString()}
+              </td>
+              <td className="px-4 py-2.5 text-right text-muted-foreground">
+                {timeAgo(conv.updated_at)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/analytics/summary-cards.tsx
+++ b/packages/dashboard/src/components/analytics/summary-cards.tsx
@@ -1,0 +1,36 @@
+import { CoinsIcon, HashIcon, KeyIcon, MessageSquareIcon } from "lucide-react";
+
+interface SummaryCardsProps {
+  totalConversations: number;
+  totalMessages: number;
+  totalTokens: number;
+  activeApiKeys: number;
+}
+
+export function SummaryCards({
+  totalConversations,
+  totalMessages,
+  totalTokens,
+  activeApiKeys,
+}: SummaryCardsProps) {
+  const stats = [
+    { icon: MessageSquareIcon, label: "Conversations", value: totalConversations.toLocaleString() },
+    { icon: HashIcon, label: "Messages", value: totalMessages.toLocaleString() },
+    { icon: CoinsIcon, label: "Tokens", value: totalTokens.toLocaleString() },
+    { icon: KeyIcon, label: "API Keys", value: activeApiKeys },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      {stats.map((s) => (
+        <div key={s.label} className="border border-border rounded-lg p-4 bg-card">
+          <div className="flex items-center gap-2 mb-1.5">
+            <s.icon className="h-4 w-4 text-muted-foreground" />
+            <span className="text-sm text-muted-foreground">{s.label}</span>
+          </div>
+          <p className="text-2xl font-semibold tabular-nums">{s.value}</p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/analytics/time-range-select.tsx
+++ b/packages/dashboard/src/components/analytics/time-range-select.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+const RANGES = [
+  { label: "7d", value: "7d" },
+  { label: "30d", value: "30d" },
+  { label: "90d", value: "90d" },
+] as const;
+
+export type TimeRange = (typeof RANGES)[number]["value"];
+
+interface TimeRangeSelectProps {
+  value: TimeRange;
+  onChange: (range: TimeRange) => void;
+}
+
+export function TimeRangeSelect({ value, onChange }: TimeRangeSelectProps) {
+  return (
+    <div className="flex gap-1 bg-muted rounded-lg p-0.5">
+      {RANGES.map((r) => (
+        <Button
+          key={r.value}
+          size="sm"
+          variant={value === r.value ? "default" : "ghost"}
+          className="h-7 px-3 text-xs"
+          onClick={() => onChange(r.value)}
+        >
+          {r.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/app-sidebar.tsx
+++ b/packages/dashboard/src/components/app-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { SignInButton, UserButton, useAuth, useUser } from "@clerk/react";
 import {
+  BarChart3Icon,
   BookOpenIcon,
   ExternalLinkIcon,
   FolderIcon,
@@ -56,6 +57,7 @@ function ThemeToggleIcon() {
 const navItems = [
   { label: "Projects", href: "/dashboard", icon: FolderIcon },
   { label: "Conversations", href: "/dashboard/conversations", icon: MessageSquareIcon },
+  { label: "Analytics", href: "/dashboard/analytics", icon: BarChart3Icon },
   { label: "Integrate", href: "/dashboard/integrate", icon: PlugIcon },
   { label: "Docs", href: "/dashboard/docs", icon: BookOpenIcon },
 ];

--- a/packages/dashboard/src/middleware.ts
+++ b/packages/dashboard/src/middleware.ts
@@ -1,0 +1,22 @@
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+
+const isPublicRoute = createRouteMatcher([
+  "/",
+  "/sign-in(.*)",
+  "/sign-up(.*)",
+]);
+
+export default clerkMiddleware(async (auth, req) => {
+  if (!isPublicRoute(req)) {
+    await auth.protect();
+  }
+});
+
+export const config = {
+  matcher: [
+    // Skip Next.js internals and static files
+    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
+    // Always run for API routes
+    "/(api|trpc)(.*)",
+  ],
+};


### PR DESCRIPTION
## Summary
- **Analytics API**: `GET /api/v1/projects/:id/analytics?range=7d|30d|90d` — returns summary stats, daily conversation/message/token counts, and recent activity
- **Analytics dashboard**: New page with summary cards, area charts (recharts), time range selector, and recent activity table
- **Auth fix**: Added Clerk `clerkMiddleware()` to protect `/dashboard/*` routes — previously accessible without login

## Test plan
- [ ] Visit `/dashboard/analytics` — verify charts render with project data
- [ ] Switch time range (7d/30d/90d) — verify charts update
- [ ] Open dashboard in incognito — verify redirect to sign-in
- [ ] Verify landing page (`/`) still accessible without auth
- [ ] Run `bunx vitest run` — all 84 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a protected analytics experience for dashboard projects with usage charts and recent activity, backed by a new project analytics API.

New Features:
- Expose a project analytics API endpoint under /api/v1/projects/:id/analytics returning usage summaries, per-day metrics, and recent conversation activity.
- Introduce a dashboard Analytics page with summary cards, usage charts, time-range selection, and recent activity table, including navigation entry in the sidebar.

Bug Fixes:
- Protect non-public dashboard and API routes with Clerk middleware while keeping the landing and auth pages publicly accessible.

Enhancements:
- Add Recharts as a dashboard dependency and wrap it in a reusable AreaChartCard component for displaying time-series metrics.