### PR TITLE
feat(dashboard): sidebar UI improvements + pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Format staged files with Biome before committing
+bun run fmt 2>&1
+
+# Allow commit even if Biome reports pre-existing lint errors
+# (fmt still applies formatting fixes to staged files)
+exit 0

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "private": true,
   "workspaces": ["packages/*"],
   "scripts": {
+    "prepare": "git config core.hooksPath .githooks",
     "dev": "cd packages/api && bunx wrangler dev",
     "dev:dashboard": "cd packages/dashboard && bun run dev",
     "build": "cd packages/api && bunx tsc --noEmit && cd ../../packages/dashboard && bun run build",
     "test": "cd packages/api && bunx vitest run",
-    "lint": "bunx biome check packages/api/src/",
+    "fmt": "bunx biome check --write packages/*/src/",
+    "lint": "bunx biome check packages/*/src/",
     "typecheck": "bunx tsc --noEmit -p packages/api/tsconfig.json",
     "db:generate": "cd packages/api && bunx drizzle-kit generate",
     "deploy": "cd packages/api && bunx wrangler deploy"

--- a/packages/dashboard/src/app/dashboard/analytics/page.tsx
+++ b/packages/dashboard/src/app/dashboard/analytics/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { AreaChartCard } from "@/components/analytics/area-chart";
 import { RecentActivity } from "@/components/analytics/recent-activity";
 import { SummaryCards } from "@/components/analytics/summary-cards";
-import { TimeRangeSelect, type TimeRange } from "@/components/analytics/time-range-select";
+import { type TimeRange, TimeRangeSelect } from "@/components/analytics/time-range-select";
 import { api } from "@/lib/api";
 
 // ---------------------------------------------------------------------------

--- a/packages/dashboard/src/app/dashboard/layout.tsx
+++ b/packages/dashboard/src/app/dashboard/layout.tsx
@@ -2,7 +2,6 @@
 
 import { SignIn, useAuth } from "@clerk/react";
 import { AppSidebar } from "@/components/app-sidebar";
-import { Separator } from "@/components/ui/separator";
 import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
@@ -32,7 +31,6 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
       <SidebarInset>
         <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-4">
           <SidebarTrigger className="-ml-1" />
-          <Separator orientation="vertical" className="mr-2 h-4" />
         </header>
         <main className="flex-1 p-6">
           <div className="max-w-4xl mx-auto">{children}</div>

--- a/packages/dashboard/src/app/dashboard/project/page.tsx
+++ b/packages/dashboard/src/app/dashboard/project/page.tsx
@@ -21,10 +21,39 @@ import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { api } from "@/lib/api";
 
-interface ApiKey { id: string; name: string; key_prefix: string; created_at: number; last_used_at: number | null; revoked_at: number | null; }
-interface ProjectDetail { id: string; name: string; slug: string; created_at: number; api_keys: ApiKey[]; }
-interface Conversation { id: string; external_id: string | null; title: string | null; message_count: number; token_count: number; metadata: Record<string, unknown> | null; created_at: number; updated_at: number; }
-interface Message { id: string; role: string; content: string; metadata: Record<string, unknown> | null; token_count: number; created_at: number; }
+interface ApiKey {
+  id: string;
+  name: string;
+  key_prefix: string;
+  created_at: number;
+  last_used_at: number | null;
+  revoked_at: number | null;
+}
+interface ProjectDetail {
+  id: string;
+  name: string;
+  slug: string;
+  created_at: number;
+  api_keys: ApiKey[];
+}
+interface Conversation {
+  id: string;
+  external_id: string | null;
+  title: string | null;
+  message_count: number;
+  token_count: number;
+  metadata: Record<string, unknown> | null;
+  created_at: number;
+  updated_at: number;
+}
+interface Message {
+  id: string;
+  role: string;
+  content: string;
+  metadata: Record<string, unknown> | null;
+  token_count: number;
+  created_at: number;
+}
 
 const ROLE_COLORS: Record<string, string> = {
   user: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
@@ -64,21 +93,37 @@ function ProjectContent() {
   useEffect(() => {
     if (!slug) return;
     const storedKey = sessionStorage.getItem(`new_key_${slug}`);
-    if (storedKey) { setCreatedKey(storedKey); sessionStorage.removeItem(`new_key_${slug}`); }
+    if (storedKey) {
+      setCreatedKey(storedKey);
+      sessionStorage.removeItem(`new_key_${slug}`);
+    }
     api<ProjectDetail>(`/v1/projects/by-slug/${slug}`)
       .then((p) => {
         setProject(p);
         setConvsLoading(true);
         api<{ data: Conversation[] }>(`/v1/projects/${p.id}/conversations?limit=100`)
-          .then((res) => setConversations(res.data)).catch(() => {}).finally(() => setConvsLoading(false));
-      }).catch(() => {}).finally(() => setLoading(false));
+          .then((res) => setConversations(res.data))
+          .catch(() => {})
+          .finally(() => setConvsLoading(false));
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
   }, [slug]);
 
-  async function handleCopy(text: string) { await navigator.clipboard.writeText(text); setCopiedKey(text); setTimeout(() => setCopiedKey(null), 2000); }
+  async function handleCopy(text: string) {
+    await navigator.clipboard.writeText(text);
+    setCopiedKey(text);
+    setTimeout(() => setCopiedKey(null), 2000);
+  }
   async function handleCreateKey() {
     if (!newKeyName.trim() || !project) return;
-    const res = await api<{ id: string; key: string }>(`/v1/projects/${project.id}/keys`, { method: "POST", body: JSON.stringify({ name: newKeyName.trim() }) });
-    setCreatedKey(res.key); setShowCreateKey(false); setNewKeyName("");
+    const res = await api<{ id: string; key: string }>(`/v1/projects/${project.id}/keys`, {
+      method: "POST",
+      body: JSON.stringify({ name: newKeyName.trim() }),
+    });
+    setCreatedKey(res.key);
+    setShowCreateKey(false);
+    setNewKeyName("");
     setProject(await api<ProjectDetail>(`/v1/projects/by-slug/${slug}`));
   }
   async function handleRevokeKey(keyId: string) {
@@ -87,20 +132,30 @@ function ProjectContent() {
     setProject(await api<ProjectDetail>(`/v1/projects/by-slug/${slug}`));
   }
   async function toggleConversation(convId: string) {
-    if (expandedConv === convId) { setExpandedConv(null); return; }
+    if (expandedConv === convId) {
+      setExpandedConv(null);
+      return;
+    }
     setExpandedConv(convId);
     if (!messagesCache[convId] && project) {
-      const res = await api<{ data: Message[] }>(`/v1/projects/${project.id}/conversations/${convId}/messages`);
+      const res = await api<{ data: Message[] }>(
+        `/v1/projects/${project.id}/conversations/${convId}/messages`,
+      );
       setMessagesCache((prev) => ({ ...prev, [convId]: res.data }));
     }
   }
 
-  if (loading) return (
-    <div className="space-y-4">
-      <div className="h-7 w-48 bg-muted rounded animate-pulse" />
-      <div className="grid grid-cols-4 gap-3 mt-4">{[1,2,3,4].map((i) => <div key={i} className="h-20 bg-muted rounded-lg animate-pulse" />)}</div>
-    </div>
-  );
+  if (loading)
+    return (
+      <div className="space-y-4">
+        <div className="h-7 w-48 bg-muted rounded animate-pulse" />
+        <div className="grid grid-cols-4 gap-3 mt-4">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-20 bg-muted rounded-lg animate-pulse" />
+          ))}
+        </div>
+      </div>
+    );
   if (!project) return <p className="text-muted-foreground">Project not found.</p>;
 
   const activeKeys = project.api_keys.filter((k) => !k.revoked_at);
@@ -110,20 +165,46 @@ function ProjectContent() {
 
   function renderCell(conv: Conversation, col: ColumnKey) {
     switch (col) {
-      case "title": return conv.title || "Untitled";
-      case "external_id": return <code className="font-mono text-muted-foreground">{conv.external_id || "—"}</code>;
-      case "message_count": return <span className="tabular-nums">{conv.message_count}</span>;
-      case "token_count": return <span className="tabular-nums">{conv.token_count.toLocaleString()}</span>;
-      case "metadata": return conv.metadata ? <code className="font-mono text-muted-foreground text-xs truncate max-w-[140px] block">{JSON.stringify(conv.metadata)}</code> : "—";
-      case "created_at": return <span className="text-muted-foreground">{new Date(conv.created_at).toLocaleDateString()}</span>;
-      case "updated_at": return <span className="text-muted-foreground">{new Date(conv.updated_at).toLocaleDateString()}</span>;
+      case "title":
+        return conv.title || "Untitled";
+      case "external_id":
+        return <code className="font-mono text-muted-foreground">{conv.external_id || "—"}</code>;
+      case "message_count":
+        return <span className="tabular-nums">{conv.message_count}</span>;
+      case "token_count":
+        return <span className="tabular-nums">{conv.token_count.toLocaleString()}</span>;
+      case "metadata":
+        return conv.metadata ? (
+          <code className="font-mono text-muted-foreground text-xs truncate max-w-[140px] block">
+            {JSON.stringify(conv.metadata)}
+          </code>
+        ) : (
+          "—"
+        );
+      case "created_at":
+        return (
+          <span className="text-muted-foreground">
+            {new Date(conv.created_at).toLocaleDateString()}
+          </span>
+        );
+      case "updated_at":
+        return (
+          <span className="text-muted-foreground">
+            {new Date(conv.updated_at).toLocaleDateString()}
+          </span>
+        );
     }
   }
 
   return (
     <div>
       <div className="flex items-center gap-3 mb-6">
-        <Link href="/dashboard" className="text-muted-foreground hover:text-foreground transition-colors"><ArrowLeftIcon className="h-4 w-4" /></Link>
+        <Link
+          href="/dashboard"
+          className="text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeftIcon className="h-4 w-4" />
+        </Link>
         <div>
           <h1 className="text-xl font-semibold tracking-tight">{project.name}</h1>
           <p className="text-sm text-muted-foreground font-mono">{project.slug}</p>
@@ -134,12 +215,20 @@ function ProjectContent() {
         <div className="border border-border rounded-lg p-5 mb-6 bg-card">
           <p className="font-medium mb-2">Your API key (shown once)</p>
           <div className="flex items-center gap-2">
-            <code className="flex-1 text-sm font-mono bg-muted px-3 py-2 rounded break-all">{createdKey}</code>
+            <code className="flex-1 text-sm font-mono bg-muted px-3 py-2 rounded break-all">
+              {createdKey}
+            </code>
             <Button size="sm" variant="outline" onClick={() => handleCopy(createdKey)}>
-              {copiedKey === createdKey ? <CheckIcon className="h-4 w-4" /> : <CopyIcon className="h-4 w-4" />}
+              {copiedKey === createdKey ? (
+                <CheckIcon className="h-4 w-4" />
+              ) : (
+                <CopyIcon className="h-4 w-4" />
+              )}
             </Button>
           </div>
-          <p className="text-sm text-muted-foreground mt-2">Copy this key now. It won&apos;t be shown again.</p>
+          <p className="text-sm text-muted-foreground mt-2">
+            Copy this key now. It won&apos;t be shown again.
+          </p>
         </div>
       )}
 
@@ -151,7 +240,10 @@ function ProjectContent() {
           { icon: KeyIcon, label: "API Keys", value: activeKeys.length },
         ].map((s) => (
           <div key={s.label} className="border border-border rounded-lg p-4 bg-card">
-            <div className="flex items-center gap-2 mb-1.5"><s.icon className="h-4 w-4 text-muted-foreground" /><span className="text-sm text-muted-foreground">{s.label}</span></div>
+            <div className="flex items-center gap-2 mb-1.5">
+              <s.icon className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">{s.label}</span>
+            </div>
             <p className="text-2xl font-semibold tabular-nums">{s.value}</p>
           </div>
         ))}
@@ -168,7 +260,7 @@ function ProjectContent() {
           <div>
             <h3 className="font-medium mb-3">Quick start</h3>
             <pre className="font-mono text-sm bg-card border border-border rounded-lg p-5 overflow-x-auto text-muted-foreground leading-relaxed">
-{`curl -X POST https://agentstate.app/api/v1/conversations \\
+              {`curl -X POST https://agentstate.app/api/v1/conversations \\
   -H "Authorization: Bearer <your-key>" \\
   -H "Content-Type: application/json" \\
   -d '{"messages": [{"role": "user", "content": "Hello"}]}'`}
@@ -177,9 +269,14 @@ function ProjectContent() {
           <div>
             <h3 className="font-medium mb-2">Project details</h3>
             <div className="text-sm text-muted-foreground space-y-1.5">
-              <p>ID: <code className="font-mono text-foreground/70">{project.id}</code></p>
+              <p>
+                ID: <code className="font-mono text-foreground/70">{project.id}</code>
+              </p>
               <p>Created: {new Date(project.created_at).toLocaleString()}</p>
-              <p>Base URL: <code className="font-mono text-foreground/70">https://agentstate.app/api</code></p>
+              <p>
+                Base URL:{" "}
+                <code className="font-mono text-foreground/70">https://agentstate.app/api</code>
+              </p>
             </div>
           </div>
         </TabsContent>
@@ -187,50 +284,119 @@ function ProjectContent() {
         <TabsContent value="keys">
           <div className="flex items-center justify-between mb-4">
             <p className="text-sm text-muted-foreground">Manage API keys for this project.</p>
-            <Button size="sm" variant="outline" onClick={() => setShowCreateKey(true)}><PlusIcon className="h-4 w-4 mr-1.5" />New Key</Button>
+            <Button size="sm" variant="outline" onClick={() => setShowCreateKey(true)}>
+              <PlusIcon className="h-4 w-4 mr-1.5" />
+              New Key
+            </Button>
           </div>
           {showCreateKey && (
             <div className="border border-border rounded-lg p-5 mb-4 bg-card">
-              <label htmlFor="key-name" className="text-sm text-muted-foreground mb-2 block">Key name</label>
+              <label htmlFor="key-name" className="text-sm text-muted-foreground mb-2 block">
+                Key name
+              </label>
               <div className="flex gap-2">
-                <Input id="key-name" placeholder="e.g. Production" value={newKeyName} onChange={(e) => setNewKeyName(e.target.value)} onKeyDown={(e) => e.key === "Enter" && handleCreateKey()} autoFocus />
-                <Button onClick={handleCreateKey} disabled={!newKeyName.trim()}>Create</Button>
-                <Button variant="ghost" onClick={() => setShowCreateKey(false)}>Cancel</Button>
+                <Input
+                  id="key-name"
+                  placeholder="e.g. Production"
+                  value={newKeyName}
+                  onChange={(e) => setNewKeyName(e.target.value)}
+                  onKeyDown={(e) => e.key === "Enter" && handleCreateKey()}
+                  autoFocus
+                />
+                <Button onClick={handleCreateKey} disabled={!newKeyName.trim()}>
+                  Create
+                </Button>
+                <Button variant="ghost" onClick={() => setShowCreateKey(false)}>
+                  Cancel
+                </Button>
               </div>
             </div>
           )}
           <div className="border border-border rounded-lg overflow-hidden">
             {activeKeys.length > 0 ? (
               <table className="w-full text-sm">
-                <thead><tr className="border-b border-border bg-card">
-                  <th className="text-left px-4 py-3 text-muted-foreground font-medium">Name</th>
-                  <th className="text-left px-4 py-3 text-muted-foreground font-medium">Key</th>
-                  <th className="text-left px-4 py-3 text-muted-foreground font-medium hidden sm:table-cell">Last used</th>
-                  <th className="px-4 py-3 w-10" />
-                </tr></thead>
-                <tbody>{activeKeys.map((key) => (
-                  <tr key={key.id} className="border-b last:border-b-0 border-border hover:bg-muted/20 transition-colors">
-                    <td className="px-4 py-3"><div className="flex items-center gap-2"><KeyIcon className="h-4 w-4 text-muted-foreground" />{key.name}</div></td>
-                    <td className="px-4 py-3"><code className="font-mono text-muted-foreground">{key.key_prefix}...</code></td>
-                    <td className="px-4 py-3 text-muted-foreground hidden sm:table-cell">{key.last_used_at ? new Date(key.last_used_at).toLocaleDateString() : "Never"}</td>
-                    <td className="px-4 py-3"><Button size="sm" variant="ghost" className="h-7 w-7 p-0 text-muted-foreground hover:text-red-500" aria-label={`Revoke key ${key.name}`} onClick={() => handleRevokeKey(key.id)}><TrashIcon className="h-4 w-4" /></Button></td>
+                <thead>
+                  <tr className="border-b border-border bg-card">
+                    <th className="text-left px-4 py-3 text-muted-foreground font-medium">Name</th>
+                    <th className="text-left px-4 py-3 text-muted-foreground font-medium">Key</th>
+                    <th className="text-left px-4 py-3 text-muted-foreground font-medium hidden sm:table-cell">
+                      Last used
+                    </th>
+                    <th className="px-4 py-3 w-10" />
                   </tr>
-                ))}</tbody>
+                </thead>
+                <tbody>
+                  {activeKeys.map((key) => (
+                    <tr
+                      key={key.id}
+                      className="border-b last:border-b-0 border-border hover:bg-muted/20 transition-colors"
+                    >
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <KeyIcon className="h-4 w-4 text-muted-foreground" />
+                          {key.name}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <code className="font-mono text-muted-foreground">{key.key_prefix}...</code>
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground hidden sm:table-cell">
+                        {key.last_used_at
+                          ? new Date(key.last_used_at).toLocaleDateString()
+                          : "Never"}
+                      </td>
+                      <td className="px-4 py-3">
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="h-7 w-7 p-0 text-muted-foreground hover:text-red-500"
+                          aria-label={`Revoke key ${key.name}`}
+                          onClick={() => handleRevokeKey(key.id)}
+                        >
+                          <TrashIcon className="h-4 w-4" />
+                        </Button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
               </table>
-            ) : <div className="p-8 text-center text-muted-foreground">No active API keys</div>}
+            ) : (
+              <div className="p-8 text-center text-muted-foreground">No active API keys</div>
+            )}
           </div>
         </TabsContent>
 
         <TabsContent value="conversations">
           <div className="flex items-center justify-between mb-4">
-            <p className="text-sm text-muted-foreground">{totalConvs} conversation{totalConvs !== 1 ? "s" : ""}</p>
+            <p className="text-sm text-muted-foreground">
+              {totalConvs} conversation{totalConvs !== 1 ? "s" : ""}
+            </p>
             <div className="relative">
-              <Button size="sm" variant="outline" type="button" onClick={() => setShowColPicker(!showColPicker)}>Columns</Button>
+              <Button
+                size="sm"
+                variant="outline"
+                type="button"
+                onClick={() => setShowColPicker(!showColPicker)}
+              >
+                Columns
+              </Button>
               {showColPicker && (
                 <div className="absolute right-0 top-9 z-10 border border-border rounded-lg bg-card p-2 shadow-lg min-w-[160px]">
                   {ALL_COLUMNS.map((col) => (
-                    <label key={col.key} className="flex items-center gap-2 px-2 py-1.5 text-sm cursor-pointer hover:bg-accent rounded">
-                      <input type="checkbox" checked={visibleCols.includes(col.key)} onChange={() => setVisibleCols((p) => p.includes(col.key) ? p.filter((c) => c !== col.key) : [...p, col.key])} className="rounded" />
+                    <label
+                      key={col.key}
+                      className="flex items-center gap-2 px-2 py-1.5 text-sm cursor-pointer hover:bg-accent rounded"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={visibleCols.includes(col.key)}
+                        onChange={() =>
+                          setVisibleCols((p) =>
+                            p.includes(col.key) ? p.filter((c) => c !== col.key) : [...p, col.key],
+                          )
+                        }
+                        className="rounded"
+                      />
                       {col.label}
                     </label>
                   ))}
@@ -239,61 +405,104 @@ function ProjectContent() {
             </div>
           </div>
           {convsLoading ? (
-            <div className="space-y-2">{[1,2,3].map((i) => <div key={i} className="h-14 bg-muted rounded-lg animate-pulse" />)}</div>
+            <div className="space-y-2">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-14 bg-muted rounded-lg animate-pulse" />
+              ))}
+            </div>
           ) : conversations.length > 0 ? (
             <div className="border border-border rounded-lg overflow-hidden">
               <table className="w-full text-sm">
-                <thead><tr className="border-b border-border bg-card">
-                  <th className="w-8 px-3 py-3" />
-                  {ALL_COLUMNS.filter((c) => visibleCols.includes(c.key)).map((col) => (
-                    <th key={col.key} className="text-left px-4 py-3 text-muted-foreground font-medium">{col.label}</th>
-                  ))}
-                </tr></thead>
-                <tbody>{conversations.map((conv) => (
-                  <tr key={conv.id} className="group">
-                    <td colSpan={visibleCols.length + 1} className="p-0">
-                      <div
-                        className="flex items-center border-b border-border hover:bg-muted/20 transition-colors cursor-pointer"
-                        onClick={() => toggleConversation(conv.id)}
-                        tabIndex={0}
-                        role="button"
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter" || e.key === " ") {
-                            e.preventDefault();
-                            toggleConversation(conv.id);
-                          }
-                        }}
+                <thead>
+                  <tr className="border-b border-border bg-card">
+                    <th className="w-8 px-3 py-3" />
+                    {ALL_COLUMNS.filter((c) => visibleCols.includes(c.key)).map((col) => (
+                      <th
+                        key={col.key}
+                        className="text-left px-4 py-3 text-muted-foreground font-medium"
                       >
-                        <div className="px-3 py-3 text-muted-foreground">{expandedConv === conv.id ? <ChevronDownIcon className="h-4 w-4" /> : <ChevronRightIcon className="h-4 w-4" />}</div>
-                        {ALL_COLUMNS.filter((c) => visibleCols.includes(c.key)).map((col) => (<div key={col.key} className="px-4 py-3">{renderCell(conv, col.key)}</div>))}
-                      </div>
-                      {expandedConv === conv.id && (
-                        <div className="bg-muted/10 border-b border-border px-6 py-5">
-                          {messagesCache[conv.id] ? (
-                            <div className="space-y-4 max-h-[500px] overflow-y-auto">
-                              {messagesCache[conv.id].length > 0 ? messagesCache[conv.id].map((msg) => (
-                                <div key={msg.id} className="flex gap-3">
-                                  <span className={`text-xs font-mono px-2 py-0.5 rounded shrink-0 mt-1 ${ROLE_COLORS[msg.role] || ROLE_COLORS.system}`}>{msg.role}</span>
-                                  <div className="min-w-0 flex-1">
-                                    <p className="text-sm whitespace-pre-wrap break-words leading-relaxed">{msg.content}</p>
-                                    <p className="text-xs text-muted-foreground mt-1">{new Date(msg.created_at).toLocaleString()}{msg.token_count > 0 && ` · ${msg.token_count} tokens`}</p>
-                                  </div>
-                                </div>
-                              )) : <p className="text-sm text-muted-foreground">No messages</p>}
-                            </div>
-                          ) : <div className="space-y-2"><div className="h-5 w-3/4 bg-muted rounded animate-pulse" /><div className="h-5 w-1/2 bg-muted rounded animate-pulse" /></div>}
-                        </div>
-                      )}
-                    </td>
+                        {col.label}
+                      </th>
+                    ))}
                   </tr>
-                ))}</tbody>
+                </thead>
+                <tbody>
+                  {conversations.map((conv) => (
+                    <tr key={conv.id} className="group">
+                      <td colSpan={visibleCols.length + 1} className="p-0">
+                        <div
+                          className="flex items-center border-b border-border hover:bg-muted/20 transition-colors cursor-pointer"
+                          onClick={() => toggleConversation(conv.id)}
+                          tabIndex={0}
+                          role="button"
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter" || e.key === " ") {
+                              e.preventDefault();
+                              toggleConversation(conv.id);
+                            }
+                          }}
+                        >
+                          <div className="px-3 py-3 text-muted-foreground">
+                            {expandedConv === conv.id ? (
+                              <ChevronDownIcon className="h-4 w-4" />
+                            ) : (
+                              <ChevronRightIcon className="h-4 w-4" />
+                            )}
+                          </div>
+                          {ALL_COLUMNS.filter((c) => visibleCols.includes(c.key)).map((col) => (
+                            <div key={col.key} className="px-4 py-3">
+                              {renderCell(conv, col.key)}
+                            </div>
+                          ))}
+                        </div>
+                        {expandedConv === conv.id && (
+                          <div className="bg-muted/10 border-b border-border px-6 py-5">
+                            {messagesCache[conv.id] ? (
+                              <div className="space-y-4 max-h-[500px] overflow-y-auto">
+                                {messagesCache[conv.id].length > 0 ? (
+                                  messagesCache[conv.id].map((msg) => (
+                                    <div key={msg.id} className="flex gap-3">
+                                      <span
+                                        className={`text-xs font-mono px-2 py-0.5 rounded shrink-0 mt-1 ${ROLE_COLORS[msg.role] || ROLE_COLORS.system}`}
+                                      >
+                                        {msg.role}
+                                      </span>
+                                      <div className="min-w-0 flex-1">
+                                        <p className="text-sm whitespace-pre-wrap break-words leading-relaxed">
+                                          {msg.content}
+                                        </p>
+                                        <p className="text-xs text-muted-foreground mt-1">
+                                          {new Date(msg.created_at).toLocaleString()}
+                                          {msg.token_count > 0 && ` · ${msg.token_count} tokens`}
+                                        </p>
+                                      </div>
+                                    </div>
+                                  ))
+                                ) : (
+                                  <p className="text-sm text-muted-foreground">No messages</p>
+                                )}
+                              </div>
+                            ) : (
+                              <div className="space-y-2">
+                                <div className="h-5 w-3/4 bg-muted rounded animate-pulse" />
+                                <div className="h-5 w-1/2 bg-muted rounded animate-pulse" />
+                              </div>
+                            )}
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
               </table>
             </div>
           ) : (
             <div className="border border-dashed border-border rounded-lg p-10 text-center">
               <MessageSquareIcon className="h-6 w-6 text-muted-foreground mx-auto mb-3" />
               <p className="text-muted-foreground">No conversations yet</p>
-              <p className="text-sm text-muted-foreground mt-1">Use the API key to start storing conversations.</p>
+              <p className="text-sm text-muted-foreground mt-1">
+                Use the API key to start storing conversations.
+              </p>
             </div>
           )}
         </TabsContent>
@@ -303,5 +512,9 @@ function ProjectContent() {
 }
 
 export default function ProjectPage() {
-  return (<Suspense fallback={<div className="h-32 bg-muted rounded animate-pulse" />}><ProjectContent /></Suspense>);
+  return (
+    <Suspense fallback={<div className="h-32 bg-muted rounded animate-pulse" />}>
+      <ProjectContent />
+    </Suspense>
+  );
 }

--- a/packages/dashboard/src/app/dashboard/project/page.tsx
+++ b/packages/dashboard/src/app/dashboard/project/page.tsx
@@ -111,9 +111,13 @@ function ProjectContent() {
   }, [slug]);
 
   async function handleCopy(text: string) {
-    await navigator.clipboard.writeText(text);
-    setCopiedKey(text);
-    setTimeout(() => setCopiedKey(null), 2000);
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedKey(text);
+      setTimeout(() => setCopiedKey(null), 2000);
+    } catch {
+      console.error("Failed to copy to clipboard");
+    }
   }
   async function handleCreateKey() {
     if (!newKeyName.trim() || !project) return;

--- a/packages/dashboard/src/app/globals.css
+++ b/packages/dashboard/src/app/globals.css
@@ -64,14 +64,14 @@
   --input: #e5e5e5;
   --ring: #a3a3a3;
   --radius: 0.5rem;
-  --sidebar: #fafafa;
-  --sidebar-foreground: #1a1a1a;
-  --sidebar-primary: #1a1a1a;
+  --sidebar: #f8f8f8;
+  --sidebar-foreground: #3a3a3a;
+  --sidebar-primary: #2a2a2a;
   --sidebar-primary-foreground: #fafafa;
-  --sidebar-accent: #f0f0f0;
-  --sidebar-accent-foreground: #1a1a1a;
-  --sidebar-border: #e5e5e5;
-  --sidebar-ring: #a3a3a3;
+  --sidebar-accent: #f0eeec;
+  --sidebar-accent-foreground: #2a2a2a;
+  --sidebar-border: #ebe9e6;
+  --sidebar-ring: #b5b0aa;
 }
 
 .dark {
@@ -93,14 +93,14 @@
   --border: #333333;
   --input: #333333;
   --ring: #525252;
-  --sidebar: #232323;
-  --sidebar-foreground: #ededed;
-  --sidebar-primary: #ededed;
+  --sidebar: #1f1f1f;
+  --sidebar-foreground: #c8c8c8;
+  --sidebar-primary: #e0e0e0;
   --sidebar-primary-foreground: #1a1a1a;
-  --sidebar-accent: #2a2a2a;
-  --sidebar-accent-foreground: #ededed;
-  --sidebar-border: #333333;
-  --sidebar-ring: #525252;
+  --sidebar-accent: #2a2828;
+  --sidebar-accent-foreground: #d4d4d4;
+  --sidebar-border: #2e2c2a;
+  --sidebar-ring: #4a4744;
 }
 
 @layer base {

--- a/packages/dashboard/src/app/page.tsx
+++ b/packages/dashboard/src/app/page.tsx
@@ -66,7 +66,11 @@ export default function LandingPage() {
                 Get started
                 <ArrowRightIcon className="ml-2 h-4 w-4" />
               </Button>
-              <Button variant="outline" className="h-10 px-6 text-base" render={<Link href="/dashboard/docs" />}>
+              <Button
+                variant="outline"
+                className="h-10 px-6 text-base"
+                render={<Link href="/dashboard/docs" />}
+              >
                 API Reference
               </Button>
             </div>

--- a/packages/dashboard/src/components/analytics/area-chart.tsx
+++ b/packages/dashboard/src/components/analytics/area-chart.tsx
@@ -2,8 +2,8 @@
 
 import {
   Area,
-  AreaChart as RechartsAreaChart,
   CartesianGrid,
+  AreaChart as RechartsAreaChart,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -57,7 +57,12 @@ function formatDateLabel(dateStr: string): string {
   return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
-export function AreaChartCard({ title, data, color = "#2563eb", valueLabel = "Count" }: AreaChartCardProps) {
+export function AreaChartCard({
+  title,
+  data,
+  color = "#2563eb",
+  valueLabel = "Count",
+}: AreaChartCardProps) {
   const filled = fillDateGaps(data, 30);
 
   return (

--- a/packages/dashboard/src/components/analytics/recent-activity.tsx
+++ b/packages/dashboard/src/components/analytics/recent-activity.tsx
@@ -54,10 +54,11 @@ export function RecentActivity({ conversations }: RecentActivityProps) {
         </thead>
         <tbody>
           {conversations.map((conv) => (
-            <tr key={conv.id} className="border-b last:border-b-0 border-border hover:bg-muted/20 transition-colors">
-              <td className="px-4 py-2.5 truncate max-w-[200px]">
-                {conv.title || "Untitled"}
-              </td>
+            <tr
+              key={conv.id}
+              className="border-b last:border-b-0 border-border hover:bg-muted/20 transition-colors"
+            >
+              <td className="px-4 py-2.5 truncate max-w-[200px]">{conv.title || "Untitled"}</td>
               <td className="px-4 py-2.5 tabular-nums text-muted-foreground hidden sm:table-cell">
                 {conv.message_count}
               </td>

--- a/packages/dashboard/src/components/app-sidebar.tsx
+++ b/packages/dashboard/src/components/app-sidebar.tsx
@@ -2,13 +2,13 @@
 
 import { SignInButton, UserButton, useAuth, useUser } from "@clerk/react";
 import {
-  BarChart3Icon,
+  ActivityIcon,
+  BlocksIcon,
   BookOpenIcon,
   ExternalLinkIcon,
-  FolderIcon,
-  MessageSquareIcon,
+  LayoutDashboardIcon,
+  MessageCircleIcon,
   MoonIcon,
-  PlugIcon,
   SunIcon,
 } from "lucide-react";
 import Link from "next/link";
@@ -26,6 +26,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarRail,
+  SidebarSeparator,
 } from "@/components/ui/sidebar";
 
 function ThemeToggleIcon() {
@@ -55,11 +56,10 @@ function ThemeToggleIcon() {
 }
 
 const navItems = [
-  { label: "Projects", href: "/dashboard", icon: FolderIcon },
-  { label: "Conversations", href: "/dashboard/conversations", icon: MessageSquareIcon },
-  { label: "Analytics", href: "/dashboard/analytics", icon: BarChart3Icon },
-  { label: "Integrate", href: "/dashboard/integrate", icon: PlugIcon },
-  { label: "Docs", href: "/dashboard/docs", icon: BookOpenIcon },
+  { label: "Projects", href: "/dashboard", icon: LayoutDashboardIcon },
+  { label: "Conversations", href: "/dashboard/conversations", icon: MessageCircleIcon },
+  { label: "Analytics", href: "/dashboard/analytics", icon: ActivityIcon },
+  { label: "Integrate", href: "/dashboard/integrate", icon: BlocksIcon },
 ];
 
 export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
@@ -120,6 +120,14 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
       <SidebarFooter>
         <SidebarMenu>
           <SidebarMenuItem>
+            <Link href="/dashboard/docs">
+              <SidebarMenuButton isActive={pathname.startsWith("/dashboard/docs")} tooltip="Docs">
+                <BookOpenIcon />
+                <span>Docs</span>
+              </SidebarMenuButton>
+            </Link>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
             <Link href="/" target="_blank">
               <SidebarMenuButton tooltip="agentstate.app">
                 <ExternalLinkIcon />
@@ -127,6 +135,9 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
               </SidebarMenuButton>
             </Link>
           </SidebarMenuItem>
+        </SidebarMenu>
+        <SidebarSeparator />
+        <SidebarMenu>
           {isLoaded && (
             <SidebarMenuItem>
               {isSignedIn ? (

--- a/packages/dashboard/src/components/ui/tabs.tsx
+++ b/packages/dashboard/src/components/ui/tabs.tsx
@@ -1,26 +1,19 @@
-"use client"
+"use client";
 
-import { Tabs as TabsPrimitive } from "@base-ui/react/tabs"
-import { cva, type VariantProps } from "class-variance-authority"
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-function Tabs({
-  className,
-  orientation = "horizontal",
-  ...props
-}: TabsPrimitive.Root.Props) {
+function Tabs({ className, orientation = "horizontal", ...props }: TabsPrimitive.Root.Props) {
   return (
     <TabsPrimitive.Root
       data-slot="tabs"
       data-orientation={orientation}
-      className={cn(
-        "group/tabs flex gap-2 data-horizontal:flex-col",
-        className
-      )}
+      className={cn("group/tabs flex gap-2 data-horizontal:flex-col", className)}
       {...props}
     />
-  )
+  );
 }
 
 const tabsListVariants = cva(
@@ -35,8 +28,8 @@ const tabsListVariants = cva(
     defaultVariants: {
       variant: "default",
     },
-  }
-)
+  },
+);
 
 function TabsList({
   className,
@@ -50,7 +43,7 @@ function TabsList({
       className={cn(tabsListVariants({ variant }), className)}
       {...props}
     />
-  )
+  );
 }
 
 function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
@@ -62,11 +55,11 @@ function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
         "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
         "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
@@ -76,7 +69,7 @@ function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
       className={cn("flex-1 text-sm outline-none", className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants };

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -46,7 +46,7 @@ export class AgentState {
     const res = await fetch(`${this.baseUrl}${path}`, {
       ...options,
       headers: {
-        "Authorization": `Bearer ${this.apiKey}`,
+        Authorization: `Bearer ${this.apiKey}`,
         "Content-Type": "application/json",
         ...options?.headers,
       },
@@ -97,10 +97,13 @@ export class AgentState {
     return this.request(`/v1/conversations${qs ? `?${qs}` : ""}`);
   }
 
-  async updateConversation(id: string, data: {
-    title?: string;
-    metadata?: Record<string, unknown>;
-  }): Promise<Conversation> {
+  async updateConversation(
+    id: string,
+    data: {
+      title?: string;
+      metadata?: Record<string, unknown>;
+    },
+  ): Promise<Conversation> {
     return this.request(`/v1/conversations/${id}`, {
       method: "PUT",
       body: JSON.stringify(data),
@@ -112,17 +115,23 @@ export class AgentState {
   }
 
   // Messages
-  async appendMessages(conversationId: string, messages: Omit<Message, "id" | "created_at">[]): Promise<{ messages: Message[] }> {
+  async appendMessages(
+    conversationId: string,
+    messages: Omit<Message, "id" | "created_at">[],
+  ): Promise<{ messages: Message[] }> {
     return this.request(`/v1/conversations/${conversationId}/messages`, {
       method: "POST",
       body: JSON.stringify({ messages }),
     });
   }
 
-  async listMessages(conversationId: string, params?: {
-    limit?: number;
-    after?: string;
-  }): Promise<ListResponse<Message>> {
+  async listMessages(
+    conversationId: string,
+    params?: {
+      limit?: number;
+      after?: string;
+    },
+  ): Promise<ListResponse<Message>> {
     const query = new URLSearchParams();
     if (params?.limit) query.set("limit", String(params.limit));
     if (params?.after) query.set("after", params.after);
@@ -140,7 +149,9 @@ export class AgentState {
   }
 
   // Export
-  async exportConversations(ids?: string[]): Promise<{ data: ConversationWithMessages[]; count: number }> {
+  async exportConversations(
+    ids?: string[],
+  ): Promise<{ data: ConversationWithMessages[]; count: number }> {
     return this.request("/v1/conversations/export", {
       method: "POST",
       body: JSON.stringify(ids ? { ids } : {}),


### PR DESCRIPTION
## Summary
- Softer sidebar icons, reorganized menu groups, warmer color palette, and orphaned separator fix
- Added Biome pre-commit hook with `bun fmt` / `bun lint` covering all packages

## Changes

### Sidebar UI
- **Icons**: `FolderIcon` → `LayoutDashboardIcon`, `MessageSquareIcon` → `MessageCircleIcon`, `BarChart3Icon` → `ActivityIcon`, `PlugIcon` → `BlocksIcon`
- **Menu**: Docs moved from main nav to footer; `SidebarSeparator` added between footer links and user section
- **Colors**: Warm-tinted neutrals for sidebar in both light/dark mode (less clinical gray)
- **Layout**: Removed orphaned `<Separator orientation="vertical">` from dashboard header

### Tooling
- `.githooks/pre-commit` runs `bun fmt` before each commit
- `prepare` script auto-configures `core.hooksPath` on `bun install`
- `bun fmt` (auto-fix) and `bun lint` (check) now cover all 4 packages

## Test plan
- [ ] Visit `/dashboard` — verify sidebar icons look softer and intentional
- [ ] Check Docs link appears in footer above user section
- [ ] Toggle dark mode — sidebar colors should be warm, not stark gray
- [ ] No orphaned vertical line next to sidebar toggle button
- [ ] `bunx tsc --noEmit -p packages/dashboard/tsconfig.json` passes
- [ ] `bun fmt` runs on commit (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve the dashboard sidebar UX and theme while adding workspace-wide formatting hooks and scripts.

Enhancements:
- Refresh dashboard sidebar navigation with updated icons, relocated Docs link to the footer, and a clearer separation between footer links and the user section.
- Tweak light and dark theme sidebar color tokens for a warmer, less stark appearance.
- Simplify the dashboard header layout by removing an unnecessary vertical separator.
- Apply minor layout and accessibility polish to tables and tab components in the dashboard and analytics views.

Build:
- Add a Biome-based formatting script that runs across all workspace packages and introduce a pre-commit hook wired via a prepare script to enforce formatting before commits.

Chores:
- Reformat TypeScript and React code across dashboard and SDK modules to conform to the new Biome formatting rules without changing behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added a Docs link in the sidebar footer for quick access to documentation
  * Automatic formatting on commit (pre-commit hook) to keep code style consistent

* **Style**
  * Refined sidebar color palette for improved contrast in light and dark modes
  * Updated dashboard navigation icons for clearer visual hierarchy
  * Removed a visual divider from the dashboard header for a cleaner layout
<!-- end of auto-generated comment: release notes by coderabbit.ai -->