### PR TITLE
docs: update README with SDK quick start and documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ Store, retrieve, and manage AI conversations via a simple REST API. Works with a
 ## Quick Start
 
 ```bash
+npm install @agentstate/sdk
+```
+
+```typescript
+import { AgentState } from "@agentstate/sdk";
+
+const client = new AgentState({ apiKey: "as_live_..." });
+const conv = await client.createConversation({
+  messages: [{ role: "user", content: "Hello" }],
+});
+```
+
+Or use the REST API directly:
+
+```bash
 # Create a conversation
 curl -X POST https://agentstate.app/api/v1/conversations \
   -H "Authorization: Bearer as_live_your_key" \
@@ -74,10 +89,17 @@ cd packages/dashboard && bun run dev
 
 See [CLAUDE.md](CLAUDE.md) for full dev commands and conventions.
 
-## Docs
+## Documentation
 
-- [Integration Guide](docs/integration.md) — API reference + framework examples
-- [CLAUDE.md](CLAUDE.md) — Development guide
+| Guide | Description |
+|-------|-------------|
+| [Getting Started](docs/getting-started.md) | Zero to working in 2 minutes |
+| [API Reference](docs/api-reference.md) | Complete REST API documentation |
+| [TypeScript SDK](docs/sdk.md) | SDK installation, methods, and examples |
+| [Framework Integration](docs/integration.md) | Vercel AI SDK, Cloudflare Workers AI, LangGraph |
+| [Environment Variables](docs/environment-variables.md) | All env vars and Cloudflare bindings |
+
+See [CLAUDE.md](CLAUDE.md) for development guide and conventions.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add SDK installation (`npm install @agentstate/sdk`) and TypeScript example to Quick Start section, before the existing curl examples
- Replace the old "Docs" bullet list with a structured Documentation table linking to all guides: getting started, API reference, SDK, integration, and environment variables
- Preserve all existing content (features, endpoints, tech stack, development, license)

## Test plan
- [ ] Verify all documentation links resolve to valid files
- [ ] Confirm README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update README quick start and documentation sections to highlight the TypeScript SDK and provide a structured documentation index.

Documentation:
- Add npm installation and TypeScript SDK usage example to the Quick Start section before existing REST API curl examples.
- Replace the docs bullet list with a Documentation table linking to key guides including getting started, API reference, SDK, integration, and environment variables, while clarifying CLAUDE.md as the development guide.