### PR TITLE
refactor(api): extract Zod schemas into validation module

### DIFF
--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -1,6 +1,7 @@
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 import { index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 import { nanoid } from "nanoid";
+import { MESSAGE_ROLES } from "../lib/validation";
 
 // ---------------------------------------------------------------------------
 // organizations
@@ -109,7 +110,7 @@ export const messages = sqliteTable(
     conversationId: text("conversation_id")
       .notNull()
       .references(() => conversations.id),
-    role: text("role", { enum: ["system", "user", "assistant", "tool"] }).notNull(),
+    role: text("role", { enum: MESSAGE_ROLES }).notNull(),
     content: text("content").notNull(),
     metadata: text("metadata"),
     tokenCount: integer("token_count").notNull().default(0),

--- a/packages/api/src/lib/validation.ts
+++ b/packages/api/src/lib/validation.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Single source of truth for message roles */
+export const MESSAGE_ROLES = ["system", "user", "assistant", "tool"] as const;
+export type MessageRole = (typeof MESSAGE_ROLES)[number];
+
+// ---------------------------------------------------------------------------
+// Message schemas
+// ---------------------------------------------------------------------------
+
+export const MessageInputSchema = z.object({
+  role: z.enum(MESSAGE_ROLES),
+  content: z.string().min(1),
+  metadata: z.record(z.unknown()).optional(),
+  token_count: z.number().int().nonnegative().optional(),
+});
+export type MessageInput = z.infer<typeof MessageInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Conversation schemas
+// ---------------------------------------------------------------------------
+
+export const CreateConversationSchema = z.object({
+  external_id: z.string().optional(),
+  title: z.string().optional(),
+  metadata: z.record(z.unknown()).optional(),
+  messages: z.array(MessageInputSchema).optional(),
+});
+export type CreateConversationInput = z.infer<typeof CreateConversationSchema>;
+
+export const UpdateConversationSchema = z.object({
+  title: z.string().optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+export type UpdateConversationInput = z.infer<typeof UpdateConversationSchema>;
+
+export const AppendMessagesSchema = z.object({
+  messages: z.array(MessageInputSchema).min(1),
+});
+export type AppendMessagesInput = z.infer<typeof AppendMessagesSchema>;
+
+export const ExportSchema = z.object({
+  ids: z.array(z.string()).max(100).optional(),
+});
+export type ExportInput = z.infer<typeof ExportSchema>;
+
+export const BulkDeleteSchema = z.object({
+  ids: z.array(z.string()).min(1).max(100),
+});
+export type BulkDeleteInput = z.infer<typeof BulkDeleteSchema>;
+
+// ---------------------------------------------------------------------------
+// Tag schemas
+// ---------------------------------------------------------------------------
+
+export const AddTagsSchema = z.object({
+  tags: z.array(z.string().min(1).max(64)).min(1).max(50),
+});
+export type AddTagsInput = z.infer<typeof AddTagsSchema>;
+
+// ---------------------------------------------------------------------------
+// API key schemas
+// ---------------------------------------------------------------------------
+
+export const CreateApiKeySchema = z.object({
+  name: z.string().min(1, "name is required").max(255),
+});
+export type CreateApiKeyInput = z.infer<typeof CreateApiKeySchema>;

--- a/packages/api/src/routes/conversations.ts
+++ b/packages/api/src/routes/conversations.ts
@@ -1,46 +1,17 @@
 import { and, asc, desc, eq, gt, inArray, like, lt, sql } from "drizzle-orm";
 import { Hono } from "hono";
-import { z } from "zod";
 import { conversations, conversationTags, messages } from "../db/schema";
 import { generateId } from "../lib/id";
+import {
+  AppendMessagesSchema,
+  BulkDeleteSchema,
+  CreateConversationSchema,
+  ExportSchema,
+  UpdateConversationSchema,
+} from "../lib/validation";
 import { apiKeyAuth } from "../middleware/auth";
 import { rateLimitMiddleware } from "../middleware/rate-limit";
 import type { Bindings, Variables } from "../types";
-
-// ---------------------------------------------------------------------------
-// Validation schemas
-// ---------------------------------------------------------------------------
-
-const MessageInputSchema = z.object({
-  role: z.enum(["system", "user", "assistant", "tool"]),
-  content: z.string().min(1),
-  metadata: z.record(z.unknown()).optional(),
-  token_count: z.number().int().nonnegative().optional(),
-});
-
-const CreateConversationSchema = z.object({
-  external_id: z.string().optional(),
-  title: z.string().optional(),
-  metadata: z.record(z.unknown()).optional(),
-  messages: z.array(MessageInputSchema).optional(),
-});
-
-const UpdateConversationSchema = z.object({
-  title: z.string().optional(),
-  metadata: z.record(z.unknown()).optional(),
-});
-
-const AppendMessagesSchema = z.object({
-  messages: z.array(MessageInputSchema).min(1),
-});
-
-const ExportSchema = z.object({
-  ids: z.array(z.string()).max(100).optional(),
-});
-
-const BulkDeleteSchema = z.object({
-  ids: z.array(z.string()).min(1).max(100),
-});
 
 // ---------------------------------------------------------------------------
 // Helper: serialize metadata to/from JSON text column

--- a/packages/api/src/routes/keys.ts
+++ b/packages/api/src/routes/keys.ts
@@ -1,9 +1,9 @@
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
-import { z } from "zod";
 import { apiKeys } from "../db/schema";
 import { hashApiKey } from "../lib/crypto";
 import { generateApiKey, generateId } from "../lib/id";
+import { CreateApiKeySchema } from "../lib/validation";
 import { apiKeyAuth } from "../middleware/auth";
 import { rateLimitMiddleware } from "../middleware/rate-limit";
 import type { Bindings, Variables } from "../types";
@@ -34,7 +34,7 @@ app.post("/:projectId/keys", async (c) => {
     return c.json({ error: { code: "BAD_REQUEST", message: "Invalid JSON body" } }, 400);
   }
 
-  const parsed = z.object({ name: z.string().min(1, "name is required").max(255) }).safeParse(body);
+  const parsed = CreateApiKeySchema.safeParse(body);
   if (!parsed.success) {
     return c.json(
       {

--- a/packages/api/src/routes/tags.ts
+++ b/packages/api/src/routes/tags.ts
@@ -1,19 +1,11 @@
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
-import { z } from "zod";
 import { conversations, conversationTags } from "../db/schema";
 import { generateId } from "../lib/id";
+import { AddTagsSchema } from "../lib/validation";
 import { apiKeyAuth } from "../middleware/auth";
 import { rateLimitMiddleware } from "../middleware/rate-limit";
 import type { Bindings, Variables } from "../types";
-
-// ---------------------------------------------------------------------------
-// Validation schemas
-// ---------------------------------------------------------------------------
-
-const AddTagsSchema = z.object({
-  tags: z.array(z.string().min(1).max(64)).min(1).max(50),
-});
 
 // ---------------------------------------------------------------------------
 // Router


### PR DESCRIPTION
## Summary
- Create `packages/api/src/lib/validation.ts` as single source of truth for all Zod validation schemas
- Move inline schemas from `conversations.ts`, `tags.ts`, and `keys.ts` into the new module
- Extract `MESSAGE_ROLES` constant and use it in both validation schemas and Drizzle DB schema, eliminating duplication
- Export `z.infer` types for all schemas (`MessageInput`, `CreateConversationInput`, etc.)

## Test plan
- [x] All 84 existing tests pass unchanged
- [x] Biome lint/format passes
- [x] TypeScript type check passes
- [x] No circular imports (validation.ts has no internal imports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)