### PR TITLE
refactor(api): extract serialization module

### DIFF
--- a/packages/api/src/lib/serialization.ts
+++ b/packages/api/src/lib/serialization.ts
@@ -1,0 +1,63 @@
+import type { conversations, messages } from "../db/schema";
+
+// ---------------------------------------------------------------------------
+// Metadata serialization helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize a metadata object to a JSON string for storage.
+ * Returns `null` when the input is `undefined` or `null`.
+ */
+export function serializeMetadata(
+  metadata: Record<string, unknown> | undefined | null,
+): string | null {
+  return metadata != null ? JSON.stringify(metadata) : null;
+}
+
+/**
+ * Deserialize a raw JSON string from the database back into a metadata object.
+ * Returns `null` when the input is `null`, empty, or unparseable.
+ */
+export function deserializeMetadata(raw: string | null): Record<string, unknown> | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Row deserialization helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a message DB row into the API response shape.
+ */
+export function deserializeMessage(row: typeof messages.$inferSelect) {
+  return {
+    id: row.id,
+    role: row.role,
+    content: row.content,
+    metadata: deserializeMetadata(row.metadata),
+    token_count: row.tokenCount,
+    created_at: row.createdAt,
+  };
+}
+
+/**
+ * Convert a conversation DB row into the API response shape.
+ */
+export function deserializeConversationFull(row: typeof conversations.$inferSelect) {
+  return {
+    id: row.id,
+    project_id: row.projectId,
+    external_id: row.externalId,
+    title: row.title,
+    metadata: deserializeMetadata(row.metadata),
+    message_count: row.messageCount,
+    token_count: row.tokenCount,
+    created_at: row.createdAt,
+    updated_at: row.updatedAt,
+  };
+}

--- a/packages/api/src/routes/conversations.ts
+++ b/packages/api/src/routes/conversations.ts
@@ -3,6 +3,11 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { conversations, conversationTags, messages } from "../db/schema";
 import { generateId } from "../lib/id";
+import {
+  deserializeConversationFull,
+  deserializeMessage,
+  serializeMetadata,
+} from "../lib/serialization";
 import { apiKeyAuth } from "../middleware/auth";
 import { rateLimitMiddleware } from "../middleware/rate-limit";
 import type { Bindings, Variables } from "../types";
@@ -41,39 +46,6 @@ const ExportSchema = z.object({
 const BulkDeleteSchema = z.object({
   ids: z.array(z.string()).min(1).max(100),
 });
-
-// ---------------------------------------------------------------------------
-// Helper: serialize metadata to/from JSON text column
-// ---------------------------------------------------------------------------
-
-function serializeMetadata(metadata: Record<string, unknown> | undefined): string | null {
-  return metadata !== undefined ? JSON.stringify(metadata) : null;
-}
-
-function deserializeMessage(row: typeof messages.$inferSelect) {
-  return {
-    id: row.id,
-    role: row.role,
-    content: row.content,
-    metadata: row.metadata ? JSON.parse(row.metadata) : null,
-    token_count: row.tokenCount,
-    created_at: row.createdAt,
-  };
-}
-
-function deserializeConversationFull(row: typeof conversations.$inferSelect) {
-  return {
-    id: row.id,
-    project_id: row.projectId,
-    external_id: row.externalId,
-    title: row.title,
-    metadata: row.metadata ? JSON.parse(row.metadata) : null,
-    message_count: row.messageCount,
-    token_count: row.tokenCount,
-    created_at: row.createdAt,
-    updated_at: row.updatedAt,
-  };
-}
 
 // ---------------------------------------------------------------------------
 // Router

--- a/packages/api/src/routes/projects.ts
+++ b/packages/api/src/routes/projects.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { apiKeys, conversations, messages, organizations, projects } from "../db/schema";
 import { hashApiKey } from "../lib/crypto";
 import { generateApiKey, generateId } from "../lib/id";
+import { deserializeConversationFull, deserializeMessage } from "../lib/serialization";
 import type { Bindings, Variables } from "../types";
 
 const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
@@ -250,17 +251,7 @@ app.get("/:id/conversations", async (c) => {
     .limit(limit);
 
   return c.json({
-    data: rows.map((r) => ({
-      id: r.id,
-      project_id: r.projectId,
-      external_id: r.externalId,
-      title: r.title,
-      metadata: r.metadata ? JSON.parse(r.metadata) : null,
-      message_count: r.messageCount,
-      token_count: r.tokenCount,
-      created_at: r.createdAt,
-      updated_at: r.updatedAt,
-    })),
+    data: rows.map(deserializeConversationFull),
   });
 });
 
@@ -292,14 +283,7 @@ app.get("/:id/conversations/:convId/messages", async (c) => {
     .limit(500);
 
   return c.json({
-    data: msgs.map((m) => ({
-      id: m.id,
-      role: m.role,
-      content: m.content,
-      metadata: m.metadata ? JSON.parse(m.metadata) : null,
-      token_count: m.tokenCount,
-      created_at: m.createdAt,
-    })),
+    data: msgs.map(deserializeMessage),
   });
 });
 


### PR DESCRIPTION
## Summary
- Extract `serializeMetadata`, `deserializeMessage`, and `deserializeConversationFull` from `conversations.ts` into a new `packages/api/src/lib/serialization.ts` module
- Add `deserializeMetadata` helper with try/catch error handling, replacing bare `JSON.parse` calls that could throw on malformed data
- Update `projects.ts` to use shared helpers instead of inline `JSON.parse(r.metadata)` patterns

## Test plan
- [x] All 84 existing unit tests pass
- [x] Biome lint/format clean
- [x] TypeScript type check passes
- [x] Behavior preserved: same response shapes, same null handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)