### PR TITLE
test(api): add tests for tags, analytics, and rate limiting

### DIFF
--- a/packages/api/test/analytics.test.ts
+++ b/packages/api/test/analytics.test.ts
@@ -1,0 +1,153 @@
+import { SELF } from "cloudflare:test";
+import { describe, it, expect, beforeAll } from "vitest";
+import { applyMigrations, seedProject, authHeaders, TEST_PROJECT_ID } from "./setup";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createConversation(body: Record<string, unknown> = {}) {
+  return SELF.fetch("http://localhost/v1/conversations", {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify(body),
+  });
+}
+
+interface AnalyticsResponse {
+  summary: {
+    total_conversations: number;
+    total_messages: number;
+    total_tokens: number;
+    active_api_keys: number;
+  };
+  conversations_per_day: Array<{ date: string; count: number }>;
+  messages_per_day: Array<{ date: string; count: number }>;
+  tokens_per_day: Array<{ date: string; total: number }>;
+  recent_conversations: Array<{
+    id: string;
+    title: string | null;
+    message_count: number;
+    token_count: number;
+    updated_at: number;
+  }>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Analytics", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await seedProject();
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /api/v1/projects/:id/analytics
+  // -------------------------------------------------------------------------
+
+  describe("GET /api/v1/projects/:id/analytics", () => {
+    it("returns the correct response shape", async () => {
+      const res = await SELF.fetch(
+        `http://localhost/api/v1/projects/${TEST_PROJECT_ID}/analytics`,
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<AnalyticsResponse>();
+      expect(body.summary).toBeDefined();
+      expect(typeof body.summary.total_conversations).toBe("number");
+      expect(typeof body.summary.total_messages).toBe("number");
+      expect(typeof body.summary.total_tokens).toBe("number");
+      expect(typeof body.summary.active_api_keys).toBe("number");
+      expect(Array.isArray(body.conversations_per_day)).toBe(true);
+      expect(Array.isArray(body.messages_per_day)).toBe(true);
+      expect(Array.isArray(body.tokens_per_day)).toBe(true);
+      expect(Array.isArray(body.recent_conversations)).toBe(true);
+    });
+
+    it("defaults to 30d range", async () => {
+      // Both explicit ?range=30d and no range param should return the same result
+      const resDefault = await SELF.fetch(
+        `http://localhost/api/v1/projects/${TEST_PROJECT_ID}/analytics`,
+      );
+      const resExplicit = await SELF.fetch(
+        `http://localhost/api/v1/projects/${TEST_PROJECT_ID}/analytics?range=30d`,
+      );
+
+      expect(resDefault.status).toBe(200);
+      expect(resExplicit.status).toBe(200);
+
+      const bodyDefault = await resDefault.json<AnalyticsResponse>();
+      const bodyExplicit = await resExplicit.json<AnalyticsResponse>();
+
+      // Summary stats should match since both use the same range
+      expect(bodyDefault.summary).toEqual(bodyExplicit.summary);
+    });
+
+    it("supports 7d range", async () => {
+      const res = await SELF.fetch(
+        `http://localhost/api/v1/projects/${TEST_PROJECT_ID}/analytics?range=7d`,
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<AnalyticsResponse>();
+      expect(body.summary).toBeDefined();
+      expect(Array.isArray(body.conversations_per_day)).toBe(true);
+    });
+
+    it("counts match actual data after creating conversations", async () => {
+      // Record baseline
+      const baselineRes = await SELF.fetch(
+        `http://localhost/api/v1/projects/${TEST_PROJECT_ID}/analytics`,
+      );
+      const baseline = await baselineRes.json<AnalyticsResponse>();
+      const baseConvs = baseline.summary.total_conversations;
+      const baseMsgs = baseline.summary.total_messages;
+      const baseTokens = baseline.summary.total_tokens;
+
+      // Create a conversation with 2 messages
+      await createConversation({
+        title: "Analytics Test",
+        messages: [
+          { role: "user", content: "Hello", token_count: 5 },
+          { role: "assistant", content: "Hi there!", token_count: 10 },
+        ],
+      });
+
+      // Verify counts increased
+      const afterRes = await SELF.fetch(
+        `http://localhost/api/v1/projects/${TEST_PROJECT_ID}/analytics`,
+      );
+      const after = await afterRes.json<AnalyticsResponse>();
+
+      expect(after.summary.total_conversations).toBe(baseConvs + 1);
+      expect(after.summary.total_messages).toBe(baseMsgs + 2);
+      expect(after.summary.total_tokens).toBe(baseTokens + 15);
+    });
+
+    it("includes recently created conversations in recent_conversations", async () => {
+      const createRes = await createConversation({ title: "Recent Analytics Conv" });
+      expect(createRes.status).toBe(201);
+      const created = await createRes.json<{ id: string }>();
+
+      const res = await SELF.fetch(
+        `http://localhost/api/v1/projects/${TEST_PROJECT_ID}/analytics`,
+      );
+      const body = await res.json<AnalyticsResponse>();
+
+      const recentIds = body.recent_conversations.map((c) => c.id);
+      expect(recentIds).toContain(created.id);
+    });
+
+    it("reports active_api_keys count", async () => {
+      const res = await SELF.fetch(
+        `http://localhost/api/v1/projects/${TEST_PROJECT_ID}/analytics`,
+      );
+      const body = await res.json<AnalyticsResponse>();
+
+      // The seed creates one active API key
+      expect(body.summary.active_api_keys).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/packages/api/test/rate-limit.test.ts
+++ b/packages/api/test/rate-limit.test.ts
@@ -1,0 +1,114 @@
+import { SELF, env } from "cloudflare:test";
+import { describe, it, expect, beforeAll } from "vitest";
+import { applyMigrations, seedProject, authHeaders, TEST_API_KEY } from "./setup";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Rate Limiting", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await seedProject();
+  });
+
+  // -------------------------------------------------------------------------
+  // Rate limit headers
+  // -------------------------------------------------------------------------
+
+  it("includes rate limit headers in the response", async () => {
+    const res = await SELF.fetch("http://localhost/v1/conversations", {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("100");
+    expect(res.headers.get("X-RateLimit-Remaining")).toBeTruthy();
+    expect(res.headers.get("X-RateLimit-Reset")).toBeTruthy();
+  });
+
+  it("X-RateLimit-Remaining decrements on each request", async () => {
+    // Clear rate limit table to get a clean state
+    await env.DB.prepare("DELETE FROM rate_limits").run();
+
+    const res1 = await SELF.fetch("http://localhost/v1/conversations", {
+      headers: authHeaders(),
+    });
+    const remaining1 = Number(res1.headers.get("X-RateLimit-Remaining"));
+
+    const res2 = await SELF.fetch("http://localhost/v1/conversations", {
+      headers: authHeaders(),
+    });
+    const remaining2 = Number(res2.headers.get("X-RateLimit-Remaining"));
+
+    // The second request should have fewer remaining than the first
+    expect(remaining2).toBeLessThan(remaining1);
+    expect(remaining1 - remaining2).toBe(1);
+  });
+
+  it("returns 429 when rate limit is exceeded", async () => {
+    // Clear rate limit table for a clean test
+    await env.DB.prepare("DELETE FROM rate_limits").run();
+
+    // Compute the key hash to seed the rate_limits table directly.
+    // This avoids making 100+ real requests.
+    const keyHash = await computeSHA256Hex(TEST_API_KEY);
+    const now = Date.now();
+    const windowStart = now - (now % 60_000);
+
+    // Insert a rate limit row at the limit (100 requests already consumed)
+    await env.DB.prepare(
+      `INSERT INTO rate_limits (id, api_key_hash, window_start, request_count, updated_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    )
+      .bind("rl_test_429", keyHash, windowStart, 100, now)
+      .run();
+
+    // The next request should be over the limit (count becomes 101 > 100)
+    const res = await SELF.fetch("http://localhost/v1/conversations", {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(429);
+
+    const body = await res.json<{ error: { code: string; message: string } }>();
+    expect(body.error.code).toBe("RATE_LIMITED");
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("0");
+  });
+
+  it("resets rate limit in a new window", async () => {
+    // Clear rate limit table
+    await env.DB.prepare("DELETE FROM rate_limits").run();
+
+    // Insert a stale rate limit row from a past window (2 minutes ago)
+    const keyHash = await computeSHA256Hex(TEST_API_KEY);
+    const pastWindow = Date.now() - 120_000;
+    const pastWindowStart = pastWindow - (pastWindow % 60_000);
+
+    await env.DB.prepare(
+      `INSERT INTO rate_limits (id, api_key_hash, window_start, request_count, updated_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    )
+      .bind("rl_test_reset", keyHash, pastWindowStart, 100, pastWindow)
+      .run();
+
+    // Request in the current window should succeed (new window, count = 1)
+    const res = await SELF.fetch("http://localhost/v1/conversations", {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    expect(Number(res.headers.get("X-RateLimit-Remaining"))).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------------------
+
+async function computeSHA256Hex(input: string): Promise<string> {
+  const encoded = new TextEncoder().encode(input);
+  const buffer = await crypto.subtle.digest("SHA-256", encoded);
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/packages/api/test/tags.test.ts
+++ b/packages/api/test/tags.test.ts
@@ -1,0 +1,302 @@
+import { SELF, env } from "cloudflare:test";
+import { describe, it, expect, beforeAll } from "vitest";
+import { applyMigrations, seedProject, authHeaders } from "./setup";
+
+// ---------------------------------------------------------------------------
+// Extra DDL for conversation_tags (not yet in setup.ts migrations)
+// ---------------------------------------------------------------------------
+
+const TAGS_DDL = [
+  `CREATE TABLE IF NOT EXISTS \`conversation_tags\` (
+    \`id\` text PRIMARY KEY NOT NULL,
+    \`conversation_id\` text NOT NULL,
+    \`tag\` text NOT NULL,
+    \`created_at\` integer NOT NULL,
+    FOREIGN KEY (\`conversation_id\`) REFERENCES \`conversations\`(\`id\`) ON UPDATE no action ON DELETE no action
+  )`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS \`conversation_tags_conversation_id_tag_idx\` ON \`conversation_tags\` (\`conversation_id\`,\`tag\`)`,
+  `CREATE INDEX IF NOT EXISTS \`conversation_tags_tag_idx\` ON \`conversation_tags\` (\`tag\`)`,
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createConversation(body: Record<string, unknown> = {}) {
+  return SELF.fetch("http://localhost/v1/conversations", {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify(body),
+  });
+}
+
+interface ConversationWithMessages {
+  id: string;
+  project_id: string;
+  messages: Array<{ id: string; role: string; content: string }>;
+}
+
+interface TagsResponse {
+  data: { tags: string[] };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Tags", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    for (const stmt of TAGS_DDL) {
+      await env.DB.prepare(stmt).run();
+    }
+    await seedProject();
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /v1/conversations/:id/tags — Add tags
+  // -------------------------------------------------------------------------
+
+  describe("POST /v1/conversations/:id/tags", () => {
+    it("adds tags to a conversation", async () => {
+      const createRes = await createConversation({ title: "Tag Test" });
+      const conv = await createRes.json<ConversationWithMessages>();
+
+      const res = await SELF.fetch(
+        `http://localhost/v1/conversations/${conv.id}/tags`,
+        {
+          method: "POST",
+          headers: authHeaders(),
+          body: JSON.stringify({ tags: ["bug", "urgent"] }),
+        },
+      );
+      expect(res.status).toBe(201);
+
+      const body = await res.json<TagsResponse>();
+      expect(body.data.tags).toContain("bug");
+      expect(body.data.tags).toContain("urgent");
+    });
+
+    it("is idempotent — duplicate tags are ignored", async () => {
+      const createRes = await createConversation({ title: "Idempotent Tag" });
+      const conv = await createRes.json<ConversationWithMessages>();
+
+      // Add tags first time
+      await SELF.fetch(`http://localhost/v1/conversations/${conv.id}/tags`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ tags: ["feature"] }),
+      });
+
+      // Add same tag again plus a new one
+      const res = await SELF.fetch(
+        `http://localhost/v1/conversations/${conv.id}/tags`,
+        {
+          method: "POST",
+          headers: authHeaders(),
+          body: JSON.stringify({ tags: ["feature", "enhancement"] }),
+        },
+      );
+      expect(res.status).toBe(201);
+
+      const body = await res.json<TagsResponse>();
+      // Should have exactly 2 unique tags, not 3
+      expect(body.data.tags).toContain("feature");
+      expect(body.data.tags).toContain("enhancement");
+      expect(body.data.tags.length).toBe(2);
+    });
+
+    it("returns 404 for a non-existent conversation", async () => {
+      const res = await SELF.fetch(
+        "http://localhost/v1/conversations/nonexistent_conv_id/tags",
+        {
+          method: "POST",
+          headers: authHeaders(),
+          body: JSON.stringify({ tags: ["test"] }),
+        },
+      );
+      expect(res.status).toBe(404);
+
+      const body = await res.json<{ error: { code: string } }>();
+      expect(body.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns 400 when tags array is empty", async () => {
+      const createRes = await createConversation({});
+      const conv = await createRes.json<ConversationWithMessages>();
+
+      const res = await SELF.fetch(
+        `http://localhost/v1/conversations/${conv.id}/tags`,
+        {
+          method: "POST",
+          headers: authHeaders(),
+          body: JSON.stringify({ tags: [] }),
+        },
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 401 without auth", async () => {
+      const res = await SELF.fetch(
+        "http://localhost/v1/conversations/any_id/tags",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ tags: ["test"] }),
+        },
+      );
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /v1/conversations/:id/tags — List tags for a conversation
+  // -------------------------------------------------------------------------
+
+  describe("GET /v1/conversations/:id/tags", () => {
+    it("lists tags for a conversation", async () => {
+      const createRes = await createConversation({ title: "List Tags" });
+      const conv = await createRes.json<ConversationWithMessages>();
+
+      // Add some tags
+      await SELF.fetch(`http://localhost/v1/conversations/${conv.id}/tags`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ tags: ["alpha", "beta"] }),
+      });
+
+      const res = await SELF.fetch(
+        `http://localhost/v1/conversations/${conv.id}/tags`,
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<TagsResponse>();
+      expect(body.data.tags).toContain("alpha");
+      expect(body.data.tags).toContain("beta");
+      expect(body.data.tags.length).toBe(2);
+    });
+
+    it("returns empty tags for a conversation with no tags", async () => {
+      const createRes = await createConversation({ title: "No Tags" });
+      const conv = await createRes.json<ConversationWithMessages>();
+
+      const res = await SELF.fetch(
+        `http://localhost/v1/conversations/${conv.id}/tags`,
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<TagsResponse>();
+      expect(body.data.tags).toEqual([]);
+    });
+
+    it("returns 404 for a non-existent conversation", async () => {
+      const res = await SELF.fetch(
+        "http://localhost/v1/conversations/nonexistent_conv_id/tags",
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(404);
+
+      const body = await res.json<{ error: { code: string } }>();
+      expect(body.error.code).toBe("NOT_FOUND");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /v1/tags — List all tags for the project
+  // -------------------------------------------------------------------------
+
+  describe("GET /v1/tags", () => {
+    it("lists all unique tags across conversations in the project", async () => {
+      // Create two conversations with overlapping tags
+      const res1 = await createConversation({ title: "Tags A" });
+      const conv1 = await res1.json<ConversationWithMessages>();
+      await SELF.fetch(`http://localhost/v1/conversations/${conv1.id}/tags`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ tags: ["shared", "only-a"] }),
+      });
+
+      const res2 = await createConversation({ title: "Tags B" });
+      const conv2 = await res2.json<ConversationWithMessages>();
+      await SELF.fetch(`http://localhost/v1/conversations/${conv2.id}/tags`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ tags: ["shared", "only-b"] }),
+      });
+
+      const res = await SELF.fetch("http://localhost/v1/tags", {
+        headers: authHeaders(),
+      });
+      expect(res.status).toBe(200);
+
+      const body = await res.json<TagsResponse>();
+      expect(body.data.tags).toContain("shared");
+      expect(body.data.tags).toContain("only-a");
+      expect(body.data.tags).toContain("only-b");
+    });
+
+    it("returns 401 without auth", async () => {
+      const res = await SELF.fetch("http://localhost/v1/tags");
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // DELETE /v1/conversations/:id/tags/:tag — Remove a tag
+  // -------------------------------------------------------------------------
+
+  describe("DELETE /v1/conversations/:id/tags/:tag", () => {
+    it("removes a tag from a conversation", async () => {
+      const createRes = await createConversation({ title: "Delete Tag" });
+      const conv = await createRes.json<ConversationWithMessages>();
+
+      // Add tags
+      await SELF.fetch(`http://localhost/v1/conversations/${conv.id}/tags`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ tags: ["remove-me", "keep-me"] }),
+      });
+
+      // Delete one tag
+      const deleteRes = await SELF.fetch(
+        `http://localhost/v1/conversations/${conv.id}/tags/remove-me`,
+        { method: "DELETE", headers: authHeaders() },
+      );
+      expect(deleteRes.status).toBe(204);
+
+      // Verify it was removed
+      const listRes = await SELF.fetch(
+        `http://localhost/v1/conversations/${conv.id}/tags`,
+        { headers: authHeaders() },
+      );
+      const body = await listRes.json<TagsResponse>();
+      expect(body.data.tags).not.toContain("remove-me");
+      expect(body.data.tags).toContain("keep-me");
+    });
+
+    it("returns 204 even when tag does not exist (idempotent delete)", async () => {
+      const createRes = await createConversation({ title: "Delete Nonexistent" });
+      const conv = await createRes.json<ConversationWithMessages>();
+
+      const res = await SELF.fetch(
+        `http://localhost/v1/conversations/${conv.id}/tags/nonexistent-tag`,
+        { method: "DELETE", headers: authHeaders() },
+      );
+      // The route deletes and returns 204 regardless of whether the tag existed
+      expect(res.status).toBe(204);
+    });
+
+    it("returns 404 for a non-existent conversation", async () => {
+      const res = await SELF.fetch(
+        "http://localhost/v1/conversations/nonexistent_conv_id/tags/some-tag",
+        { method: "DELETE", headers: authHeaders() },
+      );
+      expect(res.status).toBe(404);
+
+      const body = await res.json<{ error: { code: string } }>();
+      expect(body.error.code).toBe("NOT_FOUND");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `tags.test.ts` (13 tests): tag CRUD on conversations, project-wide tag listing, idempotency, auth guards
- Add `analytics.test.ts` (6 tests): response shape validation, range params (7d/30d), count accuracy against actual data, recent conversations
- Add `rate-limit.test.ts` (4 tests): rate limit headers present and decrement, 429 when limit exceeded (via direct DB seeding), window reset behavior

Total new tests: 23 (107 total, up from 84)

## Test plan
- [x] All 107 tests pass locally (`bunx vitest run`)
- [x] No source files modified — only new test files created
- [x] Follows existing test patterns (SELF.fetch, applyMigrations, seedProject, authHeaders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)