### PR TITLE
refactor(api): extract serialization module

### DIFF
--- a/packages/api/src/lib/serialization.ts
+++ b/packages/api/src/lib/serialization.ts
@@ -1,0 +1,56 @@
+import type { conversations, messages } from "../db/schema";
+
+/**
+ * Serialize a metadata object to a JSON string for storage.
+ * Returns null if metadata is undefined or null.
+ */
+export function serializeMetadata(
+  metadata: Record<string, unknown> | undefined | null,
+): string | null {
+  if (metadata === undefined || metadata === null) return null;
+  return JSON.stringify(metadata);
+}
+
+/**
+ * Deserialize a JSON metadata string back to an object.
+ * Returns null if the input is null or parsing fails.
+ */
+export function deserializeMetadata(raw: string | null): Record<string, unknown> | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Convert a message DB row to the API response shape (snake_case).
+ */
+export function deserializeMessage(row: typeof messages.$inferSelect) {
+  return {
+    id: row.id,
+    role: row.role,
+    content: row.content,
+    metadata: deserializeMetadata(row.metadata),
+    token_count: row.tokenCount,
+    created_at: row.createdAt,
+  };
+}
+
+/**
+ * Convert a conversation DB row to the API response shape (snake_case).
+ */
+export function deserializeConversationFull(row: typeof conversations.$inferSelect) {
+  return {
+    id: row.id,
+    project_id: row.projectId,
+    external_id: row.externalId,
+    title: row.title,
+    metadata: deserializeMetadata(row.metadata),
+    message_count: row.messageCount,
+    token_count: row.tokenCount,
+    created_at: row.createdAt,
+    updated_at: row.updatedAt,
+  };
+}

--- a/packages/api/src/routes/conversations.ts
+++ b/packages/api/src/routes/conversations.ts
@@ -4,6 +4,11 @@ import { conversations, conversationTags, messages } from "../db/schema";
 import { parseJsonBody, validationError } from "../lib/helpers";
 import { generateId } from "../lib/id";
 import {
+  deserializeConversationFull,
+  deserializeMessage,
+  serializeMetadata,
+} from "../lib/serialization";
+import {
   AppendMessagesSchema,
   BulkDeleteSchema,
   CreateConversationSchema,
@@ -13,39 +18,6 @@ import {
 import { apiKeyAuth } from "../middleware/auth";
 import { rateLimitMiddleware } from "../middleware/rate-limit";
 import type { Bindings, Variables } from "../types";
-
-// ---------------------------------------------------------------------------
-// Helper: serialize metadata to/from JSON text column
-// ---------------------------------------------------------------------------
-
-function serializeMetadata(metadata: Record<string, unknown> | undefined): string | null {
-  return metadata !== undefined ? JSON.stringify(metadata) : null;
-}
-
-function deserializeMessage(row: typeof messages.$inferSelect) {
-  return {
-    id: row.id,
-    role: row.role,
-    content: row.content,
-    metadata: row.metadata ? JSON.parse(row.metadata) : null,
-    token_count: row.tokenCount,
-    created_at: row.createdAt,
-  };
-}
-
-function deserializeConversationFull(row: typeof conversations.$inferSelect) {
-  return {
-    id: row.id,
-    project_id: row.projectId,
-    external_id: row.externalId,
-    title: row.title,
-    metadata: row.metadata ? JSON.parse(row.metadata) : null,
-    message_count: row.messageCount,
-    token_count: row.tokenCount,
-    created_at: row.createdAt,
-    updated_at: row.updatedAt,
-  };
-}
 
 // ---------------------------------------------------------------------------
 // Router

--- a/packages/api/src/routes/projects.ts
+++ b/packages/api/src/routes/projects.ts
@@ -5,6 +5,7 @@ import { apiKeys, conversations, messages, organizations, projects } from "../db
 import { hashApiKey } from "../lib/crypto";
 import { parseJsonBody, validationError } from "../lib/helpers";
 import { generateApiKey, generateId } from "../lib/id";
+import { deserializeMetadata } from "../lib/serialization";
 import type { Bindings, Variables } from "../types";
 
 const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
@@ -246,7 +247,7 @@ app.get("/:id/conversations", async (c) => {
       project_id: r.projectId,
       external_id: r.externalId,
       title: r.title,
-      metadata: r.metadata ? JSON.parse(r.metadata) : null,
+      metadata: deserializeMetadata(r.metadata),
       message_count: r.messageCount,
       token_count: r.tokenCount,
       created_at: r.createdAt,
@@ -287,7 +288,7 @@ app.get("/:id/conversations/:convId/messages", async (c) => {
       id: m.id,
       role: m.role,
       content: m.content,
-      metadata: m.metadata ? JSON.parse(m.metadata) : null,
+      metadata: deserializeMetadata(m.metadata),
       token_count: m.tokenCount,
       created_at: m.createdAt,
     })),


### PR DESCRIPTION
## Summary
- Extract `serializeMetadata`, `deserializeMetadata`, `deserializeMessage`, `deserializeConversationFull` into `packages/api/src/lib/serialization.ts`
- Add safe `deserializeMetadata` with try/catch (replaces bare `JSON.parse`)
- Update imports in `conversations.ts` and `projects.ts`

Replaces #21 (which had merge conflicts after earlier PRs landed).

## Test plan
- [x] Lint: `bunx biome check` — 0 errors
- [x] Typecheck: `bunx tsc --noEmit` — 0 errors
- [x] Tests: 84/84 passing

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>