### PR TITLE
feat(dashboard): add error toast notifications

### DIFF
--- a/packages/dashboard/src/app/dashboard/analytics/page.tsx
+++ b/packages/dashboard/src/app/dashboard/analytics/page.tsx
@@ -5,7 +5,9 @@ import { AreaChartCard } from "@/components/analytics/area-chart";
 import { RecentActivity } from "@/components/analytics/recent-activity";
 import { SummaryCards } from "@/components/analytics/summary-cards";
 import { type TimeRange, TimeRangeSelect } from "@/components/analytics/time-range-select";
+import { toast } from "sonner";
 import { api } from "@/lib/api";
+import { getErrorMessage } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -56,7 +58,7 @@ export default function AnalyticsPage() {
           setSelectedProjectId(res.data[0].id);
         }
       })
-      .catch(() => {})
+      .catch((err) => toast.error(getErrorMessage(err, "Failed to load projects")))
       .finally(() => setLoading(false));
   }, []);
 
@@ -66,7 +68,10 @@ export default function AnalyticsPage() {
     setLoading(true);
     api<AnalyticsData>(`/v1/projects/${selectedProjectId}/analytics?range=${range}`)
       .then(setData)
-      .catch(() => setData(null))
+      .catch((err) => {
+        setData(null);
+        toast.error(getErrorMessage(err, "Failed to load analytics"));
+      })
       .finally(() => setLoading(false));
   }, [selectedProjectId, range]);
 

--- a/packages/dashboard/src/app/dashboard/conversations/page.tsx
+++ b/packages/dashboard/src/app/dashboard/conversations/page.tsx
@@ -2,7 +2,9 @@
 
 import { ChevronDownIcon, ChevronRightIcon, MessageSquareIcon } from "lucide-react";
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 import { api } from "@/lib/api";
+import { getErrorMessage } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -274,7 +276,7 @@ export default function ConversationsPage() {
           setSelectedProjectId(res.data[0].id);
         }
       })
-      .catch(() => {})
+      .catch((err) => toast.error(getErrorMessage(err, "Failed to load projects")))
       .finally(() => setLoadingProjects(false));
   }, []);
 
@@ -285,7 +287,7 @@ export default function ConversationsPage() {
     setConversations([]);
     api<{ data: Conversation[] }>(`/v1/projects/${selectedProjectId}/conversations`)
       .then((res) => setConversations(res.data))
-      .catch(() => {})
+      .catch((err) => toast.error(getErrorMessage(err, "Failed to load conversations")))
       .finally(() => setLoadingConversations(false));
   }, [selectedProjectId]);
 

--- a/packages/dashboard/src/app/dashboard/page.tsx
+++ b/packages/dashboard/src/app/dashboard/page.tsx
@@ -7,6 +7,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { api } from "@/lib/api";
 import { generateName, toSlug } from "@/lib/name-generator";
+import { toast } from "sonner";
+import { getErrorMessage } from "@/lib/utils";
 
 interface Project {
   id: string;
@@ -29,7 +31,7 @@ export default function ProjectsPage() {
   useEffect(() => {
     api<{ data: Project[] }>("/v1/projects")
       .then((res) => setProjects(res.data))
-      .catch(() => {}); // silently fail if API not ready
+      .catch((err) => toast.error(getErrorMessage(err, "Failed to load projects")));
   }, []);
 
   // Auto-generate slug from name
@@ -74,10 +76,11 @@ export default function ProjectsPage() {
       });
       // Store key in sessionStorage (not URL) — shown once on project page
       sessionStorage.setItem(`new_key_${res.project.slug}`, res.api_key.key);
+      toast.success("Project created");
       router.push(`/dashboard/project/?slug=${res.project.slug}`);
-    } catch (_err: any) {
-      // Show error (e.g., slug taken)
+    } catch (err: unknown) {
       setSlugStatus("taken");
+      toast.error(getErrorMessage(err, "Failed to create project"));
     }
   }
 

--- a/packages/dashboard/src/app/dashboard/project/page.tsx
+++ b/packages/dashboard/src/app/dashboard/project/page.tsx
@@ -21,6 +21,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { api } from "@/lib/api";
+import { toast } from "sonner";
+import { getErrorMessage } from "@/lib/utils";
 
 interface ApiKey {
   id: string;
@@ -104,10 +106,10 @@ function ProjectContent() {
         setConvsLoading(true);
         api<{ data: Conversation[] }>(`/v1/projects/${p.id}/conversations?limit=100`)
           .then((res) => setConversations(res.data))
-          .catch(() => {})
+          .catch((err) => toast.error(getErrorMessage(err, "Failed to load conversations")))
           .finally(() => setConvsLoading(false));
       })
-      .catch(() => {})
+      .catch((err) => toast.error(getErrorMessage(err, "Failed to load project")))
       .finally(() => setLoading(false));
   }, [slug]);
 
@@ -122,19 +124,29 @@ function ProjectContent() {
   }
   async function handleCreateKey() {
     if (!newKeyName.trim() || !project) return;
-    const res = await api<{ id: string; key: string }>(`/v1/projects/${project.id}/keys`, {
-      method: "POST",
-      body: JSON.stringify({ name: newKeyName.trim() }),
-    });
-    setCreatedKey(res.key);
-    setShowCreateKey(false);
-    setNewKeyName("");
-    setProject(await api<ProjectDetail>(`/v1/projects/by-slug/${slug}`));
+    try {
+      const res = await api<{ id: string; key: string }>(`/v1/projects/${project.id}/keys`, {
+        method: "POST",
+        body: JSON.stringify({ name: newKeyName.trim() }),
+      });
+      setCreatedKey(res.key);
+      setShowCreateKey(false);
+      setNewKeyName("");
+      setProject(await api<ProjectDetail>(`/v1/projects/by-slug/${slug}`));
+      toast.success("API key created");
+    } catch (err) {
+      toast.error(getErrorMessage(err, "Failed to create API key"));
+    }
   }
   async function handleRevokeKey(keyId: string) {
     if (!project) return;
-    await api(`/v1/projects/${project.id}/keys/${keyId}`, { method: "DELETE" });
-    setProject(await api<ProjectDetail>(`/v1/projects/by-slug/${slug}`));
+    try {
+      await api(`/v1/projects/${project.id}/keys/${keyId}`, { method: "DELETE" });
+      setProject(await api<ProjectDetail>(`/v1/projects/by-slug/${slug}`));
+      toast.success("API key revoked");
+    } catch (err) {
+      toast.error(getErrorMessage(err, "Failed to revoke API key"));
+    }
   }
   async function toggleConversation(convId: string) {
     if (expandedConv === convId) {

--- a/packages/dashboard/src/app/providers.tsx
+++ b/packages/dashboard/src/app/providers.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { ClerkProvider } from "@clerk/react";
+import { Toaster } from "sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ClerkProvider publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY!}>
       <TooltipProvider>{children}</TooltipProvider>
+      <Toaster richColors />
     </ClerkProvider>
   );
 }

--- a/packages/dashboard/src/lib/utils.ts
+++ b/packages/dashboard/src/lib/utils.ts
@@ -4,3 +4,8 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/** Extract a human-readable message from an unknown caught value. */
+export function getErrorMessage(err: unknown, fallback = "Something went wrong"): string {
+  return err instanceof Error ? err.message : fallback;
+}


### PR DESCRIPTION
## Summary
- Wire up sonner `<Toaster richColors />` in `providers.tsx` so toasts render globally
- Replace all silent `.catch(() => {})` handlers (8 occurrences across 4 pages) with `toast.error()` showing the actual error message
- Add `toast.success()` for project creation, API key creation, and API key revocation
- Extract `getErrorMessage()` utility in `lib/utils.ts` to avoid repeating `err instanceof Error ? err.message : fallback` 9 times

## Test plan
- [x] `bunx tsc --noEmit` passes (dashboard)
- [x] `bun run build` passes (dashboard)
- [x] `bunx vitest run` passes (API — 84 tests)
- [ ] Manual: trigger an API error and verify toast appears
- [ ] Manual: create a project and verify success toast appears
- [ ] Manual: create/revoke an API key and verify success toast appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)