### PR TITLE
refactor(dashboard): deduplicate types + fix CI for workspace deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,16 +23,16 @@ jobs:
           node-version: "22"
 
       - name: Install dependencies
-        run: npm install && npm install @rollup/rollup-linux-x64-gnu
+        run: bun install
 
       - name: Lint
         run: bunx biome check packages/api/src/
 
       - name: Type check
-        run: npx tsc --noEmit -p packages/api/tsconfig.json
+        run: bunx tsc --noEmit -p packages/api/tsconfig.json
 
       - name: Test
-        run: cd packages/api && npx vitest run
+        run: cd packages/api && bunx vitest run
 
       - name: Build Dashboard
         run: cd packages/dashboard && bun install && bun run build
@@ -56,7 +56,7 @@ jobs:
           node-version: "22"
 
       - name: Install dependencies
-        run: npm install
+        run: bun install
 
       - name: Build Dashboard
         run: cd packages/dashboard && bun install && bun run build

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
       "name": "dashboard",
       "version": "0.1.0",
       "dependencies": {
+        "@agentstate/shared": "workspace:*",
         "@base-ui/react": "^1.3.0",
         "@clerk/nextjs": "^7.0.4",
         "@clerk/react": "^6.1.0",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@agentstate/shared": "workspace:*",
     "@base-ui/react": "^1.3.0",
     "@clerk/nextjs": "^7.0.4",
     "@clerk/react": "^6.1.0",

--- a/packages/dashboard/src/app/dashboard/analytics/page.tsx
+++ b/packages/dashboard/src/app/dashboard/analytics/page.tsx
@@ -5,51 +5,23 @@ import { AreaChartCard } from "@/components/analytics/area-chart";
 import { RecentActivity } from "@/components/analytics/recent-activity";
 import { SummaryCards } from "@/components/analytics/summary-cards";
 import { type TimeRange, TimeRangeSelect } from "@/components/analytics/time-range-select";
+import type { AnalyticsResponse, ProjectResponse } from "@agentstate/shared";
 import { api } from "@/lib/api";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-interface Project {
-  id: string;
-  name: string;
-  slug: string;
-}
-
-interface AnalyticsData {
-  summary: {
-    total_conversations: number;
-    total_messages: number;
-    total_tokens: number;
-    active_api_keys: number;
-  };
-  conversations_per_day: { date: string; count: number }[];
-  messages_per_day: { date: string; count: number }[];
-  tokens_per_day: { date: string; total: number }[];
-  recent_conversations: {
-    id: string;
-    title: string | null;
-    message_count: number;
-    token_count: number;
-    updated_at: number;
-  }[];
-}
 
 // ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
 export default function AnalyticsPage() {
-  const [projects, setProjects] = useState<Project[]>([]);
+  const [projects, setProjects] = useState<ProjectResponse[]>([]);
   const [selectedProjectId, setSelectedProjectId] = useState("");
   const [range, setRange] = useState<TimeRange>("30d");
-  const [data, setData] = useState<AnalyticsData | null>(null);
+  const [data, setData] = useState<AnalyticsResponse | null>(null);
   const [loading, setLoading] = useState(true);
 
   // Fetch projects
   useEffect(() => {
-    api<{ data: Project[] }>("/v1/projects")
+    api<{ data: ProjectResponse[] }>("/v1/projects")
       .then((res) => {
         setProjects(res.data);
         if (res.data.length > 0) {
@@ -64,7 +36,7 @@ export default function AnalyticsPage() {
   useEffect(() => {
     if (!selectedProjectId) return;
     setLoading(true);
-    api<AnalyticsData>(`/v1/projects/${selectedProjectId}/analytics?range=${range}`)
+    api<AnalyticsResponse>(`/v1/projects/${selectedProjectId}/analytics?range=${range}`)
       .then(setData)
       .catch(() => setData(null))
       .finally(() => setLoading(false));

--- a/packages/dashboard/src/app/dashboard/conversations/page.tsx
+++ b/packages/dashboard/src/app/dashboard/conversations/page.tsx
@@ -2,37 +2,17 @@
 
 import { ChevronDownIcon, ChevronRightIcon, MessageSquareIcon } from "lucide-react";
 import { useEffect, useState } from "react";
+import type {
+  ConversationResponse,
+  MessageResponse,
+  ProjectResponse,
+} from "@agentstate/shared";
 import { api } from "@/lib/api";
 import { ROLE_STYLES } from "@/lib/constants";
 import { formatDate, formatDateShort } from "@/lib/format";
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-interface Project {
-  id: string;
-  name: string;
-  slug: string;
-}
-
-interface Conversation {
-  id: string;
-  project_id: string;
-  title: string | null;
-  message_count: number;
-  token_count: number;
-  created_at: number;
-  updated_at: number;
-}
-
-interface Message {
-  id: string;
-  role: "user" | "assistant" | "system" | "tool";
-  content: string;
-  token_count: number;
-  created_at: number;
-}
+type Conversation = ConversationResponse & { project_id: string };
+type Message = MessageResponse;
 
 // ---------------------------------------------------------------------------
 // Role badge
@@ -231,7 +211,7 @@ function ConversationRow({ conv }: { conv: Conversation }) {
 // ---------------------------------------------------------------------------
 
 export default function ConversationsPage() {
-  const [projects, setProjects] = useState<Project[]>([]);
+  const [projects, setProjects] = useState<ProjectResponse[]>([]);
   const [selectedProjectId, setSelectedProjectId] = useState<string>("");
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [loadingProjects, setLoadingProjects] = useState(true);
@@ -240,7 +220,7 @@ export default function ConversationsPage() {
   // Fetch projects on mount
   useEffect(() => {
     setLoadingProjects(true);
-    api<{ data: Project[] }>("/v1/projects")
+    api<{ data: ProjectResponse[] }>("/v1/projects")
       .then((res) => {
         setProjects(res.data);
         if (res.data.length > 0) {

--- a/packages/dashboard/src/app/dashboard/page.tsx
+++ b/packages/dashboard/src/app/dashboard/page.tsx
@@ -5,16 +5,11 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import type { ProjectListItem } from "@agentstate/shared";
 import { api } from "@/lib/api";
 import { generateName, toSlug } from "@/lib/name-generator";
 
-interface Project {
-  id: string;
-  name: string;
-  slug: string;
-  key_count?: number;
-  created_at: number;
-}
+type Project = ProjectListItem;
 
 export default function ProjectsPage() {
   const router = useRouter();

--- a/packages/dashboard/src/app/dashboard/project/page.tsx
+++ b/packages/dashboard/src/app/dashboard/project/page.tsx
@@ -20,42 +20,17 @@ import { Suspense, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type {
+  ConversationResponse,
+  MessageResponse,
+  ProjectDetailResponse,
+} from "@agentstate/shared";
 import { api } from "@/lib/api";
 import { ROLE_STYLES } from "@/lib/constants";
 
-interface ApiKey {
-  id: string;
-  name: string;
-  key_prefix: string;
-  created_at: number;
-  last_used_at: number | null;
-  revoked_at: number | null;
-}
-interface ProjectDetail {
-  id: string;
-  name: string;
-  slug: string;
-  created_at: number;
-  api_keys: ApiKey[];
-}
-interface Conversation {
-  id: string;
-  external_id: string | null;
-  title: string | null;
-  message_count: number;
-  token_count: number;
-  metadata: Record<string, unknown> | null;
-  created_at: number;
-  updated_at: number;
-}
-interface Message {
-  id: string;
-  role: string;
-  content: string;
-  metadata: Record<string, unknown> | null;
-  token_count: number;
-  created_at: number;
-}
+type ProjectDetail = ProjectDetailResponse;
+type Conversation = ConversationResponse;
+type Message = MessageResponse;
 
 const ALL_COLUMNS = [
   { key: "title", label: "Title" },


### PR DESCRIPTION
## Summary
- Replace locally defined interfaces in all dashboard pages with imports from `@agentstate/shared`
- Fix CI workflow to use `bun install` instead of `npm install` (required for `workspace:*` protocol)
- Removes ~80 lines of duplicated type definitions across 4 dashboard pages

Replaces #25 (which had merge conflicts).

## Test plan
- [x] Dashboard typecheck: 0 errors
- [x] Dashboard build: all pages rendered as static
- [x] API tests: 107/107 passing
- [x] Lint: 0 issues

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>