### PR TITLE
feat(dashboard): add error toast notifications

### DIFF
--- a/packages/dashboard/src/app/dashboard/analytics/page.tsx
+++ b/packages/dashboard/src/app/dashboard/analytics/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import type { AnalyticsResponse, ProjectResponse } from "@agentstate/shared";
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 import { AreaChartCard } from "@/components/analytics/area-chart";
 import { RecentActivity } from "@/components/analytics/recent-activity";
 import { SummaryCards } from "@/components/analytics/summary-cards";
 import { type TimeRange, TimeRangeSelect } from "@/components/analytics/time-range-select";
-import type { AnalyticsResponse, ProjectResponse } from "@agentstate/shared";
 import { api } from "@/lib/api";
 
 // ---------------------------------------------------------------------------
@@ -28,7 +29,7 @@ export default function AnalyticsPage() {
           setSelectedProjectId(res.data[0].id);
         }
       })
-      .catch(() => {})
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load data"))
       .finally(() => setLoading(false));
   }, []);
 
@@ -38,7 +39,10 @@ export default function AnalyticsPage() {
     setLoading(true);
     api<AnalyticsResponse>(`/v1/projects/${selectedProjectId}/analytics?range=${range}`)
       .then(setData)
-      .catch(() => setData(null))
+      .catch((e) => {
+        setData(null);
+        toast.error(e instanceof Error ? e.message : "Failed to load analytics");
+      })
       .finally(() => setLoading(false));
   }, [selectedProjectId, range]);
 

--- a/packages/dashboard/src/app/dashboard/conversations/page.tsx
+++ b/packages/dashboard/src/app/dashboard/conversations/page.tsx
@@ -1,12 +1,9 @@
 "use client";
 
+import type { ConversationResponse, MessageResponse, ProjectResponse } from "@agentstate/shared";
 import { ChevronDownIcon, ChevronRightIcon, MessageSquareIcon } from "lucide-react";
 import { useEffect, useState } from "react";
-import type {
-  ConversationResponse,
-  MessageResponse,
-  ProjectResponse,
-} from "@agentstate/shared";
+import { toast } from "sonner";
 import { api } from "@/lib/api";
 import { ROLE_STYLES } from "@/lib/constants";
 import { formatDate, formatDateShort } from "@/lib/format";
@@ -227,7 +224,7 @@ export default function ConversationsPage() {
           setSelectedProjectId(res.data[0].id);
         }
       })
-      .catch(() => {})
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load data"))
       .finally(() => setLoadingProjects(false));
   }, []);
 
@@ -238,7 +235,7 @@ export default function ConversationsPage() {
     setConversations([]);
     api<{ data: Conversation[] }>(`/v1/projects/${selectedProjectId}/conversations`)
       .then((res) => setConversations(res.data))
-      .catch(() => {})
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load data"))
       .finally(() => setLoadingConversations(false));
   }, [selectedProjectId]);
 

--- a/packages/dashboard/src/app/dashboard/page.tsx
+++ b/packages/dashboard/src/app/dashboard/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import type { ProjectListItem } from "@agentstate/shared";
 import { CheckIcon, FolderIcon, KeyIcon, LoaderIcon, PlusIcon, XIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import type { ProjectListItem } from "@agentstate/shared";
 import { api } from "@/lib/api";
 import { generateName, toSlug } from "@/lib/name-generator";
 
@@ -24,7 +25,7 @@ export default function ProjectsPage() {
   useEffect(() => {
     api<{ data: Project[] }>("/v1/projects")
       .then((res) => setProjects(res.data))
-      .catch(() => {}); // silently fail if API not ready
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load projects"));
   }, []);
 
   // Auto-generate slug from name

--- a/packages/dashboard/src/app/dashboard/project/page.tsx
+++ b/packages/dashboard/src/app/dashboard/project/page.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+import type {
+  ConversationResponse,
+  MessageResponse,
+  ProjectDetailResponse,
+} from "@agentstate/shared";
 import {
   ArrowLeftIcon,
   BookOpenIcon,
@@ -17,14 +22,10 @@ import {
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import type {
-  ConversationResponse,
-  MessageResponse,
-  ProjectDetailResponse,
-} from "@agentstate/shared";
 import { api } from "@/lib/api";
 import { ROLE_STYLES } from "@/lib/constants";
 
@@ -73,10 +74,10 @@ function ProjectContent() {
         setConvsLoading(true);
         api<{ data: Conversation[] }>(`/v1/projects/${p.id}/conversations?limit=100`)
           .then((res) => setConversations(res.data))
-          .catch(() => {})
+          .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load data"))
           .finally(() => setConvsLoading(false));
       })
-      .catch(() => {})
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load data"))
       .finally(() => setLoading(false));
   }, [slug]);
 

--- a/packages/dashboard/src/app/providers.tsx
+++ b/packages/dashboard/src/app/providers.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { ClerkProvider } from "@clerk/react";
+import { Toaster } from "sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ClerkProvider publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY!}>
       <TooltipProvider>{children}</TooltipProvider>
+      <Toaster richColors position="bottom-right" />
     </ClerkProvider>
   );
 }


### PR DESCRIPTION
## Summary
- Add `<Toaster />` from sonner to providers.tsx with `richColors` + `bottom-right` position
- Replace 7 silent `.catch(() => {})` with `toast.error()` across all dashboard pages
- Users now see error feedback when API calls fail

Replaces #28 (which had merge conflicts).

## Test plan
- [x] Dashboard typecheck: 0 errors
- [x] Dashboard build: all pages static
- [x] Lint: 0 issues

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>