### PR TITLE
feat(api): add delete project endpoint with cascade delete

### DIFF
--- a/packages/api/src/routes/projects.ts
+++ b/packages/api/src/routes/projects.ts
@@ -1,7 +1,14 @@
-import { and, asc, desc, eq, isNull, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
-import { apiKeys, conversations, messages, organizations, projects } from "../db/schema";
+import {
+  apiKeys,
+  conversations,
+  conversationTags,
+  messages,
+  organizations,
+  projects,
+} from "../db/schema";
 import { hashApiKey } from "../lib/crypto";
 import { parseJsonBody, validationError } from "../lib/helpers";
 import { generateApiKey, generateId } from "../lib/id";
@@ -382,6 +389,45 @@ app.delete("/:id/keys/:keyId", async (c) => {
     .update(apiKeys)
     .set({ revokedAt: Date.now() })
     .where(and(eq(apiKeys.id, keyId), eq(apiKeys.projectId, projectId)));
+
+  return c.body(null, 204);
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /v1/projects/:id — Delete project (cascade)
+// ---------------------------------------------------------------------------
+
+app.delete("/:id", async (c) => {
+  const db = c.get("db");
+  const projectId = c.req.param("id");
+
+  const project = await db.select().from(projects).where(eq(projects.id, projectId)).get();
+
+  if (!project) {
+    return c.json({ error: { code: "NOT_FOUND", message: "Project not found" } }, 404);
+  }
+
+  const convRows = await db
+    .select({ id: conversations.id })
+    .from(conversations)
+    .where(eq(conversations.projectId, projectId));
+
+  const convIds = convRows.map((r) => r.id);
+
+  if (convIds.length > 0) {
+    await db.batch([
+      db.delete(conversationTags).where(inArray(conversationTags.conversationId, convIds)),
+      db.delete(messages).where(inArray(messages.conversationId, convIds)),
+      db.delete(conversations).where(eq(conversations.projectId, projectId)),
+      db.delete(apiKeys).where(eq(apiKeys.projectId, projectId)),
+      db.delete(projects).where(eq(projects.id, projectId)),
+    ]);
+  } else {
+    await db.batch([
+      db.delete(apiKeys).where(eq(apiKeys.projectId, projectId)),
+      db.delete(projects).where(eq(projects.id, projectId)),
+    ]);
+  }
 
   return c.body(null, 204);
 });

--- a/packages/api/test/projects.test.ts
+++ b/packages/api/test/projects.test.ts
@@ -546,6 +546,108 @@ describe("Projects (/api/v1/projects)", () => {
   });
 
   // -------------------------------------------------------------------------
+  // DELETE /:id — Delete project
+  // -------------------------------------------------------------------------
+
+  describe("DELETE /api/v1/projects/:id", () => {
+    it("deletes a project and returns 204", async () => {
+      const createRes = await createProject({
+        name: "Delete Me",
+        slug: `delete-me-${Date.now()}`,
+      });
+      expect(createRes.status).toBe(201);
+      const { project } = await createRes.json<{ project: Project; api_key: ApiKeyCreated }>();
+
+      const deleteRes = await SELF.fetch(`http://localhost/api/v1/projects/${project.id}`, {
+        method: "DELETE",
+      });
+      expect(deleteRes.status).toBe(204);
+    });
+
+    it("returns 404 for a non-existent project", async () => {
+      const res = await SELF.fetch("http://localhost/api/v1/projects/nonexistent_proj_id_xyz", {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(404);
+
+      const body = await res.json<{ error: { code: string } }>();
+      expect(body.error.code).toBe("NOT_FOUND");
+    });
+
+    it("cascades deletion to conversations, messages, and API keys", async () => {
+      const slug = `cascade-del-${Date.now()}`;
+      const createRes = await createProject({ name: "Cascade Delete", slug });
+      expect(createRes.status).toBe(201);
+      const { project, api_key } = await createRes.json<{
+        project: Project;
+        api_key: ApiKeyCreated;
+      }>();
+
+      const authHeaders = {
+        Authorization: `Bearer ${api_key.key}`,
+        "Content-Type": "application/json",
+      };
+
+      // Create a conversation with messages via the API key
+      const convRes = await SELF.fetch("http://localhost/v1/conversations", {
+        method: "POST",
+        headers: authHeaders,
+        body: JSON.stringify({
+          messages: [
+            { role: "user", content: "Hello" },
+            { role: "assistant", content: "Hi there" },
+          ],
+        }),
+      });
+      expect(convRes.status).toBe(201);
+
+      // Delete the project
+      const deleteRes = await SELF.fetch(`http://localhost/api/v1/projects/${project.id}`, {
+        method: "DELETE",
+      });
+      expect(deleteRes.status).toBe(204);
+
+      // Verify the project is gone
+      const getRes = await SELF.fetch(`http://localhost/api/v1/projects/${project.id}`);
+      expect(getRes.status).toBe(404);
+
+      // Verify conversations listing returns empty (project no longer exists)
+      const convsRes = await SELF.fetch(
+        `http://localhost/api/v1/projects/${project.id}/conversations`,
+      );
+      const convsBody = await convsRes.json<{ data: Conversation[] }>();
+      expect(convsBody.data).toEqual([]);
+    });
+
+    it("does not affect other projects", async () => {
+      const ts = Date.now();
+      const createResA = await createProject({ name: "Keep Me", slug: `keep-me-${ts}` });
+      const createResB = await createProject({ name: "Gone", slug: `gone-${ts}` });
+      expect(createResA.status).toBe(201);
+      expect(createResB.status).toBe(201);
+
+      const { project: projectA } = await createResA.json<{ project: Project }>();
+      const { project: projectB } = await createResB.json<{ project: Project }>();
+
+      // Delete project B
+      const deleteRes = await SELF.fetch(`http://localhost/api/v1/projects/${projectB.id}`, {
+        method: "DELETE",
+      });
+      expect(deleteRes.status).toBe(204);
+
+      // Project A must still exist
+      const getResA = await SELF.fetch(`http://localhost/api/v1/projects/${projectA.id}`);
+      expect(getResA.status).toBe(200);
+      const bodyA = await getResA.json<ProjectWithKeys>();
+      expect(bodyA.id).toBe(projectA.id);
+
+      // Project B must be gone
+      const getResB = await SELF.fetch(`http://localhost/api/v1/projects/${projectB.id}`);
+      expect(getResB.status).toBe(404);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // GET /:id/conversations/:convId/messages — List messages (dashboard)
   // -------------------------------------------------------------------------
 

--- a/packages/api/test/setup.ts
+++ b/packages/api/test/setup.ts
@@ -69,6 +69,15 @@ const DDL_STATEMENTS: string[] = [
   )`,
   `CREATE UNIQUE INDEX IF NOT EXISTS \`rate_limits_key_window_idx\` ON \`rate_limits\` (\`api_key_hash\`,\`window_start\`)`,
   `CREATE INDEX IF NOT EXISTS \`rate_limits_window_start_idx\` ON \`rate_limits\` (\`window_start\`)`,
+  `CREATE TABLE IF NOT EXISTS \`conversation_tags\` (
+    \`id\` text PRIMARY KEY NOT NULL,
+    \`conversation_id\` text NOT NULL,
+    \`tag\` text NOT NULL,
+    \`created_at\` integer NOT NULL,
+    FOREIGN KEY (\`conversation_id\`) REFERENCES \`conversations\`(\`id\`) ON UPDATE no action ON DELETE no action
+  )`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS \`conversation_tags_conversation_id_tag_idx\` ON \`conversation_tags\` (\`conversation_id\`,\`tag\`)`,
+  `CREATE INDEX IF NOT EXISTS \`conversation_tags_tag_idx\` ON \`conversation_tags\` (\`tag\`)`,
 ];
 
 // Fixed seed data for deterministic tests


### PR DESCRIPTION
## Summary

- Adds `DELETE /v1/projects/:id` endpoint that removes a project and all its child data in a single atomic batched operation
- Cascade order: conversation tags → messages → conversations → API keys → project
- Returns 204 No Content on success, 404 if project not found
- Adds `conversation_tags` DDL to test setup so all tests have the full schema

## Test plan

- [ ] `DELETE /api/v1/projects/:id` returns 204 for a valid project
- [ ] Returns 404 for a non-existent project ID
- [ ] Cascades deletion to conversations, messages, and API keys (verified via conversations listing returning empty and project GET returning 404)
- [ ] Does not affect sibling projects (isolation test)
- [ ] All 111 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project deletion now automatically removes all associated conversations, messages, and API keys to ensure complete data cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->