### PR TITLE
feat(dashboard): replace hero with data flow visualization

### DIFF
--- a/packages/dashboard/src/app/globals.css
+++ b/packages/dashboard/src/app/globals.css
@@ -196,3 +196,45 @@
 .animate-draw-line {
   animation: draw-line 2s ease-out both;
 }
+
+/* Node scale pulse */
+@keyframes node-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.02);
+  }
+}
+
+/* Cursor blink for code snippets */
+@keyframes blink-cursor {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}
+
+.animate-node-pulse {
+  animation: node-pulse 4s ease-in-out infinite;
+}
+
+.animate-blink-cursor {
+  animation: blink-cursor 1s step-end infinite;
+}
+
+/* Accessibility: disable animations for reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .animate-float,
+  .animate-float-delayed,
+  .animate-float-slow,
+  .animate-node-pulse,
+  .animate-pulse-soft,
+  .animate-draw-line {
+    animation: none;
+  }
+}

--- a/packages/dashboard/src/components/landing/hero-illustration.tsx
+++ b/packages/dashboard/src/components/landing/hero-illustration.tsx
@@ -1,72 +1,173 @@
 "use client";
 
+const ACCENT = "#22c55e";
+const PATH_AGENT_TO_DB = "M210 200 Q275 160 340 200";
+const PATH_DB_TO_HISTORY = "M460 200 Q525 240 590 200";
+
 export function HeroIllustration() {
   return (
     <div className="absolute inset-0 overflow-hidden pointer-events-none" aria-hidden="true">
-      {/* Large circle — top right */}
       <svg
         role="presentation"
-        className="absolute -top-12 -right-16 w-64 h-64 opacity-[0.07] animate-float"
-        viewBox="0 0 200 200"
-      >
-        <circle cx="100" cy="100" r="90" fill="currentColor" />
-      </svg>
-
-      {/* Small circle — left */}
-      <svg
-        role="presentation"
-        className="absolute top-1/3 -left-8 w-24 h-24 opacity-[0.06] animate-float-delayed"
-        viewBox="0 0 100 100"
-      >
-        <circle cx="50" cy="50" r="40" fill="currentColor" />
-      </svg>
-
-      {/* Rounded rect — bottom right */}
-      <svg
-        role="presentation"
-        className="absolute bottom-8 right-12 w-40 h-28 opacity-[0.05] animate-float-slow"
-        viewBox="0 0 160 112"
-      >
-        <rect x="10" y="10" width="140" height="92" rx="20" fill="currentColor" />
-      </svg>
-
-      {/* Connection line — dashed path from top-left to center */}
-      <svg
-        role="presentation"
-        className="absolute top-16 left-1/4 w-48 h-48 opacity-[0.08]"
-        viewBox="0 0 200 200"
+        className="absolute inset-0 w-full h-full opacity-[0.08]"
+        viewBox="0 0 800 400"
         fill="none"
+        preserveAspectRatio="xMidYMid slice"
       >
+        {/* Background grid */}
+        <g opacity="0.03" stroke="currentColor" strokeWidth="1" strokeDasharray="4 6">
+          <line x1="80" y1="0" x2="80" y2="400" />
+          <line x1="160" y1="0" x2="160" y2="400" />
+          <line x1="240" y1="0" x2="240" y2="400" />
+          <line x1="320" y1="0" x2="320" y2="400" />
+          <line x1="400" y1="0" x2="400" y2="400" />
+          <line x1="480" y1="0" x2="480" y2="400" />
+          <line x1="560" y1="0" x2="560" y2="400" />
+          <line x1="640" y1="0" x2="640" y2="400" />
+          <line x1="720" y1="0" x2="720" y2="400" />
+          <line x1="0" y1="80" x2="800" y2="80" />
+          <line x1="0" y1="160" x2="800" y2="160" />
+          <line x1="0" y1="240" x2="800" y2="240" />
+          <line x1="0" y1="320" x2="800" y2="320" />
+        </g>
+
+        {/* ── Agent node (left) ── */}
+        <g className="animate-node-pulse" style={{ transformOrigin: "150px 200px" }}>
+          <rect
+            x="90"
+            y="160"
+            width="120"
+            height="80"
+            rx="16"
+            stroke="currentColor"
+            strokeWidth="1.5"
+          />
+          <text
+            x="150"
+            y="207"
+            textAnchor="middle"
+            fill="currentColor"
+            fontFamily="monospace"
+            fontSize="14"
+          >
+            Agent
+          </text>
+          {/* Pulsing green dot */}
+          <circle cx="110" cy="180" r="4" fill={ACCENT} className="animate-pulse-soft" />
+        </g>
+
+        {/* ── AgentState database (center) ── */}
+        <g className="animate-node-pulse" style={{ transformOrigin: "400px 200px" }}>
+          {/* Cylinder body */}
+          <path
+            d="M340 170 L340 230 Q340 250 400 250 Q460 250 460 230 L460 170"
+            stroke="currentColor"
+            strokeWidth="1.5"
+          />
+          {/* Cylinder top ellipse */}
+          <ellipse cx="400" cy="170" rx="60" ry="20" stroke="currentColor" strokeWidth="1.5" />
+          {/* Cylinder bottom ellipse (hidden behind body) */}
+          <ellipse
+            cx="400"
+            cy="230"
+            rx="60"
+            ry="20"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeDasharray="4 3"
+            opacity="0.4"
+          />
+          <text
+            x="400"
+            y="215"
+            textAnchor="middle"
+            fill="currentColor"
+            fontFamily="monospace"
+            fontSize="12"
+          >
+            AgentState
+          </text>
+          {/* Center green dot */}
+          <circle cx="400" cy="190" r="3" fill={ACCENT} className="animate-pulse-soft" />
+        </g>
+
+        {/* ── History node (right) ── */}
+        <g className="animate-node-pulse" style={{ transformOrigin: "650px 200px" }}>
+          <rect
+            x="590"
+            y="160"
+            width="120"
+            height="80"
+            rx="16"
+            stroke="currentColor"
+            strokeWidth="1.5"
+          />
+          <text
+            x="650"
+            y="195"
+            textAnchor="middle"
+            fill="currentColor"
+            fontFamily="monospace"
+            fontSize="14"
+          >
+            History
+          </text>
+          {/* Chat bubble shapes inside */}
+          <rect
+            x="615"
+            y="206"
+            width="30"
+            height="10"
+            rx="4"
+            stroke="currentColor"
+            strokeWidth="1"
+            opacity="0.5"
+          />
+          <rect
+            x="650"
+            y="218"
+            width="36"
+            height="10"
+            rx="4"
+            stroke="currentColor"
+            strokeWidth="1"
+            opacity="0.5"
+          />
+        </g>
+
+        {/* ── Connecting path: Agent → AgentState ── */}
         <path
-          d="M10 180 Q 60 60, 180 30"
+          d={PATH_AGENT_TO_DB}
           stroke="currentColor"
-          strokeWidth="2"
+          strokeWidth="1.5"
           strokeDasharray="6 4"
           className="animate-draw-line"
         />
-        <circle cx="180" cy="30" r="5" fill="currentColor" className="animate-pulse-soft" />
-      </svg>
 
-      {/* Small dots cluster — mid right */}
-      <svg
-        role="presentation"
-        className="absolute top-1/2 right-1/4 w-32 h-32 opacity-[0.06] animate-float-delayed"
-        viewBox="0 0 100 100"
-      >
-        <circle cx="20" cy="30" r="4" fill="currentColor" />
-        <circle cx="50" cy="15" r="3" fill="currentColor" />
-        <circle cx="75" cy="45" r="5" fill="currentColor" />
-        <circle cx="40" cy="70" r="3.5" fill="currentColor" />
-        <circle cx="80" cy="80" r="4" fill="currentColor" />
-      </svg>
+        {/* ── Connecting path: AgentState → History ── */}
+        <path
+          d={PATH_DB_TO_HISTORY}
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeDasharray="6 4"
+          className="animate-draw-line"
+        />
 
-      {/* Rounded rect — top center */}
-      <svg
-        role="presentation"
-        className="absolute -top-4 left-1/2 w-20 h-20 opacity-[0.04] animate-float-slow"
-        viewBox="0 0 80 80"
-      >
-        <rect x="10" y="10" width="60" height="60" rx="14" fill="currentColor" />
+        {/* ── Data packets: Agent → AgentState ── */}
+        <circle r="3" fill={ACCENT} opacity="0.6">
+          <animateMotion dur="3s" repeatCount="indefinite" path={PATH_AGENT_TO_DB} />
+        </circle>
+        <circle r="3" fill={ACCENT} opacity="0.4">
+          <animateMotion dur="3s" repeatCount="indefinite" path={PATH_AGENT_TO_DB} begin="1.5s" />
+        </circle>
+
+        {/* ── Data packets: AgentState → History ── */}
+        <circle r="3" fill={ACCENT} opacity="0.6">
+          <animateMotion dur="3s" repeatCount="indefinite" path={PATH_DB_TO_HISTORY} begin="0.5s" />
+        </circle>
+        <circle r="3" fill={ACCENT} opacity="0.4">
+          <animateMotion dur="3s" repeatCount="indefinite" path={PATH_DB_TO_HISTORY} begin="2s" />
+        </circle>
       </svg>
     </div>
   );


### PR DESCRIPTION
## Summary
- Replace abstract floating shapes in hero illustration with a purposeful data flow visualization showing Agent -> AgentState -> History pipeline
- Add animated SVG with database cylinder, rounded rectangle nodes, curved dashed connecting paths, and green data packets using native `<animateMotion>`
- Add `node-pulse` and `blink-cursor` CSS keyframe animations with `prefers-reduced-motion` accessibility support
- Extract repeated path strings and accent color into constants for DRY compliance

## Test plan
- [x] Biome lint passes clean
- [x] TypeScript type check passes (`bunx tsc --noEmit`)
- [x] Dashboard builds successfully (`bun run build`)
- [x] All 111 API tests pass (`bunx vitest run`)
- [ ] Visual verification: open landing page and confirm data flow animation renders as low-opacity background decoration

🤖 Generated with [Claude Code](https://claude.com/claude-code)