### PR TITLE
feat(dashboard): enhance architecture diagram to hub-and-spoke layout

### DIFF
--- a/packages/dashboard/src/components/landing/architecture-diagram.tsx
+++ b/packages/dashboard/src/components/landing/architecture-diagram.tsx
@@ -3,26 +3,56 @@
 const MONO_FONT = "var(--font-mono, monospace)";
 
 function ArchitectureSvg() {
-  // Node positions (centered in their columns)
-  const node1X = 40;
-  const node2X = 290;
-  const node3X = 540;
-  const nodeY = 40;
-  const nodeW = 180;
-  const nodeH = 100;
+  // Layout: hub-and-spoke centered on AgentState
+  // Hub: AgentState API in the center
+  // Spoke 1 (left):   Your Agent
+  // Spoke 2 (right):  D1 Database
+  // Spoke 3 (bottom): Workers AI
 
-  // Arrow path Y center
-  const arrowY = nodeY + nodeH / 2;
+  const viewW = 800;
+  const viewH = 300;
 
-  // Path start/end X positions
-  const path1Start = node1X + nodeW;
-  const path1End = node2X;
-  const path2Start = node2X + nodeW;
-  const path2End = node3X;
+  // Node dimensions
+  const nodeW = 160;
+  const nodeH = 90;
+
+  // Hub (center)
+  const hubX = (viewW - nodeW) / 2; // 320
+  const hubY = 40;
+  const hubCX = hubX + nodeW / 2; // center-X = 400
+  const hubCY = hubY + nodeH / 2; // center-Y = 85
+
+  // Left spoke: Your Agent (shares same Y as hub — all top-row nodes are aligned)
+  const leftX = 50;
+  const leftCX = leftX + nodeW / 2; // 130
+
+  // Right spoke: D1 Database
+  const rightX = viewW - 50 - nodeW; // 590
+  const rightCX = rightX + nodeW / 2; // 670
+
+  // Bottom spoke: Workers AI
+  const botX = (viewW - nodeW) / 2; // 320
+  const botY = 185;
+  const botCX = botX + nodeW / 2; // 400
+
+  // Connection path endpoints (edge of node boxes)
+  const leftToHubX1 = leftX + nodeW;
+  const leftToHubX2 = hubX;
+
+  const hubToRightX1 = hubX + nodeW;
+  const hubToRightX2 = rightX;
+
+  const hubToBottomY1 = hubY + nodeH;
+  const hubToBottomY2 = botY;
+
+  // Pre-computed bezier path strings (reused by both <path> and <animateMotion>)
+  const pathLeft = `M${leftToHubX1},${hubCY} C${leftToHubX1 + 30},${hubCY} ${leftToHubX2 - 30},${hubCY} ${leftToHubX2},${hubCY}`;
+  const pathRight = `M${hubToRightX1},${hubCY} C${hubToRightX1 + 30},${hubCY} ${hubToRightX2 - 30},${hubCY} ${hubToRightX2},${hubCY}`;
+  const pathBottom = `M${hubCX},${hubToBottomY1} C${hubCX},${hubToBottomY1 + 20} ${botCX},${hubToBottomY2 - 20} ${botCX},${hubToBottomY2}`;
 
   return (
     <svg
-      viewBox="0 0 800 220"
+      viewBox={`0 0 ${viewW} ${viewH}`}
       className="w-full"
       aria-hidden="true"
       role="presentation"
@@ -33,37 +63,44 @@ function ArchitectureSvg() {
           <path d="M0,0 L8,3 L0,6" fill="currentColor" opacity="0.4" />
         </marker>
 
-        {/* Pulse animation for AgentState border */}
+        {/* Subtle radial glow behind the hub */}
+        <radialGradient id="hubGlow" cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor="#22c55e" stopOpacity="0.12" />
+          <stop offset="100%" stopColor="#22c55e" stopOpacity="0" />
+        </radialGradient>
+
         <style>{`
           @keyframes border-pulse {
             0%, 100% { stroke-opacity: 0.6; }
             50% { stroke-opacity: 1; }
           }
-          .agent-border {
-            animation: border-pulse 2.5s ease-in-out infinite;
-          }
+          .agent-border { animation: border-pulse 2.5s ease-in-out infinite; }
         `}</style>
       </defs>
 
-      {/* === Connection paths === */}
+      {/* Hub glow ellipse */}
+      <ellipse
+        cx={hubCX}
+        cy={hubCY}
+        rx="120"
+        ry="70"
+        fill="url(#hubGlow)"
+      />
 
-      {/* Path 1: Your App -> AgentState */}
-      <line
-        x1={path1Start}
-        y1={arrowY}
-        x2={path1End}
-        y2={arrowY}
+      {/* ======= Connection paths ======= */}
+
+      {/* Left: Your Agent -> AgentState */}
+      <path
+        d={pathLeft}
         stroke="currentColor"
         strokeWidth="1.5"
         strokeDasharray="6 4"
         opacity="0.3"
         markerEnd="url(#arrowhead)"
       />
-
-      {/* Path 1 label */}
       <text
-        x={(path1Start + path1End) / 2}
-        y={arrowY - 12}
+        x={(leftToHubX1 + leftToHubX2) / 2}
+        y={hubCY - 14}
         textAnchor="middle"
         fill="currentColor"
         fontSize="10"
@@ -72,33 +109,22 @@ function ArchitectureSvg() {
       >
         REST API
       </text>
-
-      {/* Path 1 animated dot */}
-      <circle r="2.5" fill="#22c55e" opacity="0.5">
-        <animateMotion
-          dur="2.5s"
-          repeatCount="indefinite"
-          path={`M${path1Start},${arrowY} L${path1End},${arrowY}`}
-        />
+      <circle r="2.5" fill="#22c55e" opacity="0.8">
+        <animateMotion dur="2.4s" repeatCount="indefinite" path={pathLeft} />
       </circle>
 
-      {/* Path 2: AgentState -> D1 */}
-      <line
-        x1={path2Start}
-        y1={arrowY}
-        x2={path2End}
-        y2={arrowY}
+      {/* Right: AgentState -> D1 */}
+      <path
+        d={pathRight}
         stroke="currentColor"
         strokeWidth="1.5"
         strokeDasharray="6 4"
         opacity="0.3"
         markerEnd="url(#arrowhead)"
       />
-
-      {/* Path 2 label */}
       <text
-        x={(path2Start + path2End) / 2}
-        y={arrowY - 12}
+        x={(hubToRightX1 + hubToRightX2) / 2}
+        y={hubCY - 14}
         textAnchor="middle"
         fill="currentColor"
         fontSize="10"
@@ -107,21 +133,38 @@ function ArchitectureSvg() {
       >
         Drizzle ORM
       </text>
-
-      {/* Path 2 animated dot (delayed) */}
-      <circle r="2.5" fill="#22c55e" opacity="0.5">
-        <animateMotion
-          dur="2.5s"
-          repeatCount="indefinite"
-          begin="1.2s"
-          path={`M${path2Start},${arrowY} L${path2End},${arrowY}`}
-        />
+      <circle r="2.5" fill="#22c55e" opacity="0.8">
+        <animateMotion dur="2.4s" repeatCount="indefinite" begin="1.2s" path={pathRight} />
       </circle>
 
-      {/* === Node 1: Your App === */}
+      {/* Bottom: AgentState -> Workers AI */}
+      <path
+        d={pathBottom}
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeDasharray="6 4"
+        opacity="0.3"
+        markerEnd="url(#arrowhead)"
+      />
+      <text
+        x={hubCX + 28}
+        y={(hubToBottomY1 + hubToBottomY2) / 2 + 4}
+        textAnchor="start"
+        fill="currentColor"
+        fontSize="10"
+        opacity="0.5"
+        style={{ fontFamily: MONO_FONT }}
+      >
+        Workers AI
+      </text>
+      <circle r="2.5" fill="#22c55e" opacity="0.8">
+        <animateMotion dur="2.4s" repeatCount="indefinite" begin="0.6s" path={pathBottom} />
+      </circle>
+
+      {/* ======= Node 1: Your Agent (left) ======= */}
       <rect
-        x={node1X}
-        y={nodeY}
+        x={leftX}
+        y={hubY}
         width={nodeW}
         height={nodeH}
         rx="8"
@@ -130,32 +173,28 @@ function ArchitectureSvg() {
         opacity="0.4"
       />
 
-      {/* Browser icon */}
-      <g transform={`translate(${node1X + nodeW / 2 - 14}, ${nodeY + 18})`} opacity="0.6">
-        <rect x="0" y="0" width="28" height="20" rx="3" stroke="currentColor" strokeWidth="1.2" />
-        <line x1="0" y1="6" x2="28" y2="6" stroke="currentColor" strokeWidth="1" />
-        <circle cx="4" cy="3" r="1" fill="currentColor" />
-        <circle cx="8" cy="3" r="1" fill="currentColor" />
-        <circle cx="12" cy="3" r="1" fill="currentColor" />
+      {/* Terminal/agent icon */}
+      <g transform={`translate(${leftCX - 11}, ${hubY + 14})`} opacity="0.6">
+        <rect x="0" y="0" width="22" height="16" rx="3" stroke="currentColor" strokeWidth="1.2" />
+        <polyline points="4,5 8,8 4,11" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+        <line x1="10" y1="11" x2="16" y2="11" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
       </g>
 
-      {/* Node 1 label */}
       <text
-        x={node1X + nodeW / 2}
-        y={nodeY + 60}
+        x={leftCX}
+        y={hubY + 52}
         textAnchor="middle"
         fill="currentColor"
         fontSize="13"
         fontWeight="500"
         style={{ fontFamily: MONO_FONT }}
       >
-        Your App
+        Your Agent
       </text>
 
-      {/* Node 1 sublabel */}
       <text
-        x={node1X + nodeW / 2}
-        y={nodeY + nodeH + 22}
+        x={leftCX}
+        y={hubY + nodeH + 20}
         textAnchor="middle"
         fill="currentColor"
         fontSize="11"
@@ -164,10 +203,10 @@ function ArchitectureSvg() {
         Any HTTP client
       </text>
 
-      {/* === Node 2: AgentState API === */}
+      {/* ======= Node 2: AgentState API (hub, center) ======= */}
       <rect
-        x={node2X}
-        y={nodeY}
+        x={hubX}
+        y={hubY}
         width={nodeW}
         height={nodeH}
         rx="8"
@@ -177,7 +216,7 @@ function ArchitectureSvg() {
       />
 
       {/* AgentState logo icon */}
-      <g transform={`translate(${node2X + nodeW / 2 - 12}, ${nodeY + 14})`} opacity="0.7">
+      <g transform={`translate(${hubCX - 12}, ${hubY + 12})`} opacity="0.8">
         <rect x="0" y="0" width="24" height="24" rx="5" fill="currentColor" />
         <g stroke="white" strokeWidth="1.5" strokeLinecap="round">
           <line x1="6" y1="8" x2="14" y2="8" />
@@ -187,10 +226,9 @@ function ArchitectureSvg() {
         <circle cx="18" cy="16" r="1.5" fill="#22c55e" />
       </g>
 
-      {/* Node 2 label */}
       <text
-        x={node2X + nodeW / 2}
-        y={nodeY + 60}
+        x={hubCX}
+        y={hubY + 54}
         textAnchor="middle"
         fill="currentColor"
         fontSize="13"
@@ -200,10 +238,9 @@ function ArchitectureSvg() {
         AgentState
       </text>
 
-      {/* Node 2 sublabel */}
       <text
-        x={node2X + nodeW / 2}
-        y={nodeY + nodeH + 22}
+        x={hubCX}
+        y={hubY + nodeH + 20}
         textAnchor="middle"
         fill="currentColor"
         fontSize="11"
@@ -212,10 +249,80 @@ function ArchitectureSvg() {
         Hono on Workers
       </text>
 
-      {/* === Node 3: D1 Database === */}
+      {/* Feature badges below hub sublabel */}
+      {/* Badge: Conversations */}
       <rect
-        x={node3X}
-        y={nodeY}
+        x={hubCX - 118}
+        y={hubY + nodeH + 32}
+        width="76"
+        height="16"
+        rx="4"
+        stroke="#22c55e"
+        strokeWidth="1"
+        opacity="0.35"
+      />
+      <text
+        x={hubCX - 80}
+        y={hubY + nodeH + 43}
+        textAnchor="middle"
+        fill="#22c55e"
+        fontSize="9"
+        opacity="0.7"
+        style={{ fontFamily: MONO_FONT }}
+      >
+        Conversations
+      </text>
+
+      {/* Badge: Token tracking */}
+      <rect
+        x={hubCX - 36}
+        y={hubY + nodeH + 32}
+        width="72"
+        height="16"
+        rx="4"
+        stroke="#22c55e"
+        strokeWidth="1"
+        opacity="0.35"
+      />
+      <text
+        x={hubCX}
+        y={hubY + nodeH + 43}
+        textAnchor="middle"
+        fill="#22c55e"
+        fontSize="9"
+        opacity="0.7"
+        style={{ fontFamily: MONO_FONT }}
+      >
+        Token tracking
+      </text>
+
+      {/* Badge: AI titles */}
+      <rect
+        x={hubCX + 42}
+        y={hubY + nodeH + 32}
+        width="76"
+        height="16"
+        rx="4"
+        stroke="#22c55e"
+        strokeWidth="1"
+        opacity="0.35"
+      />
+      <text
+        x={hubCX + 80}
+        y={hubY + nodeH + 43}
+        textAnchor="middle"
+        fill="#22c55e"
+        fontSize="9"
+        opacity="0.7"
+        style={{ fontFamily: MONO_FONT }}
+      >
+        AI titles
+      </text>
+
+      {/* ======= Node 3: D1 Database (right) ======= */}
+      <rect
+        x={rightX}
+        y={hubY}
         width={nodeW}
         height={nodeH}
         rx="8"
@@ -225,7 +332,7 @@ function ArchitectureSvg() {
       />
 
       {/* Database cylinder icon */}
-      <g transform={`translate(${node3X + nodeW / 2 - 10}, ${nodeY + 14})`} opacity="0.6">
+      <g transform={`translate(${rightCX - 10}, ${hubY + 13})`} opacity="0.6">
         <ellipse cx="10" cy="4" rx="10" ry="4" stroke="currentColor" strokeWidth="1.2" />
         <path d="M0 4v14c0 2.2 4.5 4 10 4s10-1.8 10-4V4" stroke="currentColor" strokeWidth="1.2" />
         <path
@@ -236,10 +343,9 @@ function ArchitectureSvg() {
         />
       </g>
 
-      {/* Node 3 label */}
       <text
-        x={node3X + nodeW / 2}
-        y={nodeY + 64}
+        x={rightCX}
+        y={hubY + 54}
         textAnchor="middle"
         fill="currentColor"
         fontSize="13"
@@ -249,16 +355,60 @@ function ArchitectureSvg() {
         D1 Database
       </text>
 
-      {/* Node 3 sublabel */}
       <text
-        x={node3X + nodeW / 2}
-        y={nodeY + nodeH + 22}
+        x={rightCX}
+        y={hubY + nodeH + 20}
         textAnchor="middle"
         fill="currentColor"
         fontSize="11"
         opacity="0.4"
       >
         SQLite at edge
+      </text>
+
+      {/* ======= Node 4: Workers AI (bottom) ======= */}
+      <rect
+        x={botX}
+        y={botY}
+        width={nodeW}
+        height={nodeH}
+        rx="8"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        opacity="0.4"
+      />
+
+      {/* Sparkle / AI icon */}
+      <g transform={`translate(${botCX - 11}, ${botY + 13})`} opacity="0.6">
+        {/* Simple star/sparkle shape */}
+        <line x1="11" y1="0" x2="11" y2="22" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+        <line x1="0" y1="11" x2="22" y2="11" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+        <line x1="3" y1="3" x2="19" y2="19" stroke="currentColor" strokeWidth="1" strokeLinecap="round" opacity="0.6" />
+        <line x1="19" y1="3" x2="3" y2="19" stroke="currentColor" strokeWidth="1" strokeLinecap="round" opacity="0.6" />
+        <circle cx="11" cy="11" r="3.5" stroke="currentColor" strokeWidth="1.2" />
+      </g>
+
+      <text
+        x={botCX}
+        y={botY + 54}
+        textAnchor="middle"
+        fill="currentColor"
+        fontSize="13"
+        fontWeight="500"
+        style={{ fontFamily: MONO_FONT }}
+      >
+        Workers AI
+      </text>
+
+      <text
+        x={botCX}
+        y={botY + nodeH + 20}
+        textAnchor="middle"
+        fill="currentColor"
+        fontSize="11"
+        opacity="0.4"
+      >
+        Title generation
       </text>
     </svg>
   );
@@ -272,13 +422,21 @@ export function ArchitectureDiagram() {
     >
       <h2 className="text-lg font-medium mb-5">Architecture</h2>
 
-      {/* Mobile: simplified text */}
-      <div className="md:hidden text-sm text-muted-foreground font-mono flex items-center gap-2 flex-wrap">
-        <span>Your App</span>
-        <span className="text-muted-foreground/40">&rarr;</span>
-        <span>AgentState API</span>
-        <span className="text-muted-foreground/40">&rarr;</span>
-        <span>D1 Database</span>
+      {/* Mobile: vertical stack with more detail */}
+      <div className="md:hidden text-sm font-mono text-muted-foreground space-y-1">
+        <div>Your Agent</div>
+        <div className="text-muted-foreground/40 pl-2">↓ REST API</div>
+        <div className="font-medium text-foreground">AgentState API</div>
+        <div className="pl-2 flex gap-6">
+          <span>
+            <span className="text-muted-foreground/40">↓ Drizzle ORM</span>
+            <div>D1 Database</div>
+          </span>
+          <span>
+            <span className="text-muted-foreground/40">↓ Workers AI</span>
+            <div>AI Features</div>
+          </span>
+        </div>
       </div>
 
       {/* Desktop: full SVG diagram */}


### PR DESCRIPTION
## Summary

- Expands the landing page architecture diagram from a simple 3-node linear flow to a 4-node hub-and-spoke layout centered on the AgentState API hub
- Adds a **Workers AI** node (bottom spoke) to surface AI features (title generation, follow-up suggestions)
- Replaces straight lines with curved bezier paths, adds a radial glow behind the hub, and staggers 3 animated dots across all connection paths
- Adds feature badge annotations beneath the hub: `Conversations`, `Token tracking`, `AI titles`
- Improves mobile fallback from a flat arrow chain to a branching vertical stack showing all 4 nodes

## Changes

- `packages/dashboard/src/components/landing/architecture-diagram.tsx` — full redesign; viewBox expanded from `800x220` to `800x300`

## Test plan

- [x] `bunx tsc --noEmit -p packages/dashboard/tsconfig.json` — passes with zero errors
- [x] Biome formatting auto-fixed and committed
- [ ] Visual inspection at `http://localhost:3000` (desktop + mobile viewport)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned architecture diagram with a hub-and-spoke layout centered on AgentState
  * Added visual enhancements including glow effects and animated curved connection paths
  * Introduced feature badges highlighting key capabilities (Conversations, Token tracking, AI titles)
  * Updated mobile view with a detailed vertical stack layout showing all system components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->