### PR TITLE
feat(api): add GET /:id/analytics endpoint for per-conversation metrics

### DIFF
--- a/packages/api/src/routes/conversations/analytics.ts
+++ b/packages/api/src/routes/conversations/analytics.ts
@@ -1,0 +1,57 @@
+import { eq, sql } from "drizzle-orm";
+import { Hono } from "hono";
+import { conversationTags, messages } from "../../db/schema";
+import { loadConversation, notFound } from "../../lib/helpers";
+import type { Bindings, Variables } from "../../types";
+
+const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+// ---------------------------------------------------------------------------
+// GET /:id/analytics — Per-conversation analytics
+// ---------------------------------------------------------------------------
+
+router.get("/:id/analytics", async (c) => {
+  const id = c.req.param("id");
+  const conversation = await loadConversation(c, id);
+  if (!conversation) return notFound(c);
+
+  const db = c.get("db");
+
+  // Aggregate messages by role and fetch tags in parallel — both are
+  // independent reads that only require the conversation to exist.
+  const [roleStats, tagRows] = await Promise.all([
+    db
+      .select({
+        role: messages.role,
+        count: sql<number>`COUNT(*)`,
+        tokens: sql<number>`COALESCE(SUM(${messages.tokenCount}), 0)`,
+      })
+      .from(messages)
+      .where(eq(messages.conversationId, id))
+      .groupBy(messages.role),
+    db
+      .select({ tag: conversationTags.tag })
+      .from(conversationTags)
+      .where(eq(conversationTags.conversationId, id)),
+  ]);
+
+  // Build messages_by_role map
+  const messagesByRole: Record<string, { count: number; tokens: number }> = {};
+  for (const row of roleStats) {
+    messagesByRole[row.role] = { count: Number(row.count), tokens: Number(row.tokens) };
+  }
+
+  return c.json({
+    conversation_id: conversation.id,
+    title: conversation.title,
+    message_count: conversation.messageCount,
+    token_count: conversation.tokenCount,
+    tags: tagRows.map((t) => t.tag),
+    duration_ms: conversation.updatedAt - conversation.createdAt,
+    messages_by_role: messagesByRole,
+    created_at: conversation.createdAt,
+    updated_at: conversation.updatedAt,
+  });
+});
+
+export default router;

--- a/packages/api/src/routes/conversations/index.ts
+++ b/packages/api/src/routes/conversations/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { apiKeyAuth } from "../../middleware/auth";
 import { rateLimitMiddleware } from "../../middleware/rate-limit";
 import type { Bindings, Variables } from "../../types";
+import analyticsRouter from "./analytics";
 import bulkRouter from "./bulk";
 import crudRouter from "./crud";
 import messagesRouter from "./messages";
@@ -16,6 +17,7 @@ router.use("*", rateLimitMiddleware);
 // Mount sub-routers — order matters: specific paths before parameterized ones
 router.route("/", searchRouter);
 router.route("/", bulkRouter);
+router.route("/", analyticsRouter);
 router.route("/", messagesRouter);
 router.route("/", crudRouter);
 

--- a/packages/api/test/analytics.test.ts
+++ b/packages/api/test/analytics.test.ts
@@ -150,4 +150,111 @@ describe("Analytics", () => {
       expect(body.summary.active_api_keys).toBeGreaterThanOrEqual(1);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // GET /v1/conversations/:id/analytics
+  // -------------------------------------------------------------------------
+
+  interface ConversationAnalyticsResponse {
+    conversation_id: string;
+    title: string | null;
+    message_count: number;
+    token_count: number;
+    tags: string[];
+    duration_ms: number;
+    messages_by_role: Record<string, { count: number; tokens: number }>;
+    created_at: number;
+    updated_at: number;
+  }
+
+  describe("GET /v1/conversations/:id/analytics", () => {
+    it("returns the correct response shape for a conversation with messages", async () => {
+      const createRes = await createConversation({
+        title: "Conv Analytics Test",
+        messages: [
+          { role: "user", content: "Hello", token_count: 5 },
+          { role: "assistant", content: "Hi there!", token_count: 10 },
+          { role: "user", content: "How are you?", token_count: 4 },
+        ],
+      });
+      expect(createRes.status).toBe(201);
+      const created = await createRes.json<{ id: string }>();
+
+      const res = await SELF.fetch(
+        `http://localhost/v1/conversations/${created.id}/analytics`,
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<ConversationAnalyticsResponse>();
+      expect(body.conversation_id).toBe(created.id);
+      expect(body.title).toBe("Conv Analytics Test");
+      expect(body.message_count).toBe(3);
+      expect(body.token_count).toBe(19);
+      expect(Array.isArray(body.tags)).toBe(true);
+      expect(typeof body.duration_ms).toBe("number");
+      expect(body.duration_ms).toBeGreaterThanOrEqual(0);
+      expect(typeof body.messages_by_role).toBe("object");
+      expect(typeof body.created_at).toBe("number");
+      expect(typeof body.updated_at).toBe("number");
+    });
+
+    it("breaks down messages_by_role correctly", async () => {
+      const createRes = await createConversation({
+        title: "Role Breakdown",
+        messages: [
+          { role: "system", content: "You are a helpful assistant.", token_count: 8 },
+          { role: "user", content: "Hi", token_count: 3 },
+          { role: "assistant", content: "Hello!", token_count: 6 },
+          { role: "user", content: "Thanks", token_count: 2 },
+          { role: "assistant", content: "You're welcome!", token_count: 5 },
+        ],
+      });
+      const created = await createRes.json<{ id: string }>();
+
+      const res = await SELF.fetch(
+        `http://localhost/v1/conversations/${created.id}/analytics`,
+        { headers: authHeaders() },
+      );
+      const body = await res.json<ConversationAnalyticsResponse>();
+
+      expect(body.messages_by_role.system).toEqual({ count: 1, tokens: 8 });
+      expect(body.messages_by_role.user).toEqual({ count: 2, tokens: 5 });
+      expect(body.messages_by_role.assistant).toEqual({ count: 2, tokens: 11 });
+    });
+
+    it("returns empty messages_by_role for a conversation with no messages", async () => {
+      const createRes = await createConversation({ title: "Empty Conv" });
+      const created = await createRes.json<{ id: string }>();
+
+      const res = await SELF.fetch(
+        `http://localhost/v1/conversations/${created.id}/analytics`,
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<ConversationAnalyticsResponse>();
+      expect(body.message_count).toBe(0);
+      expect(body.token_count).toBe(0);
+      expect(Object.keys(body.messages_by_role).length).toBe(0);
+    });
+
+    it("returns 404 for a non-existent conversation", async () => {
+      const res = await SELF.fetch(
+        "http://localhost/v1/conversations/nonexistent_conv_id/analytics",
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(404);
+
+      const body = await res.json<{ error: { code: string } }>();
+      expect(body.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns 401 without auth", async () => {
+      const res = await SELF.fetch(
+        "http://localhost/v1/conversations/any_id/analytics",
+      );
+      expect(res.status).toBe(401);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `GET /v1/conversations/:id/analytics` endpoint returning per-conversation metrics
- Response includes `message_count`, `token_count`, `tags`, `duration_ms`, `messages_by_role` (with per-role count and token breakdown), and timestamps
- Role stats and tag queries run in parallel via `Promise.all` for efficiency
- Uses existing `loadConversation` / `notFound` helpers (same pattern as all other sub-routers)

## Test plan

- [x] New tests in `test/analytics.test.ts` covering: correct response shape, role breakdown accuracy, empty conversation, 404 for missing conversation, 401 without auth
- [x] All 116 existing tests pass (`bun run vitest run`)
- [x] Biome lint passes with zero errors
- [x] TypeScript type-check passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conversation analytics endpoint providing message counts, token usage, role-based message breakdown, duration, and tags.

* **Tests**
  * Added comprehensive test coverage for the analytics endpoint, including response validation, error handling, and authentication checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->