### PR TITLE
feat(api): add public analytics endpoints and test suite

### DIFF
--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -85,6 +85,7 @@ export const conversations = sqliteTable(
   },
   (table) => [
     index("conversations_project_id_idx").on(table.projectId),
+    index("conversations_project_id_created_at_idx").on(table.projectId, table.createdAt),
     index("conversations_project_id_external_id_idx").on(table.projectId, table.externalId),
     index("conversations_project_id_updated_at_idx").on(table.projectId, table.updatedAt),
     // Partial unique constraint: unique(project_id, external_id) only when external_id is not null.

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -6,6 +6,7 @@ import { dbMiddleware } from "./middleware/db";
 import { requestIdMiddleware } from "./middleware/request-id";
 import aiRouter from "./routes/ai";
 import analyticsRouter from "./routes/analytics";
+import analyticsPublicRouter from "./routes/analytics-public";
 import conversationsRouter from "./routes/conversations";
 import keysRouter from "./routes/keys";
 import projectsRouter from "./routes/projects";
@@ -60,6 +61,9 @@ app.route("/v1/conversations", conversationsRouter);
 app.route("/v1/conversations", aiRouter);
 // Backward compat tags at /v1/*
 app.route("/v1", tagsRouter);
+// Public analytics at /v1/analytics and /api/v1/analytics
+app.route("/v1/analytics", analyticsPublicRouter);
+app.route("/api/v1/analytics", analyticsPublicRouter);
 
 // ---------------------------------------------------------------------------
 // Error handler

--- a/packages/api/src/routes/analytics-public.ts
+++ b/packages/api/src/routes/analytics-public.ts
@@ -1,0 +1,274 @@
+import { and, eq, gte, inArray, lte, sql } from "drizzle-orm";
+import { Hono } from "hono";
+import { conversations, conversationTags } from "../db/schema";
+import { apiKeyAuth } from "../middleware/auth";
+import { rateLimitMiddleware } from "../middleware/rate-limit";
+import type { Bindings, Variables } from "../types";
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+app.use("*", apiKeyAuth);
+app.use("*", rateLimitMiddleware);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Parse unix-ms timestamp from query string, returning undefined if absent or invalid. */
+function parseTimestamp(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+/** Default period: last 30 days. Returns [start, end]. */
+function defaultPeriod(): [number, number] {
+  const end = Date.now();
+  const start = end - 30 * 86_400_000;
+  return [start, end];
+}
+
+/**
+ * Build conditions array for filtering conversations by project, optional date
+ * range, and optional tag(s).  Returns both the WHERE conditions and the
+ * resolved [start, end] period so callers can echo it in the response.
+ */
+async function buildFilters(
+  db: Variables["db"],
+  projectId: string,
+  startParam: string | undefined,
+  endParam: string | undefined,
+  tags: string[] | undefined,
+): Promise<{
+  /** Final WHERE conditions, already including tag subquery filter when applicable. */
+  conditions: ReturnType<typeof and>[];
+  start: number;
+  end: number;
+  /** true when a tag filter was requested but no conversations matched — skip the main query */
+  emptyResult: boolean;
+}> {
+  const [defaultStart, defaultEnd] = defaultPeriod();
+  const start = parseTimestamp(startParam) ?? defaultStart;
+  const end = parseTimestamp(endParam) ?? defaultEnd;
+
+  const baseConditions: ReturnType<typeof and>[] = [
+    eq(conversations.projectId, projectId),
+    gte(conversations.createdAt, start),
+    lte(conversations.createdAt, end),
+  ];
+
+  if (tags && tags.length > 0) {
+    // Find conversation_ids that have ALL specified tags
+    const rows = await db
+      .select({ conversationId: conversationTags.conversationId })
+      .from(conversationTags)
+      .where(inArray(conversationTags.tag, tags))
+      .groupBy(conversationTags.conversationId)
+      .having(sql`COUNT(DISTINCT ${conversationTags.tag}) = ${tags.length}`);
+
+    if (rows.length === 0) {
+      return { conditions: baseConditions, start, end, emptyResult: true };
+    }
+
+    return {
+      conditions: [
+        ...baseConditions,
+        inArray(
+          conversations.id,
+          rows.map((r) => r.conversationId),
+        ),
+      ],
+      start,
+      end,
+      emptyResult: false,
+    };
+  }
+
+  return { conditions: baseConditions, start, end, emptyResult: false };
+}
+
+// ---------------------------------------------------------------------------
+// GET /summary
+// ---------------------------------------------------------------------------
+
+app.get("/summary", async (c) => {
+  const db = c.get("db");
+  const projectId = c.get("projectId");
+
+  const tags = c.req.queries("tag");
+  const { conditions, start, end, emptyResult } = await buildFilters(
+    db,
+    projectId,
+    c.req.query("start"),
+    c.req.query("end"),
+    tags,
+  );
+
+  // When tag filter is active and no conversations matched, short-circuit with zeros
+  if (emptyResult) {
+    return c.json({
+      total_conversations: 0,
+      total_messages: 0,
+      total_tokens: 0,
+      avg_messages_per_conversation: 0,
+      avg_tokens_per_conversation: 0,
+      period: { start, end },
+    });
+  }
+
+  const [row] = await db
+    .select({
+      total_conversations: sql<number>`COUNT(*)`,
+      total_messages: sql<number>`COALESCE(SUM(${conversations.messageCount}), 0)`,
+      total_tokens: sql<number>`COALESCE(SUM(${conversations.tokenCount}), 0)`,
+    })
+    .from(conversations)
+    .where(and(...conditions));
+
+  const totalConvs = row?.total_conversations ?? 0;
+  const totalMsgs = row?.total_messages ?? 0;
+  const totalTokens = row?.total_tokens ?? 0;
+
+  return c.json({
+    total_conversations: totalConvs,
+    total_messages: totalMsgs,
+    total_tokens: totalTokens,
+    avg_messages_per_conversation:
+      totalConvs > 0 ? Math.round((totalMsgs / totalConvs) * 10) / 10 : 0,
+    avg_tokens_per_conversation:
+      totalConvs > 0 ? Math.round((totalTokens / totalConvs) * 10) / 10 : 0,
+    period: { start, end },
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /timeseries
+// ---------------------------------------------------------------------------
+
+const VALID_METRICS = ["conversations", "messages", "tokens"] as const;
+const VALID_GRANULARITIES = ["day", "week", "month"] as const;
+
+type Metric = (typeof VALID_METRICS)[number];
+type Granularity = (typeof VALID_GRANULARITIES)[number];
+
+function bucketExpression(granularity: Granularity): ReturnType<typeof sql> {
+  switch (granularity) {
+    case "day":
+      return sql<string>`date(${conversations.createdAt} / 1000, 'unixepoch')`;
+    case "week":
+      return sql<string>`strftime('%Y-W%W', ${conversations.createdAt} / 1000, 'unixepoch')`;
+    case "month":
+      return sql<string>`strftime('%Y-%m', ${conversations.createdAt} / 1000, 'unixepoch')`;
+  }
+}
+
+app.get("/timeseries", async (c) => {
+  const db = c.get("db");
+  const projectId = c.get("projectId");
+
+  const metricParam = c.req.query("metric") ?? "conversations";
+  const granularityParam = c.req.query("granularity") ?? "day";
+
+  const metric: Metric = VALID_METRICS.includes(metricParam as Metric)
+    ? (metricParam as Metric)
+    : "conversations";
+  const granularity: Granularity = VALID_GRANULARITIES.includes(granularityParam as Granularity)
+    ? (granularityParam as Granularity)
+    : "day";
+
+  const tags = c.req.queries("tag");
+  const { conditions, start, end, emptyResult } = await buildFilters(
+    db,
+    projectId,
+    c.req.query("start"),
+    c.req.query("end"),
+    tags,
+  );
+
+  if (emptyResult) {
+    return c.json({ metric, granularity, period: { start, end }, data: [] });
+  }
+
+  const bucket = bucketExpression(granularity);
+
+  let valueExpr: ReturnType<typeof sql>;
+  switch (metric) {
+    case "conversations":
+      valueExpr = sql<number>`COUNT(*)`;
+      break;
+    case "messages":
+      valueExpr = sql<number>`COALESCE(SUM(${conversations.messageCount}), 0)`;
+      break;
+    case "tokens":
+      valueExpr = sql<number>`COALESCE(SUM(${conversations.tokenCount}), 0)`;
+      break;
+  }
+
+  const rows = await db
+    .select({
+      bucket: bucket.as("bucket"),
+      value: valueExpr.as("value"),
+    })
+    .from(conversations)
+    .where(and(...conditions))
+    .groupBy(sql`bucket`)
+    .orderBy(sql`bucket`);
+
+  return c.json({
+    metric,
+    granularity,
+    period: { start, end },
+    data: rows,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /tags
+// ---------------------------------------------------------------------------
+
+app.get("/tags", async (c) => {
+  const db = c.get("db");
+  const projectId = c.get("projectId");
+
+  const [defaultStart, defaultEnd] = defaultPeriod();
+  const start = parseTimestamp(c.req.query("start")) ?? defaultStart;
+  const end = parseTimestamp(c.req.query("end")) ?? defaultEnd;
+
+  const limitRaw = parseInt(c.req.query("limit") ?? "50", 10);
+  const limit = Number.isNaN(limitRaw) || limitRaw < 1 ? 50 : Math.min(limitRaw, 200);
+
+  const rows = await db
+    .select({
+      tag: conversationTags.tag,
+      conversation_count: sql<number>`COUNT(DISTINCT ${conversationTags.conversationId})`.as(
+        "conversation_count",
+      ),
+      message_count: sql<number>`COALESCE(SUM(${conversations.messageCount}), 0)`.as(
+        "message_count",
+      ),
+      token_count: sql<number>`COALESCE(SUM(${conversations.tokenCount}), 0)`.as("token_count"),
+    })
+    .from(conversationTags)
+    .innerJoin(conversations, eq(conversations.id, conversationTags.conversationId))
+    .where(
+      and(
+        eq(conversations.projectId, projectId),
+        gte(conversations.createdAt, start),
+        lte(conversations.createdAt, end),
+      ),
+    )
+    .groupBy(conversationTags.tag)
+    .orderBy(sql`COUNT(DISTINCT ${conversationTags.conversationId}) DESC`)
+    .limit(limit);
+
+  return c.json({
+    period: { start, end },
+    data: rows,
+  });
+});
+
+export default app;

--- a/packages/api/src/routes/conversations/analytics.ts
+++ b/packages/api/src/routes/conversations/analytics.ts
@@ -1,0 +1,59 @@
+import { eq, sql } from "drizzle-orm";
+import { Hono } from "hono";
+import { conversationTags, messages } from "../../db/schema";
+import { loadConversation, notFound } from "../../lib/helpers";
+import type { Bindings, Variables } from "../../types";
+
+const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+// ---------------------------------------------------------------------------
+// GET /:id/analytics — Conversation-level analytics
+// ---------------------------------------------------------------------------
+
+app.get("/:id/analytics", async (c) => {
+  const id = c.req.param("id");
+  const db = c.get("db");
+
+  const conversation = await loadConversation(c, id);
+  if (!conversation) return notFound(c);
+
+  // Fetch tags and role breakdown in parallel — both are independent reads
+  const [tagRows, roleRows] = await Promise.all([
+    db
+      .select({ tag: conversationTags.tag })
+      .from(conversationTags)
+      .where(eq(conversationTags.conversationId, id)),
+    db
+      .select({
+        role: messages.role,
+        count: sql<number>`COUNT(*)`,
+        tokens: sql<number>`COALESCE(SUM(${messages.tokenCount}), 0)`,
+      })
+      .from(messages)
+      .where(eq(messages.conversationId, id))
+      .groupBy(messages.role),
+  ]);
+
+  const tags = tagRows.map((r) => r.tag);
+
+  const messagesByRole: Record<string, { count: number; tokens: number }> = Object.fromEntries(
+    roleRows.map((r) => [r.role, { count: r.count, tokens: r.tokens }]),
+  );
+
+  // Duration = updatedAt - createdAt (milliseconds)
+  const durationMs = conversation.updatedAt - conversation.createdAt;
+
+  return c.json({
+    conversation_id: conversation.id,
+    title: conversation.title,
+    message_count: conversation.messageCount,
+    token_count: conversation.tokenCount,
+    tags,
+    duration_ms: durationMs,
+    messages_by_role: messagesByRole,
+    created_at: conversation.createdAt,
+    updated_at: conversation.updatedAt,
+  });
+});
+
+export default app;

--- a/packages/api/src/routes/conversations/index.ts
+++ b/packages/api/src/routes/conversations/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { apiKeyAuth } from "../../middleware/auth";
 import { rateLimitMiddleware } from "../../middleware/rate-limit";
 import type { Bindings, Variables } from "../../types";
+import analyticsRouter from "./analytics";
 import bulkRouter from "./bulk";
 import crudRouter from "./crud";
 import messagesRouter from "./messages";
@@ -17,6 +18,7 @@ router.use("*", rateLimitMiddleware);
 router.route("/", searchRouter);
 router.route("/", bulkRouter);
 router.route("/", messagesRouter);
+router.route("/", analyticsRouter);
 router.route("/", crudRouter);
 
 export default router;

--- a/packages/api/test/analytics-public.test.ts
+++ b/packages/api/test/analytics-public.test.ts
@@ -1,0 +1,704 @@
+import { SELF } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+import { applyMigrations, authHeaders, seedProject } from "./setup";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createConversation(body: Record<string, unknown> = {}) {
+  return SELF.fetch("http://localhost/v1/conversations", {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify(body),
+  });
+}
+
+async function addTag(conversationId: string, tag: string) {
+  return SELF.fetch(`http://localhost/v1/conversations/${conversationId}/tags`, {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify({ tags: [tag] }),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Types for response shapes
+// ---------------------------------------------------------------------------
+
+interface SummaryResponse {
+  total_conversations: number;
+  total_messages: number;
+  total_tokens: number;
+  avg_messages_per_conversation: number;
+  avg_tokens_per_conversation: number;
+  period: { start: number; end: number };
+}
+
+interface TimeseriesResponse {
+  metric: string;
+  granularity: string;
+  period: { start: number; end: number };
+  data: Array<{ bucket: string; value: number }>;
+}
+
+interface TagsAnalyticsResponse {
+  period: { start: number; end: number };
+  data: Array<{
+    tag: string;
+    conversation_count: number;
+    message_count: number;
+    token_count: number;
+  }>;
+}
+
+interface ConversationAnalyticsResponse {
+  conversation_id: string;
+  title: string | null;
+  message_count: number;
+  token_count: number;
+  tags: string[];
+  duration_ms: number;
+  messages_by_role: Record<string, { count: number; tokens: number }>;
+  created_at: number;
+  updated_at: number;
+}
+
+interface ConversationCreatedResponse {
+  id: string;
+  project_id: string;
+  title: string | null;
+  message_count: number;
+  token_count: number;
+  created_at: number;
+  updated_at: number;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Public Analytics API", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await seedProject();
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /v1/analytics/summary
+  // -------------------------------------------------------------------------
+
+  describe("GET /v1/analytics/summary", () => {
+    it("requires auth", async () => {
+      const res = await SELF.fetch("http://localhost/v1/analytics/summary");
+      expect(res.status).toBe(401);
+
+      const body = await res.json<{ error: { code: string } }>();
+      expect(body.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("returns summary with correct shape", async () => {
+      const res = await SELF.fetch("http://localhost/v1/analytics/summary", {
+        headers: authHeaders(),
+      });
+      expect(res.status).toBe(200);
+
+      const body = await res.json<SummaryResponse>();
+      expect(typeof body.total_conversations).toBe("number");
+      expect(typeof body.total_messages).toBe("number");
+      expect(typeof body.total_tokens).toBe("number");
+      expect(typeof body.avg_messages_per_conversation).toBe("number");
+      expect(typeof body.avg_tokens_per_conversation).toBe("number");
+      expect(typeof body.period.start).toBe("number");
+      expect(typeof body.period.end).toBe("number");
+      expect(body.period.end).toBeGreaterThan(body.period.start);
+    });
+
+    it("respects date range filtering", async () => {
+      const now = Date.now();
+      const farFuture = now + 100 * 86_400_000;
+      const evenFurtherFuture = farFuture + 86_400_000;
+
+      // A range entirely in the future should return zero conversations
+      const res = await SELF.fetch(
+        `http://localhost/v1/analytics/summary?start=${farFuture}&end=${evenFurtherFuture}`,
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<SummaryResponse>();
+      expect(body.total_conversations).toBe(0);
+      expect(body.period.start).toBe(farFuture);
+      expect(body.period.end).toBe(evenFurtherFuture);
+    });
+
+    it("counts update after creating conversations", async () => {
+      // Record baseline
+      const baseRes = await SELF.fetch("http://localhost/v1/analytics/summary", {
+        headers: authHeaders(),
+      });
+      const base = await baseRes.json<SummaryResponse>();
+
+      // Create a conversation with messages
+      await createConversation({
+        title: "Summary Count Test",
+        messages: [
+          { role: "user", content: "Hello", token_count: 5 },
+          { role: "assistant", content: "Hi there!", token_count: 10 },
+        ],
+      });
+
+      const afterRes = await SELF.fetch("http://localhost/v1/analytics/summary", {
+        headers: authHeaders(),
+      });
+      const after = await afterRes.json<SummaryResponse>();
+
+      expect(after.total_conversations).toBe(base.total_conversations + 1);
+      expect(after.total_messages).toBe(base.total_messages + 2);
+      expect(after.total_tokens).toBe(base.total_tokens + 15);
+    });
+
+    it("filters by tag and returns only tagged conversations", async () => {
+      // Create conversations — one tagged, one not
+      const taggedRes = await createConversation({ title: "Tagged Summary Conv" });
+      const tagged = await taggedRes.json<ConversationCreatedResponse>();
+      await addTag(tagged.id, "summary-tag-test");
+
+      await createConversation({ title: "Untagged Summary Conv" });
+
+      // Get baseline for all
+      const allRes = await SELF.fetch("http://localhost/v1/analytics/summary", {
+        headers: authHeaders(),
+      });
+      const all = await allRes.json<SummaryResponse>();
+
+      // Get filtered by tag
+      const filteredRes = await SELF.fetch(
+        "http://localhost/v1/analytics/summary?tag=summary-tag-test",
+        { headers: authHeaders() },
+      );
+      expect(filteredRes.status).toBe(200);
+
+      const filtered = await filteredRes.json<SummaryResponse>();
+      expect(filtered.total_conversations).toBeGreaterThanOrEqual(1);
+      expect(filtered.total_conversations).toBeLessThan(all.total_conversations);
+    });
+
+    it("returns zero counts for non-existent tag", async () => {
+      const res = await SELF.fetch(
+        "http://localhost/v1/analytics/summary?tag=nonexistent-tag-xyz",
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<SummaryResponse>();
+      expect(body.total_conversations).toBe(0);
+      expect(body.total_messages).toBe(0);
+      expect(body.total_tokens).toBe(0);
+    });
+
+    it("computes avg_messages_per_conversation correctly", async () => {
+      const now = Date.now();
+      const start = now - 1000;
+      const end = now + 86_400_000;
+
+      // Create a conversation with known message counts
+      await createConversation({
+        title: "Avg Test Conv",
+        messages: [
+          { role: "user", content: "msg1", token_count: 10 },
+          { role: "assistant", content: "msg2", token_count: 20 },
+          { role: "user", content: "msg3", token_count: 5 },
+        ],
+      });
+
+      const res = await SELF.fetch(
+        `http://localhost/v1/analytics/summary?start=${start}&end=${end}`,
+        { headers: authHeaders() },
+      );
+      const body = await res.json<SummaryResponse>();
+
+      if (body.total_conversations > 0) {
+        const expectedAvgMsgs =
+          Math.round((body.total_messages / body.total_conversations) * 10) / 10;
+        expect(body.avg_messages_per_conversation).toBe(expectedAvgMsgs);
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /v1/analytics/timeseries
+  // -------------------------------------------------------------------------
+
+  describe("GET /v1/analytics/timeseries", () => {
+    it("requires auth", async () => {
+      const res = await SELF.fetch("http://localhost/v1/analytics/timeseries");
+      expect(res.status).toBe(401);
+    });
+
+    it("returns daily granularity by default", async () => {
+      // Create a conversation to ensure data exists
+      await createConversation({ title: "Timeseries Daily Test" });
+
+      const res = await SELF.fetch("http://localhost/v1/analytics/timeseries", {
+        headers: authHeaders(),
+      });
+      expect(res.status).toBe(200);
+
+      const body = await res.json<TimeseriesResponse>();
+      expect(body.metric).toBe("conversations");
+      expect(body.granularity).toBe("day");
+      expect(Array.isArray(body.data)).toBe(true);
+      expect(typeof body.period.start).toBe("number");
+      expect(typeof body.period.end).toBe("number");
+
+      // Each data point should have bucket (string) and value (number)
+      for (const point of body.data) {
+        expect(typeof point.bucket).toBe("string");
+        expect(typeof point.value).toBe("number");
+        // Day format: YYYY-MM-DD
+        expect(point.bucket).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      }
+    });
+
+    it("supports weekly granularity", async () => {
+      const res = await SELF.fetch(
+        "http://localhost/v1/analytics/timeseries?metric=conversations&granularity=week",
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<TimeseriesResponse>();
+      expect(body.granularity).toBe("week");
+
+      for (const point of body.data) {
+        // Week format: YYYY-Www
+        expect(point.bucket).toMatch(/^\d{4}-W\d{2}$/);
+      }
+    });
+
+    it("supports monthly granularity", async () => {
+      const res = await SELF.fetch(
+        "http://localhost/v1/analytics/timeseries?metric=conversations&granularity=month",
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<TimeseriesResponse>();
+      expect(body.granularity).toBe("month");
+
+      for (const point of body.data) {
+        // Month format: YYYY-MM
+        expect(point.bucket).toMatch(/^\d{4}-\d{2}$/);
+      }
+    });
+
+    it("supports messages metric", async () => {
+      const res = await SELF.fetch(
+        "http://localhost/v1/analytics/timeseries?metric=messages",
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<TimeseriesResponse>();
+      expect(body.metric).toBe("messages");
+      expect(Array.isArray(body.data)).toBe(true);
+
+      for (const point of body.data) {
+        expect(point.value).toBeGreaterThanOrEqual(0);
+      }
+    });
+
+    it("supports tokens metric", async () => {
+      await createConversation({
+        title: "Tokens Timeseries",
+        messages: [{ role: "user", content: "hello", token_count: 50 }],
+      });
+
+      const res = await SELF.fetch(
+        "http://localhost/v1/analytics/timeseries?metric=tokens",
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<TimeseriesResponse>();
+      expect(body.metric).toBe("tokens");
+      expect(Array.isArray(body.data)).toBe(true);
+
+      const totalTokens = body.data.reduce((sum, p) => sum + p.value, 0);
+      expect(totalTokens).toBeGreaterThanOrEqual(0);
+    });
+
+    it("falls back to conversations metric for invalid metric param", async () => {
+      const res = await SELF.fetch(
+        "http://localhost/v1/analytics/timeseries?metric=invalid",
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<TimeseriesResponse>();
+      expect(body.metric).toBe("conversations");
+    });
+
+    it("falls back to day granularity for invalid granularity param", async () => {
+      const res = await SELF.fetch(
+        "http://localhost/v1/analytics/timeseries?granularity=invalid",
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<TimeseriesResponse>();
+      expect(body.granularity).toBe("day");
+    });
+
+    it("filters by tag", async () => {
+      const convRes = await createConversation({ title: "Timeseries Tag Filter" });
+      const conv = await convRes.json<ConversationCreatedResponse>();
+      await addTag(conv.id, "ts-tag-filter");
+
+      const res = await SELF.fetch(
+        "http://localhost/v1/analytics/timeseries?tag=ts-tag-filter",
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<TimeseriesResponse>();
+      expect(Array.isArray(body.data)).toBe(true);
+
+      // Total sum of filtered timeseries should reflect at least the conv we created
+      const total = body.data.reduce((sum, p) => sum + p.value, 0);
+      expect(total).toBeGreaterThanOrEqual(1);
+    });
+
+    it("returns empty data array for future date range", async () => {
+      const future = Date.now() + 100 * 86_400_000;
+      const res = await SELF.fetch(
+        `http://localhost/v1/analytics/timeseries?start=${future}&end=${future + 86_400_000}`,
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<TimeseriesResponse>();
+      expect(body.data).toEqual([]);
+    });
+
+    it("echoes back the period in response", async () => {
+      const start = Date.now() - 7 * 86_400_000;
+      const end = Date.now();
+
+      const res = await SELF.fetch(
+        `http://localhost/v1/analytics/timeseries?start=${start}&end=${end}`,
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<TimeseriesResponse>();
+      expect(body.period.start).toBe(start);
+      expect(body.period.end).toBe(end);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /v1/analytics/tags
+  // -------------------------------------------------------------------------
+
+  describe("GET /v1/analytics/tags", () => {
+    it("requires auth", async () => {
+      const res = await SELF.fetch("http://localhost/v1/analytics/tags");
+      expect(res.status).toBe(401);
+    });
+
+    it("returns correct response shape", async () => {
+      const res = await SELF.fetch("http://localhost/v1/analytics/tags", {
+        headers: authHeaders(),
+      });
+      expect(res.status).toBe(200);
+
+      const body = await res.json<TagsAnalyticsResponse>();
+      expect(Array.isArray(body.data)).toBe(true);
+      expect(typeof body.period.start).toBe("number");
+      expect(typeof body.period.end).toBe("number");
+    });
+
+    it("returns tag breakdown after adding tags", async () => {
+      const tagName = `breakdown-tag-${Date.now()}`;
+
+      // Create conversations with tags
+      const convRes1 = await createConversation({
+        title: "Tags Breakdown 1",
+        messages: [{ role: "user", content: "msg", token_count: 100 }],
+      });
+      const conv1 = await convRes1.json<ConversationCreatedResponse>();
+      await addTag(conv1.id, tagName);
+
+      const convRes2 = await createConversation({
+        title: "Tags Breakdown 2",
+        messages: [
+          { role: "user", content: "msg", token_count: 50 },
+          { role: "assistant", content: "reply", token_count: 75 },
+        ],
+      });
+      const conv2 = await convRes2.json<ConversationCreatedResponse>();
+      await addTag(conv2.id, tagName);
+
+      const res = await SELF.fetch("http://localhost/v1/analytics/tags", {
+        headers: authHeaders(),
+      });
+      expect(res.status).toBe(200);
+
+      const body = await res.json<TagsAnalyticsResponse>();
+      const tagRow = body.data.find((d) => d.tag === tagName);
+      expect(tagRow).toBeDefined();
+      expect(tagRow?.conversation_count).toBe(2);
+      expect(tagRow?.message_count).toBe(3); // 1 + 2
+      expect(tagRow?.token_count).toBe(225); // 100 + 50 + 75
+    });
+
+    it("respects limit param", async () => {
+      // Add enough tags to exceed the limit
+      for (let i = 0; i < 5; i++) {
+        const convRes = await createConversation({ title: `Limit Test Conv ${i}` });
+        const conv = await convRes.json<ConversationCreatedResponse>();
+        await addTag(conv.id, `limit-tag-${i}-${Date.now()}`);
+      }
+
+      const res = await SELF.fetch("http://localhost/v1/analytics/tags?limit=2", {
+        headers: authHeaders(),
+      });
+      expect(res.status).toBe(200);
+
+      const body = await res.json<TagsAnalyticsResponse>();
+      expect(body.data.length).toBeLessThanOrEqual(2);
+    });
+
+    it("orders by conversation_count desc", async () => {
+      const highTag = `high-count-${Date.now()}`;
+      const lowTag = `low-count-${Date.now()}`;
+
+      // Add highTag to 2 conversations
+      for (let i = 0; i < 2; i++) {
+        const convRes = await createConversation({ title: `High Tag Conv ${i}` });
+        const conv = await convRes.json<ConversationCreatedResponse>();
+        await addTag(conv.id, highTag);
+      }
+
+      // Add lowTag to 1 conversation
+      const convRes = await createConversation({ title: "Low Tag Conv" });
+      const conv = await convRes.json<ConversationCreatedResponse>();
+      await addTag(conv.id, lowTag);
+
+      const res = await SELF.fetch("http://localhost/v1/analytics/tags", {
+        headers: authHeaders(),
+      });
+      expect(res.status).toBe(200);
+
+      const body = await res.json<TagsAnalyticsResponse>();
+
+      const highIdx = body.data.findIndex((d) => d.tag === highTag);
+      const lowIdx = body.data.findIndex((d) => d.tag === lowTag);
+
+      if (highIdx !== -1 && lowIdx !== -1) {
+        expect(highIdx).toBeLessThan(lowIdx);
+      }
+
+      // Verify descending order of all returned entries
+      for (let i = 1; i < body.data.length; i++) {
+        expect(body.data[i].conversation_count).toBeLessThanOrEqual(
+          body.data[i - 1].conversation_count,
+        );
+      }
+    });
+
+    it("respects date range — returns empty for future range", async () => {
+      const future = Date.now() + 100 * 86_400_000;
+      const res = await SELF.fetch(
+        `http://localhost/v1/analytics/tags?start=${future}&end=${future + 86_400_000}`,
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<TagsAnalyticsResponse>();
+      expect(body.data).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /v1/conversations/:id/analytics
+  // -------------------------------------------------------------------------
+
+  describe("GET /v1/conversations/:id/analytics", () => {
+    it("requires auth", async () => {
+      const convRes = await createConversation({ title: "Auth Test" });
+      const conv = await convRes.json<ConversationCreatedResponse>();
+
+      const res = await SELF.fetch(
+        `http://localhost/v1/conversations/${conv.id}/analytics`,
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 404 for non-existent conversation", async () => {
+      const res = await SELF.fetch(
+        "http://localhost/v1/conversations/nonexistent_id_xyz/analytics",
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(404);
+
+      const body = await res.json<{ error: { code: string } }>();
+      expect(body.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns correct analytics shape", async () => {
+      const convRes = await createConversation({
+        title: "Analytics Shape Test",
+        messages: [{ role: "user", content: "Hello", token_count: 7 }],
+      });
+      const conv = await convRes.json<ConversationCreatedResponse>();
+
+      const res = await SELF.fetch(
+        `http://localhost/v1/conversations/${conv.id}/analytics`,
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<ConversationAnalyticsResponse>();
+      expect(body.conversation_id).toBe(conv.id);
+      expect(body.title).toBe("Analytics Shape Test");
+      expect(typeof body.message_count).toBe("number");
+      expect(typeof body.token_count).toBe("number");
+      expect(Array.isArray(body.tags)).toBe(true);
+      expect(typeof body.duration_ms).toBe("number");
+      expect(typeof body.messages_by_role).toBe("object");
+      expect(typeof body.created_at).toBe("number");
+      expect(typeof body.updated_at).toBe("number");
+    });
+
+    it("includes messages_by_role breakdown", async () => {
+      const convRes = await createConversation({
+        title: "Role Breakdown Test",
+        messages: [
+          { role: "user", content: "msg1", token_count: 10 },
+          { role: "user", content: "msg2", token_count: 15 },
+          { role: "assistant", content: "reply1", token_count: 30 },
+          { role: "assistant", content: "reply2", token_count: 20 },
+        ],
+      });
+      const conv = await convRes.json<ConversationCreatedResponse>();
+
+      const res = await SELF.fetch(
+        `http://localhost/v1/conversations/${conv.id}/analytics`,
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<ConversationAnalyticsResponse>();
+      expect(body.messages_by_role.user).toBeDefined();
+      expect(body.messages_by_role.user.count).toBe(2);
+      expect(body.messages_by_role.user.tokens).toBe(25);
+      expect(body.messages_by_role.assistant).toBeDefined();
+      expect(body.messages_by_role.assistant.count).toBe(2);
+      expect(body.messages_by_role.assistant.tokens).toBe(50);
+    });
+
+    it("includes tags", async () => {
+      const convRes = await createConversation({ title: "Tagged Analytics Test" });
+      const conv = await convRes.json<ConversationCreatedResponse>();
+
+      await addTag(conv.id, "analytics-tag-one");
+      await addTag(conv.id, "analytics-tag-two");
+
+      const res = await SELF.fetch(
+        `http://localhost/v1/conversations/${conv.id}/analytics`,
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<ConversationAnalyticsResponse>();
+      expect(body.tags).toContain("analytics-tag-one");
+      expect(body.tags).toContain("analytics-tag-two");
+      expect(body.tags.length).toBe(2);
+    });
+
+    it("calculates duration_ms as updated_at minus created_at", async () => {
+      const convRes = await createConversation({ title: "Duration Test" });
+      const conv = await convRes.json<ConversationCreatedResponse>();
+
+      const res = await SELF.fetch(
+        `http://localhost/v1/conversations/${conv.id}/analytics`,
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<ConversationAnalyticsResponse>();
+      expect(body.duration_ms).toBe(body.updated_at - body.created_at);
+      expect(body.duration_ms).toBeGreaterThanOrEqual(0);
+    });
+
+    it("returns zero token_count and empty role breakdown for conversations without messages", async () => {
+      const convRes = await createConversation({ title: "Empty Conv" });
+      const conv = await convRes.json<ConversationCreatedResponse>();
+
+      const res = await SELF.fetch(
+        `http://localhost/v1/conversations/${conv.id}/analytics`,
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<ConversationAnalyticsResponse>();
+      expect(body.message_count).toBe(0);
+      expect(body.token_count).toBe(0);
+      expect(Object.keys(body.messages_by_role).length).toBe(0);
+    });
+
+    it("reflects correct message_count and token_count from conversation", async () => {
+      const convRes = await createConversation({
+        title: "Count Accuracy Test",
+        messages: [
+          { role: "user", content: "q1", token_count: 3 },
+          { role: "assistant", content: "a1", token_count: 7 },
+          { role: "user", content: "q2", token_count: 4 },
+        ],
+      });
+      const conv = await convRes.json<ConversationCreatedResponse>();
+
+      const res = await SELF.fetch(
+        `http://localhost/v1/conversations/${conv.id}/analytics`,
+        { headers: authHeaders() },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json<ConversationAnalyticsResponse>();
+      expect(body.message_count).toBe(3);
+      expect(body.token_count).toBe(14);
+    });
+
+    it("is accessible via /api/v1 prefix", async () => {
+      const convRes = await createConversation({ title: "API Prefix Test" });
+      const conv = await convRes.json<ConversationCreatedResponse>();
+
+      const res = await SELF.fetch(
+        `http://localhost/api/v1/conversations/${conv.id}/analytics`,
+        { headers: authHeaders() },
+      );
+      // Both /v1 and /api/v1 are valid; /api/v1/conversations is also registered
+      // so this should return 200
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Additional: /api/v1/analytics also works (backward compat prefix)
+  // -------------------------------------------------------------------------
+
+  describe("GET /api/v1/analytics/summary (api prefix)", () => {
+    it("works with /api/v1 prefix", async () => {
+      const res = await SELF.fetch("http://localhost/api/v1/analytics/summary", {
+        headers: authHeaders(),
+      });
+      expect(res.status).toBe(200);
+
+      const body = await res.json<SummaryResponse>();
+      expect(typeof body.total_conversations).toBe("number");
+    });
+  });
+});

--- a/packages/api/test/setup.ts
+++ b/packages/api/test/setup.ts
@@ -29,6 +29,7 @@ const DDL_STATEMENTS: string[] = [
     FOREIGN KEY (\`project_id\`) REFERENCES \`projects\`(\`id\`) ON UPDATE no action ON DELETE no action
   )`,
   `CREATE INDEX IF NOT EXISTS \`conversations_project_id_idx\` ON \`conversations\` (\`project_id\`)`,
+  `CREATE INDEX IF NOT EXISTS \`conversations_project_id_created_at_idx\` ON \`conversations\` (\`project_id\`,\`created_at\`)`,
   `CREATE INDEX IF NOT EXISTS \`conversations_project_id_external_id_idx\` ON \`conversations\` (\`project_id\`,\`external_id\`)`,
   `CREATE INDEX IF NOT EXISTS \`conversations_project_id_updated_at_idx\` ON \`conversations\` (\`project_id\`,\`updated_at\`)`,
   `CREATE UNIQUE INDEX IF NOT EXISTS \`conversations_project_id_external_id_unique_idx\` ON \`conversations\` (\`project_id\`,\`external_id\`)`,


### PR DESCRIPTION
## Summary

- Add 3 project-level analytics endpoints under `/v1/analytics`: `summary`, `timeseries`, and `tags`
- Add 1 conversation-level endpoint: `GET /v1/conversations/:id/analytics` with role breakdown, tags, and duration
- All endpoints support date range filtering (`?start=&end=`) and multi-tag filtering (`?tag=`)
- Add composite index on `(project_id, created_at)` for efficient analytics queries
- 34 new integration tests covering auth, response shapes, data accuracy, tag filtering, granularity formats, and edge cases — all 145 tests pass

## Test plan

- [ ] `bun run test` in `packages/api` — all 145 tests pass (34 new)
- [ ] Auth required: 401 without Bearer token on all analytics endpoints
- [ ] Summary shape: all numeric fields present, `period.start < period.end`
- [ ] Timeseries: `day` format `YYYY-MM-DD`, `week` format `YYYY-Www`, `month` format `YYYY-MM`
- [ ] Tag breakdown: `conversation_count`, `message_count`, `token_count` match known seeded data
- [ ] Conversation analytics: role counts and token totals match inserted messages
- [ ] Tag filter: filtered summary count < unfiltered count; non-existent tag returns zeros
- [ ] Date range: future range returns empty/zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)