### PR TITLE
feat(dashboard): update sidebar header and footer - remove logo, add home link

### DIFF
--- a/packages/dashboard/src/components/app-sidebar.tsx
+++ b/packages/dashboard/src/components/app-sidebar.tsx
@@ -5,7 +5,7 @@ import {
   ActivityIcon,
   BlocksIcon,
   BookOpenIcon,
-  ExternalLinkIcon,
+  HomeIcon,
   LayoutDashboardIcon,
   MessageCircleIcon,
 } from "lucide-react";
@@ -43,27 +43,6 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
   return (
     <Sidebar collapsible="icon" {...props}>
       <SidebarHeader>
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <Link href="/dashboard">
-              <SidebarMenuButton size="lg" tooltip="AgentState">
-                <div className="flex aspect-square size-8 items-center justify-center shrink-0 text-primary">
-                  <svg viewBox="0 0 32 32" fill="none" className="size-8">
-                    <title>AgentState logo</title>
-                    <rect x="2" y="2" width="28" height="28" rx="7" fill="currentColor" />
-                    <g stroke="white" strokeWidth="1.8" strokeLinecap="round">
-                      <line x1="9" y1="11" x2="19" y2="11" />
-                      <line x1="13" y1="16" x2="23" y2="16" />
-                      <line x1="9" y1="21" x2="17" y2="21" />
-                    </g>
-                    <circle cx="23" cy="21" r="2" fill="#22c55e" />
-                  </svg>
-                </div>
-                <span className="font-semibold text-sm truncate">AgentState</span>
-              </SidebarMenuButton>
-            </Link>
-          </SidebarMenuItem>
-        </SidebarMenu>
         <ProjectSwitcher />
       </SidebarHeader>
 
@@ -102,10 +81,10 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
             </Link>
           </SidebarMenuItem>
           <SidebarMenuItem>
-            <Link href="/" target="_blank">
-              <SidebarMenuButton tooltip="agentstate.app">
-                <ExternalLinkIcon />
-                <span>agentstate.app</span>
+            <Link href="/">
+              <SidebarMenuButton isActive={pathname === "/"} tooltip="Home">
+                <HomeIcon />
+                <span>Home</span>
               </SidebarMenuButton>
             </Link>
           </SidebarMenuItem>


### PR DESCRIPTION
## Summary
Unit 2 of sidebar redesign: Update sidebar header and footer components.

- Remove AgentState logo + title link from sidebar header (keeping only ProjectSwitcher)
- Replace ExternalLinkIcon with HomeIcon in imports
- Update footer link from external agentstate.app to internal Home link
- Add proper `isActive` state for Home link based on current pathname

## Test plan
- [x] Run Biome formatter (no changes needed)
- [x] Verify git diff shows correct changes
- [x] Commit with semantic message and co-authors
- [x] Push branch and create PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed AgentState branding block from the sidebar header
  * Updated sidebar navigation to feature a Home button linking to the dashboard home route
  * Replaced icon and updated menu item label and tooltip for improved navigation clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->