### PR TITLE
feat(dashboard): update ProjectSwitcher with Agent State branding

### DIFF
--- a/packages/dashboard/src/components/project-switcher.tsx
+++ b/packages/dashboard/src/components/project-switcher.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ProjectListItem } from "@agentstate/shared";
-import { Check, ChevronsUpDown, FolderIcon } from "lucide-react";
+import { Check, ChevronsUpDown } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import * as React from "react";
 import {
@@ -12,6 +12,19 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
 import { api } from "@/lib/api";
+
+const AgentStateLogo = ({ size = "size-8" }: { size?: string }) => (
+  <svg viewBox="0 0 32 32" fill="none" className={size}>
+    <title>AgentState logo</title>
+    <rect x="2" y="2" width="28" height="28" rx="7" fill="currentColor" />
+    <g stroke="white" strokeWidth="1.8" strokeLinecap="round">
+      <line x1="9" y1="11" x2="19" y2="11" />
+      <line x1="13" y1="16" x2="23" y2="16" />
+      <line x1="9" y1="21" x2="17" y2="21" />
+    </g>
+    <circle cx="23" cy="21" r="2" fill="#22c55e" />
+  </svg>
+);
 
 function ProjectSwitcherInner() {
   const router = useRouter();
@@ -47,15 +60,13 @@ function ProjectSwitcherInner() {
               />
             }
           >
-            <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground shrink-0">
-              <FolderIcon className="size-4" />
+            <div className="flex aspect-square size-8 items-center justify-center shrink-0 text-primary">
+              {isLoading ? <AgentStateLogo /> : <AgentStateLogo />}
             </div>
             <div className="grid flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden">
-              <span className="truncate font-semibold">
-                {isLoading ? "Loading..." : (currentProject?.name ?? "Select project")}
-              </span>
+              <span className="truncate font-semibold">Agent State</span>
               <span className="truncate text-xs text-muted-foreground">
-                {currentProject?.slug ?? ""}
+                {currentProject?.name ?? "Select project"}
               </span>
             </div>
             <ChevronsUpDown className="ml-auto size-4 shrink-0 group-data-[collapsible=icon]:hidden" />
@@ -70,7 +81,9 @@ function ProjectSwitcherInner() {
                   onClick={() => router.push(`/dashboard/project/?slug=${project.slug}`)}
                   className="gap-2"
                 >
-                  <FolderIcon className="size-4 shrink-0" />
+                  <div className="flex aspect-square size-4 items-center justify-center shrink-0 text-primary">
+                    <AgentStateLogo size="size-4" />
+                  </div>
                   <span className="flex-1 truncate">{project.name}</span>
                   {currentProject?.id === project.id && (
                     <Check className="size-4 shrink-0 ml-auto" />

--- a/packages/dashboard/src/components/project-switcher.tsx
+++ b/packages/dashboard/src/components/project-switcher.tsx
@@ -14,8 +14,7 @@ import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "@/components/ui
 import { api } from "@/lib/api";
 
 const AgentStateLogo = ({ size = "size-8" }: { size?: string }) => (
-  <svg viewBox="0 0 32 32" fill="none" className={size}>
-    <title>AgentState logo</title>
+  <svg viewBox="0 0 32 32" fill="none" className={size} aria-hidden="true" focusable="false">
     <rect x="2" y="2" width="28" height="28" rx="7" fill="currentColor" />
     <g stroke="white" strokeWidth="1.8" strokeLinecap="round">
       <line x1="9" y1="11" x2="19" y2="11" />
@@ -61,7 +60,7 @@ function ProjectSwitcherInner() {
             }
           >
             <div className="flex aspect-square size-8 items-center justify-center shrink-0 text-primary">
-              {isLoading ? <AgentStateLogo /> : <AgentStateLogo />}
+              <AgentStateLogo />
             </div>
             <div className="grid flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden">
               <span className="truncate font-semibold">Agent State</span>


### PR DESCRIPTION
## Summary
- Replace FolderIcon with AgentState logo SVG (reused from app-sidebar.tsx)
- Show "Agent State" as primary text (always visible, even during loading)
- Display project name as muted secondary text (instead of slug)
- Update dropdown menu items to use AgentState logo instead of FolderIcon
- Remove unused FolderIcon import

## Changes made
✅ Added AgentStateLogo component with configurable size prop
✅ Updated loading state to show logo + "Agent State"
✅ Updated selected state to show "Agent State" + project name (muted)
✅ Updated dropdown menu items to use AgentState logo
✅ Removed FolderIcon import

## Testing
- ✅ Biome formatting: passed
- ✅ TypeScript type checking: passed
- 🔄 Local testing: ready for verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced the project switcher interface with a new agent state visual indicator. Updated labels now display "Agent State" consistently, providing clearer project identification. Project name visibility has been improved throughout the switcher display and dropdown menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->