### PR TITLE
feat(dashboard): add motion to homepage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.577.0",
+        "motion": "^12.38.0",
         "next": "16.2.6",
         "next-themes": "^0.4.6",
         "react": "19.2.3",
@@ -1005,6 +1006,8 @@
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
+    "framer-motion": ["framer-motion@12.38.0", "", { "dependencies": { "motion-dom": "^12.38.0", "motion-utils": "^12.36.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g=="],
+
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
@@ -1306,6 +1309,12 @@
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "mlly": ["mlly@1.8.1", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ=="],
+
+    "motion": ["motion@12.38.0", "", { "dependencies": { "framer-motion": "^12.38.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w=="],
+
+    "motion-dom": ["motion-dom@12.38.0", "", { "dependencies": { "motion-utils": "^12.36.0" } }, "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA=="],
+
+    "motion-utils": ["motion-utils@12.36.0", "", {}, "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -16,6 +16,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",
+    "motion": "^12.38.0",
     "next": "16.2.6",
     "next-themes": "^0.4.6",
     "react": "19.2.3",

--- a/packages/dashboard/public/agents.md
+++ b/packages/dashboard/public/agents.md
@@ -1,0 +1,1 @@
+../../api/src/content/agents.md

--- a/packages/dashboard/src/app/_api-endpoints.tsx
+++ b/packages/dashboard/src/app/_api-endpoints.tsx
@@ -1,5 +1,12 @@
 import { ArrowRightIcon } from "lucide-react";
 import Link from "next/link";
+import {
+  landingCard,
+  landingContainer,
+  landingHover,
+  MotionDiv,
+  MotionSection,
+} from "@/components/landing/motion";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -31,54 +38,63 @@ const apiEndpoints = [
 
 export function ApiEndpoints() {
   return (
-    <section className="max-w-5xl mx-auto px-6 pb-24">
-      <Card>
-        <CardHeader>
-          <CardTitle>API endpoints</CardTitle>
-          <CardDescription>
-            The public surface stays small enough for agents and humans to keep in context.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Table className="table-fixed">
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-24">Method</TableHead>
-                <TableHead>Path</TableHead>
-                <TableHead className="hidden w-56 sm:table-cell">Use</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {apiEndpoints.map(([method, path, desc]) => (
-                <TableRow key={path + method}>
-                  <TableCell>
-                    <Badge variant="outline">{method}</Badge>
-                  </TableCell>
-                  <TableCell className="truncate font-mono">{path}</TableCell>
-                  <TableCell className="hidden text-muted-foreground sm:table-cell">
-                    {desc}
-                  </TableCell>
+    <MotionSection
+      className="max-w-5xl mx-auto px-6 pb-24"
+      animate="visible"
+      initial="hidden"
+      variants={landingContainer}
+    >
+      <MotionDiv variants={landingCard} whileHover={landingHover}>
+        <Card>
+          <CardHeader>
+            <CardTitle>API endpoints</CardTitle>
+            <CardDescription>
+              The public surface stays small enough for agents and humans to keep in context.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table className="table-fixed">
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-24">Method</TableHead>
+                  <TableHead>Path</TableHead>
+                  <TableHead className="hidden w-56 sm:table-cell">Use</TableHead>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </CardContent>
-        <CardFooter className="flex flex-wrap gap-2">
-          <Button variant="outline" size="sm" nativeButton={false} render={<Link href="/docs" />}>
-            Full API reference
-            <ArrowRightIcon data-icon="inline-end" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            nativeButton={false}
-            render={<Link href="/agents.md" />}
-          >
-            agents.md
-            <ArrowRightIcon data-icon="inline-end" />
-          </Button>
-        </CardFooter>
-      </Card>
-    </section>
+              </TableHeader>
+              <TableBody>
+                {apiEndpoints.map(([method, path, desc]) => (
+                  <TableRow key={path + method}>
+                    <TableCell>
+                      <Badge variant="outline">{method}</Badge>
+                    </TableCell>
+                    <TableCell className="truncate font-mono">{path}</TableCell>
+                    <TableCell className="hidden text-muted-foreground sm:table-cell">
+                      {desc}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+          <CardFooter className="flex flex-wrap gap-2">
+            <Button variant="outline" size="sm" nativeButton={false} render={<Link href="/docs" />}>
+              Full API reference
+              <ArrowRightIcon data-icon="inline-end" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              nativeButton={false}
+              render={
+                <a href="/agents.md">
+                  agents.md
+                  <ArrowRightIcon data-icon="inline-end" />
+                </a>
+              }
+            />
+          </CardFooter>
+        </Card>
+      </MotionDiv>
+    </MotionSection>
   );
 }

--- a/packages/dashboard/src/app/_api-endpoints.tsx
+++ b/packages/dashboard/src/app/_api-endpoints.tsx
@@ -85,13 +85,12 @@ export function ApiEndpoints() {
               variant="ghost"
               size="sm"
               nativeButton={false}
-              render={
-                <a href="/agents.md">
-                  agents.md
-                  <ArrowRightIcon data-icon="inline-end" />
-                </a>
-              }
-            />
+              // biome-ignore lint/a11y/useAnchorContent: Base UI injects the Button children into this render anchor.
+              render={<a href="/agents.md" />}
+            >
+              agents.md
+              <ArrowRightIcon data-icon="inline-end" />
+            </Button>
           </CardFooter>
         </Card>
       </MotionDiv>

--- a/packages/dashboard/src/app/_code-examples.tsx
+++ b/packages/dashboard/src/app/_code-examples.tsx
@@ -1,3 +1,11 @@
+import {
+  landingCard,
+  landingContainer,
+  landingHover,
+  landingItem,
+  MotionDiv,
+  MotionSection,
+} from "@/components/landing/motion";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
@@ -23,34 +31,41 @@ API key: as_live_...`,
 
 export function CodeExamples() {
   return (
-    <section className="max-w-5xl mx-auto px-6 pb-20">
+    <MotionSection
+      className="max-w-5xl mx-auto px-6 pb-20"
+      animate="visible"
+      initial="hidden"
+      variants={landingContainer}
+    >
       <div className="flex flex-col gap-6">
-        <div className="flex flex-col gap-2">
+        <MotionDiv className="flex flex-col gap-2" variants={landingItem}>
           <h2 className="text-lg font-medium">Integration paths</h2>
           <p className="max-w-2xl text-sm text-muted-foreground">
             Start with agent-readable docs or a direct API call. Both paths hit the same storage
             contract.
           </p>
-        </div>
-        <div className="grid gap-4 sm:grid-cols-2">
+        </MotionDiv>
+        <MotionDiv className="grid gap-4 sm:grid-cols-2" variants={landingContainer}>
           {examples.map((example) => (
-            <Card key={example.label} size="sm">
-              <CardHeader>
-                <CardTitle>{example.title}</CardTitle>
-                <CardDescription className="flex flex-col gap-2">
-                  <Badge variant="outline">{example.label}</Badge>
-                  <span>{example.description}</span>
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <pre className="whitespace-pre-wrap break-words rounded-md bg-muted p-3 font-mono text-sm leading-6 text-muted-foreground">
-                  <code>{example.code}</code>
-                </pre>
-              </CardContent>
-            </Card>
+            <MotionDiv key={example.label} variants={landingCard} whileHover={landingHover}>
+              <Card size="sm">
+                <CardHeader>
+                  <CardTitle>{example.title}</CardTitle>
+                  <CardDescription className="flex flex-col gap-2">
+                    <Badge variant="outline">{example.label}</Badge>
+                    <span>{example.description}</span>
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <pre className="whitespace-pre-wrap break-words rounded-md bg-muted p-3 font-mono text-sm leading-6 text-muted-foreground">
+                    <code>{example.code}</code>
+                  </pre>
+                </CardContent>
+              </Card>
+            </MotionDiv>
           ))}
-        </div>
+        </MotionDiv>
       </div>
-    </section>
+    </MotionSection>
   );
 }

--- a/packages/dashboard/src/app/_features.tsx
+++ b/packages/dashboard/src/app/_features.tsx
@@ -5,6 +5,14 @@ import {
   type LucideIcon,
   ShieldCheckIcon,
 } from "lucide-react";
+import {
+  landingCard,
+  landingContainer,
+  landingHover,
+  landingItem,
+  MotionDiv,
+  MotionSection,
+} from "@/components/landing/motion";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
@@ -46,35 +54,42 @@ const features: readonly Feature[] = [
 
 export function Features() {
   return (
-    <section className="max-w-5xl mx-auto px-6 pb-20">
+    <MotionSection
+      className="max-w-5xl mx-auto px-6 pb-20"
+      animate="visible"
+      initial="hidden"
+      variants={landingContainer}
+    >
       <div className="flex flex-col gap-6">
-        <div className="flex flex-col gap-2">
+        <MotionDiv className="flex flex-col gap-2" variants={landingItem}>
           <h2 className="text-lg font-medium">Operations snapshot</h2>
           <p className="max-w-2xl text-sm text-muted-foreground">
             The primitives an agent product needs after the first conversation lands in production.
           </p>
-        </div>
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        </MotionDiv>
+        <MotionDiv className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4" variants={landingContainer}>
           {features.map(({ title, badge, icon: Icon, description }) => (
-            <Card key={title}>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <span className="flex size-8 items-center justify-center rounded-lg bg-muted text-muted-foreground">
-                    <Icon aria-hidden="true" />
-                  </span>
-                  {title}
-                </CardTitle>
-                <CardDescription>
-                  <Badge variant="secondary">{badge}</Badge>
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground leading-relaxed">{description}</p>
-              </CardContent>
-            </Card>
+            <MotionDiv key={title} variants={landingCard} whileHover={landingHover}>
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <span className="flex size-8 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                      <Icon aria-hidden="true" />
+                    </span>
+                    {title}
+                  </CardTitle>
+                  <CardDescription>
+                    <Badge variant="secondary">{badge}</Badge>
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-sm text-muted-foreground leading-relaxed">{description}</p>
+                </CardContent>
+              </Card>
+            </MotionDiv>
           ))}
-        </div>
+        </MotionDiv>
       </div>
-    </section>
+    </MotionSection>
   );
 }

--- a/packages/dashboard/src/app/_header.tsx
+++ b/packages/dashboard/src/app/_header.tsx
@@ -1,11 +1,17 @@
 import { ArrowRightIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import { MotionHeader } from "@/components/landing/motion";
 import { Button } from "@/components/ui/button";
 
 export function Header() {
   return (
-    <header className="sticky top-0 z-50 border-b border-border bg-card/80 px-6 py-3 backdrop-blur-sm">
+    <MotionHeader
+      animate={{ opacity: 1, y: 0 }}
+      className="sticky top-0 z-50 border-b border-border bg-card/80 px-6 py-3 backdrop-blur-sm"
+      initial={{ opacity: 0, y: -8 }}
+      transition={{ duration: 0.35 }}
+    >
       <div className="max-w-5xl mx-auto flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Image
@@ -39,6 +45,6 @@ export function Header() {
           </Button>
         </div>
       </div>
-    </header>
+    </MotionHeader>
   );
 }

--- a/packages/dashboard/src/app/_hero.tsx
+++ b/packages/dashboard/src/app/_hero.tsx
@@ -73,8 +73,11 @@ export function Hero() {
               variant="outline"
               size="lg"
               nativeButton={false}
-              render={<a href="/agents.md">agents.md</a>}
-            />
+              // biome-ignore lint/a11y/useAnchorContent: Base UI injects the Button children into this render anchor.
+              render={<a href="/agents.md" />}
+            >
+              agents.md
+            </Button>
             <Button variant="outline" size="lg" nativeButton={false} render={<Link href="/docs" />}>
               API reference
             </Button>

--- a/packages/dashboard/src/app/_hero.tsx
+++ b/packages/dashboard/src/app/_hero.tsx
@@ -6,6 +6,14 @@ import {
   MessageSquareIcon,
 } from "lucide-react";
 import Link from "next/link";
+import {
+  landingCard,
+  landingContainer,
+  landingHover,
+  landingItem,
+  MotionDiv,
+  MotionSection,
+} from "@/components/landing/motion";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -34,15 +42,20 @@ const productSignals = [
 
 export function Hero() {
   return (
-    <section className="max-w-5xl mx-auto px-6 py-16 sm:py-20">
+    <MotionSection
+      animate="visible"
+      className="max-w-5xl mx-auto px-6 py-16 sm:py-20"
+      initial="hidden"
+      variants={landingContainer}
+    >
       <div className="grid gap-8 lg:grid-cols-[1fr_24rem] lg:items-start">
         <div className="flex flex-col gap-6">
-          <div className="flex flex-wrap gap-2">
+          <MotionDiv className="flex flex-wrap gap-2" variants={landingItem}>
             <Badge variant="outline">REST API</Badge>
             <Badge variant="outline">Cloudflare D1</Badge>
             <Badge variant="outline">Agent memory</Badge>
-          </div>
-          <div className="flex flex-col gap-4">
+          </MotionDiv>
+          <MotionDiv className="flex flex-col gap-4" variants={landingItem}>
             <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl md:text-6xl">
               AgentState
             </h1>
@@ -50,8 +63,8 @@ export function Hero() {
               Conversation history database-as-a-service for AI agents. Store threads, retrieve
               context, monitor usage, and ship without building another chat-history backend.
             </p>
-          </div>
-          <div className="flex flex-wrap items-center gap-3">
+          </MotionDiv>
+          <MotionDiv className="flex flex-wrap items-center gap-3" variants={landingItem}>
             <Button size="lg" nativeButton={false} render={<Link href="/dashboard" />}>
               Open dashboard
               <ArrowRightIcon data-icon="inline-end" />
@@ -60,69 +73,73 @@ export function Hero() {
               variant="outline"
               size="lg"
               nativeButton={false}
-              render={<Link href="/agents.md" />}
-            >
-              agents.md
-            </Button>
+              render={<a href="/agents.md">agents.md</a>}
+            />
             <Button variant="outline" size="lg" nativeButton={false} render={<Link href="/docs" />}>
               API reference
             </Button>
-          </div>
-          <div className="grid gap-3 sm:grid-cols-2">
+          </MotionDiv>
+          <MotionDiv className="grid gap-3 sm:grid-cols-2" variants={landingContainer}>
             {productSignals.map(({ icon: Icon, label }) => (
-              <Card key={label} size="sm">
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2">
-                    <span className="flex size-8 items-center justify-center rounded-lg bg-muted text-muted-foreground">
-                      <Icon aria-hidden="true" />
-                    </span>
-                    {label}
-                  </CardTitle>
-                </CardHeader>
-              </Card>
+              <MotionDiv key={label} variants={landingCard} whileHover={landingHover}>
+                <Card size="sm">
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                      <span className="flex size-8 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                        <Icon aria-hidden="true" />
+                      </span>
+                      {label}
+                    </CardTitle>
+                  </CardHeader>
+                </Card>
+              </MotionDiv>
             ))}
-          </div>
+          </MotionDiv>
         </div>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Operations overview</CardTitle>
-            <CardDescription>One API surface for runtime memory and audit history.</CardDescription>
-            <CardAction>
-              <Badge variant="secondary">Live</Badge>
-            </CardAction>
-          </CardHeader>
-          <CardContent className="flex flex-col gap-4">
-            {overviewRows.map((row) => (
-              <div key={row.value} className="flex flex-col gap-1">
-                <div className="flex items-center justify-between gap-3">
-                  <span className="text-sm font-medium">{row.label}</span>
-                  <Badge variant="outline">v1</Badge>
+        <MotionDiv variants={landingCard} whileHover={landingHover}>
+          <Card>
+            <CardHeader>
+              <CardTitle>Operations overview</CardTitle>
+              <CardDescription>
+                One API surface for runtime memory and audit history.
+              </CardDescription>
+              <CardAction>
+                <Badge variant="secondary">Live</Badge>
+              </CardAction>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-4">
+              {overviewRows.map((row) => (
+                <div key={row.value} className="flex flex-col gap-1">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium">{row.label}</span>
+                    <Badge variant="outline">v1</Badge>
+                  </div>
+                  <code className="truncate rounded-md bg-muted px-3 py-2 font-mono text-sm text-muted-foreground">
+                    {row.value}
+                  </code>
                 </div>
-                <code className="truncate rounded-md bg-muted px-3 py-2 font-mono text-sm text-muted-foreground">
-                  {row.value}
-                </code>
+              ))}
+              <Separator />
+              <div className="grid grid-cols-2 gap-3">
+                <div className="flex flex-col gap-1">
+                  <span className="text-2xl font-semibold">21</span>
+                  <span className="text-sm text-muted-foreground">char IDs</span>
+                </div>
+                <div className="flex flex-col gap-1">
+                  <span className="text-2xl font-semibold">SHA-256</span>
+                  <span className="text-sm text-muted-foreground">key hashes</span>
+                </div>
               </div>
-            ))}
-            <Separator />
-            <div className="grid grid-cols-2 gap-3">
-              <div className="flex flex-col gap-1">
-                <span className="text-2xl font-semibold">21</span>
-                <span className="text-sm text-muted-foreground">char IDs</span>
-              </div>
-              <div className="flex flex-col gap-1">
-                <span className="text-2xl font-semibold">SHA-256</span>
-                <span className="text-sm text-muted-foreground">key hashes</span>
-              </div>
-            </div>
-          </CardContent>
-          <CardFooter>
-            <p className="text-sm text-muted-foreground">
-              Built for agents that need stable memory across deploys, sessions, and frameworks.
-            </p>
-          </CardFooter>
-        </Card>
+            </CardContent>
+            <CardFooter>
+              <p className="text-sm text-muted-foreground">
+                Built for agents that need stable memory across deploys, sessions, and frameworks.
+              </p>
+            </CardFooter>
+          </Card>
+        </MotionDiv>
       </div>
-    </section>
+    </MotionSection>
   );
 }

--- a/packages/dashboard/src/app/dashboard/conversations/_hooks.ts
+++ b/packages/dashboard/src/app/dashboard/conversations/_hooks.ts
@@ -1,3 +1,3 @@
 export type { Conversation } from "./_use-conversations-data";
-export { _useConversationsData } from "./_use-conversations-data";
-export { _useConversationsPagination } from "./_use-conversations-pagination";
+export { useConversationsData } from "./_use-conversations-data";
+export { useConversationsPagination } from "./_use-conversations-pagination";

--- a/packages/dashboard/src/app/dashboard/conversations/_use-conversations-data.ts
+++ b/packages/dashboard/src/app/dashboard/conversations/_use-conversations-data.ts
@@ -22,7 +22,7 @@ interface UseConversationsDataActions {
 
 export type UseConversationsDataResult = UseConversationsDataState & UseConversationsDataActions;
 
-export function _useConversationsData(): UseConversationsDataResult {
+export function useConversationsData(): UseConversationsDataResult {
   const [projects, setProjects] = useState<ProjectResponse[]>([]);
   const [selectedProjectId, setSelectedProjectId] = useState<string>("");
   const [conversations, setConversations] = useState<Conversation[]>([]);

--- a/packages/dashboard/src/app/dashboard/conversations/_use-conversations-pagination.ts
+++ b/packages/dashboard/src/app/dashboard/conversations/_use-conversations-pagination.ts
@@ -8,7 +8,7 @@ interface UseConversationsPaginationResult {
   loadMore: () => void;
 }
 
-export function _useConversationsPagination(
+export function useConversationsPagination(
   selectedProjectId: string,
   conversations: Conversation[],
   appendConversations: (newConversations: Conversation[]) => void,

--- a/packages/dashboard/src/app/dashboard/conversations/page.tsx
+++ b/packages/dashboard/src/app/dashboard/conversations/page.tsx
@@ -10,7 +10,7 @@ import {
   _LoadMoreButton,
   _ProjectSelector,
 } from "./_components";
-import { _useConversationsData, _useConversationsPagination } from "./_hooks";
+import { useConversationsData, useConversationsPagination } from "./_hooks";
 
 // ---------------------------------------------------------------------------
 // Page
@@ -29,9 +29,9 @@ export default function ConversationsPage() {
     setSelectedProjectId,
     appendConversations,
     setHasMore,
-  } = _useConversationsData();
+  } = useConversationsData();
 
-  const { isLoadingMore, loadMore } = _useConversationsPagination(
+  const { isLoadingMore, loadMore } = useConversationsPagination(
     selectedProjectId,
     conversations,
     appendConversations,

--- a/packages/dashboard/src/app/dashboard/domains/_verification-method.tsx
+++ b/packages/dashboard/src/app/dashboard/domains/_verification-method.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { _VerificationRecord } from "./_verification-record";
+import { VerificationRecord } from "./_verification-record";
 
 interface VerificationMethodProps {
   title: string;
@@ -15,7 +15,7 @@ export function _VerificationMethod({ title, description, records }: Verificatio
       <p className="text-sm text-muted-foreground mb-3">{description}</p>
       <div className="space-y-2">
         {records.map((record) => (
-          <_VerificationRecord key={record.label} {...record} />
+          <VerificationRecord key={record.label} {...record} />
         ))}
       </div>
     </div>

--- a/packages/dashboard/src/app/dashboard/domains/_verification-record.tsx
+++ b/packages/dashboard/src/app/dashboard/domains/_verification-record.tsx
@@ -10,7 +10,7 @@ interface VerificationRecordProps {
   copy: string;
 }
 
-export function _VerificationRecord({ label, value, copy }: VerificationRecordProps) {
+export function VerificationRecord({ label, value, copy }: VerificationRecordProps) {
   const { copied, copy: copyToClipboard } = useCopiedText();
   return (
     <div className="flex items-center gap-2">

--- a/packages/dashboard/src/app/dashboard/project/_components.tsx
+++ b/packages/dashboard/src/app/dashboard/project/_components.tsx
@@ -4,25 +4,25 @@ export { CONVERSATION_COLUMNS } from "./_conversation-row";
 export { _ConversationsEmptyState } from "./_conversations-empty-state";
 export { _CreatedKeyDisplay } from "./_created-key-display";
 export { _DataTab } from "./_data-tab";
-export { _useDataTabState } from "./_data-tab-state";
+export { useDataTabState } from "./_data-tab-state";
 // Re-export existing dependencies
 export { KeysTab as _KeysTab } from "./_keys-tab";
-export { _useKeysTabState } from "./_keys-tab-state";
+export { useKeysTabState } from "./_keys-tab-state";
 // Re-export loading state component
 export { _ProjectLoadingState } from "./_loading-state";
 export { _PageHeader } from "./_page-header";
 export { _ProjectDetails } from "./_project-details";
 export { _ProjectSettings } from "./_project-settings";
-export { _RetentionSettings } from "./_retention-settings";
 export { _QuickStartCode } from "./_quick-start-code";
+export { RetentionSettings } from "./_retention-settings";
 export { _StatCard } from "./_stat-card";
 export { _StatsGrid } from "./_stats-grid";
 export { _TabTrigger } from "./_tab-trigger";
 export type { ColumnKey } from "./_types";
 // Re-export hooks
-export { _useComputedStats } from "./_use-computed-stats";
-export { _useConversationActions } from "./_use-conversation-actions";
-export { _useDeleteProject } from "./_use-delete-project";
-export { _useKeyActions } from "./_use-key-actions";
-export { _useNewKeyStorage } from "./_use-new-key-storage";
-export { _useProjectData } from "./_use-project-data";
+export { useComputedStats } from "./_use-computed-stats";
+export { useConversationActions } from "./_use-conversation-actions";
+export { useDeleteProject } from "./_use-delete-project";
+export { useKeyActions } from "./_use-key-actions";
+export { useNewKeyStorage } from "./_use-new-key-storage";
+export { useProjectData } from "./_use-project-data";

--- a/packages/dashboard/src/app/dashboard/project/_conversation-cell-renderers.tsx
+++ b/packages/dashboard/src/app/dashboard/project/_conversation-cell-renderers.tsx
@@ -16,7 +16,9 @@ export function renderConversationCell(conv: Conversation, col: ColumnKey): Reac
     case "token_count":
       return <span className="tabular-nums">{conv.token_count.toLocaleString()}</span>;
     case "total_cost":
-      return <span className="tabular-nums">{formatCostMicrodollars(conv.total_cost_microdollars)}</span>;
+      return (
+        <span className="tabular-nums">{formatCostMicrodollars(conv.total_cost_microdollars)}</span>
+      );
     case "total_tokens":
       return <span className="tabular-nums">{conv.total_tokens.toLocaleString()}</span>;
     case "metadata":

--- a/packages/dashboard/src/app/dashboard/project/_data-tab-state.ts
+++ b/packages/dashboard/src/app/dashboard/project/_data-tab-state.ts
@@ -1,9 +1,15 @@
 import { useState } from "react";
 import type { ColumnKey } from "./_components";
 
-const DEFAULT_COLUMNS: ColumnKey[] = ["title", "message_count", "token_count", "total_cost", "updated_at"];
+const DEFAULT_COLUMNS: ColumnKey[] = [
+  "title",
+  "message_count",
+  "token_count",
+  "total_cost",
+  "updated_at",
+];
 
-export function _useDataTabState() {
+export function useDataTabState() {
   const [visibleCols, setVisibleCols] = useState<ColumnKey[]>(DEFAULT_COLUMNS);
   const [showColPicker, setShowColPicker] = useState(false);
 

--- a/packages/dashboard/src/app/dashboard/project/_data-tab.tsx
+++ b/packages/dashboard/src/app/dashboard/project/_data-tab.tsx
@@ -2,8 +2,8 @@
 
 import type { ConversationResponse, MessageResponse } from "@agentstate/shared";
 import { ColumnPicker } from "./_column-picker";
-import { ConversationsHeader, ConversationsContent } from "./data-tab";
 import type { ColumnKey } from "./_types";
+import { ConversationsContent, ConversationsHeader } from "./data-tab";
 
 type Conversation = ConversationResponse;
 type Message = MessageResponse;
@@ -52,11 +52,7 @@ export function _DataTab({
         onToggleColPicker={onToggleColPicker}
       />
       {showColPicker && (
-        <ColumnPicker
-          allColumns={allColumns}
-          visible={visibleCols}
-          onChange={onChangeColumns}
-        />
+        <ColumnPicker allColumns={allColumns} visible={visibleCols} onChange={onChangeColumns} />
       )}
       <ConversationsContent
         loading={convsLoading}

--- a/packages/dashboard/src/app/dashboard/project/_keys-tab-state.ts
+++ b/packages/dashboard/src/app/dashboard/project/_keys-tab-state.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-export function _useKeysTabState() {
+export function useKeysTabState() {
   const [showCreateKey, setShowCreateKey] = useState(false);
   const [newKeyName, setNewKeyName] = useState("");
 

--- a/packages/dashboard/src/app/dashboard/project/_project-settings.tsx
+++ b/packages/dashboard/src/app/dashboard/project/_project-settings.tsx
@@ -2,7 +2,7 @@ import type { ProjectDetailResponse } from "@agentstate/shared";
 import { DeleteConfirmation } from "./_delete-confirmation";
 import { _ProjectDetails } from "./_project-details";
 import { _QuickStartCode } from "./_quick-start-code";
-import { _RetentionSettings } from "./_retention-settings";
+import { RetentionSettings } from "./_retention-settings";
 
 interface ProjectSettingsProps {
   project: ProjectDetailResponse;
@@ -25,7 +25,7 @@ export function _ProjectSettings({
     <div className="space-y-6">
       <_QuickStartCode />
       <_ProjectDetails project={project} />
-      <_RetentionSettings project={project} onUpdated={onProjectUpdated} />
+      <RetentionSettings project={project} onUpdated={onProjectUpdated} />
       <DeleteConfirmation
         projectName={project.name}
         projectSlug={project.slug}

--- a/packages/dashboard/src/app/dashboard/project/_retention-settings.tsx
+++ b/packages/dashboard/src/app/dashboard/project/_retention-settings.tsx
@@ -3,16 +3,16 @@
 import type { ProjectDetailResponse } from "@agentstate/shared";
 import { useState } from "react";
 import { toast } from "sonner";
-import { api } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { api } from "@/lib/api";
 
 interface RetentionSettingsProps {
   project: ProjectDetailResponse;
   onUpdated: (updated: ProjectDetailResponse) => void;
 }
 
-export function _RetentionSettings({ project, onUpdated }: RetentionSettingsProps) {
+export function RetentionSettings({ project, onUpdated }: RetentionSettingsProps) {
   const [retentionDays, setRetentionDays] = useState<string>(
     project.retention_days != null ? String(project.retention_days) : "",
   );
@@ -26,7 +26,10 @@ export function _RetentionSettings({ project, onUpdated }: RetentionSettingsProp
     const trimmed = retentionDays.trim();
     const value = trimmed === "" ? null : Number(trimmed);
 
-    if (value !== null && (Number.isNaN(value) || !Number.isInteger(value) || value < 1 || value > 3650)) {
+    if (
+      value !== null &&
+      (Number.isNaN(value) || !Number.isInteger(value) || value < 1 || value > 3650)
+    ) {
       toast.error("Retention must be between 1 and 3650 days, or empty for infinite.");
       return;
     }

--- a/packages/dashboard/src/app/dashboard/project/_use-computed-stats.ts
+++ b/packages/dashboard/src/app/dashboard/project/_use-computed-stats.ts
@@ -11,7 +11,7 @@ interface UseComputedStatsResult {
   totalTokens: number;
 }
 
-export function _useComputedStats(
+export function useComputedStats(
   project: ProjectDetail | null,
   conversations: Conversation[],
 ): UseComputedStatsResult {

--- a/packages/dashboard/src/app/dashboard/project/_use-conversation-actions.ts
+++ b/packages/dashboard/src/app/dashboard/project/_use-conversation-actions.ts
@@ -6,7 +6,7 @@ import { api } from "@/lib/api";
 type ProjectDetail = ProjectDetailResponse;
 type Message = MessageResponse;
 
-export function _useConversationActions(project: ProjectDetail | null) {
+export function useConversationActions(project: ProjectDetail | null) {
   const [expandedConv, setExpandedConv] = useState<string | null>(null);
   const [messagesCache, setMessagesCache] = useState<Record<string, Message[]>>({});
   const [loadingMessages, setLoadingMessages] = useState<Record<string, boolean>>({});

--- a/packages/dashboard/src/app/dashboard/project/_use-delete-project.ts
+++ b/packages/dashboard/src/app/dashboard/project/_use-delete-project.ts
@@ -6,7 +6,7 @@ import { api } from "@/lib/api";
 
 type ProjectDetail = ProjectDetailResponse;
 
-export function _useDeleteProject(project: ProjectDetail | null) {
+export function useDeleteProject(project: ProjectDetail | null) {
   const router = useRouter();
   const [deleteConfirmSlug, setDeleteConfirmSlug] = useState("");
   const [deleting, setDeleting] = useState(false);

--- a/packages/dashboard/src/app/dashboard/project/_use-key-actions.ts
+++ b/packages/dashboard/src/app/dashboard/project/_use-key-actions.ts
@@ -10,7 +10,7 @@ interface UseKeyActionsProps {
   onProjectRefresh: () => Promise<void>;
 }
 
-export function _useKeyActions({ project, onKeyCreated, onProjectRefresh }: UseKeyActionsProps) {
+export function useKeyActions({ project, onKeyCreated, onProjectRefresh }: UseKeyActionsProps) {
   const handleCreateKey = useCallback(
     async (keyName: string) => {
       if (!keyName.trim() || !project) return false;

--- a/packages/dashboard/src/app/dashboard/project/_use-new-key-storage.ts
+++ b/packages/dashboard/src/app/dashboard/project/_use-new-key-storage.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-export function _useNewKeyStorage(slug: string | null) {
+export function useNewKeyStorage(slug: string | null) {
   const [createdKey, setCreatedKey] = useState<string | null>(null);
 
   useEffect(() => {

--- a/packages/dashboard/src/app/dashboard/project/_use-project-data.ts
+++ b/packages/dashboard/src/app/dashboard/project/_use-project-data.ts
@@ -16,7 +16,7 @@ interface UseProjectDataResult {
   refreshProject: () => Promise<void>;
 }
 
-export function _useProjectData(slug: string | null): UseProjectDataResult {
+export function useProjectData(slug: string | null): UseProjectDataResult {
   const [project, setProject] = useState<ProjectDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [conversations, setConversations] = useState<Conversation[]>([]);

--- a/packages/dashboard/src/app/dashboard/project/data-tab/conversations-content.tsx
+++ b/packages/dashboard/src/app/dashboard/project/data-tab/conversations-content.tsx
@@ -1,9 +1,9 @@
 import type { ConversationResponse, MessageResponse } from "@agentstate/shared";
 import { DataTable } from "@/components/dashboard/data-table";
 import { ConversationRowSkeleton } from "@/components/dashboard/loading-states";
-import type { ColumnKey } from "../_types";
 import { ConversationRow } from "../_conversation-row";
 import { _ConversationsEmptyState } from "../_conversations-empty-state";
+import type { ColumnKey } from "../_types";
 
 type Conversation = ConversationResponse;
 type Message = MessageResponse;

--- a/packages/dashboard/src/app/dashboard/project/data-tab/index.ts
+++ b/packages/dashboard/src/app/dashboard/project/data-tab/index.ts
@@ -1,2 +1,2 @@
-export { ConversationsHeader } from "./conversations-header";
 export { ConversationsContent } from "./conversations-content";
+export { ConversationsHeader } from "./conversations-header";

--- a/packages/dashboard/src/app/dashboard/project/page.tsx
+++ b/packages/dashboard/src/app/dashboard/project/page.tsx
@@ -15,15 +15,15 @@ import {
   _TabTrigger,
   CONVERSATION_COLUMNS,
 } from "./_components";
-import { _useDataTabState } from "./_data-tab-state";
-import { _useKeysTabState } from "./_keys-tab-state";
+import { useDataTabState } from "./_data-tab-state";
+import { useKeysTabState } from "./_keys-tab-state";
 import { _ProjectLoadingState } from "./_loading-state";
-import { _useComputedStats } from "./_use-computed-stats";
-import { _useConversationActions } from "./_use-conversation-actions";
-import { _useDeleteProject } from "./_use-delete-project";
-import { _useKeyActions } from "./_use-key-actions";
-import { _useNewKeyStorage } from "./_use-new-key-storage";
-import { _useProjectData } from "./_use-project-data";
+import { useComputedStats } from "./_use-computed-stats";
+import { useConversationActions } from "./_use-conversation-actions";
+import { useDeleteProject } from "./_use-delete-project";
+import { useKeyActions } from "./_use-key-actions";
+import { useNewKeyStorage } from "./_use-new-key-storage";
+import { useProjectData } from "./_use-project-data";
 
 function ProjectContent() {
   const params = useSearchParams();
@@ -31,15 +31,15 @@ function ProjectContent() {
   const { copied, copy } = useCopiedText();
 
   // Data fetching
-  const { project, loading, conversations, convsLoading, refreshProject } = _useProjectData(slug);
+  const { project, loading, conversations, convsLoading, refreshProject } = useProjectData(slug);
 
   // UI state
-  const { createdKey, setCreatedKey } = _useNewKeyStorage(slug);
-  const keysTab = _useKeysTabState();
-  const dataTab = _useDataTabState();
+  const { createdKey, setCreatedKey } = useNewKeyStorage(slug);
+  const keysTab = useKeysTabState();
+  const dataTab = useDataTabState();
 
   // Actions
-  const keyActions = _useKeyActions({
+  const keyActions = useKeyActions({
     project,
     onKeyCreated: (key) => {
       setCreatedKey(key);
@@ -48,12 +48,12 @@ function ProjectContent() {
     onProjectRefresh: refreshProject,
   });
   const { expandedConv, messagesCache, loadingMessages, toggleConversation } =
-    _useConversationActions(project);
+    useConversationActions(project);
   const { deleteConfirmSlug, deleting, setDeleteConfirmSlug, handleDeleteProject } =
-    _useDeleteProject(project);
+    useDeleteProject(project);
 
   // Computed stats
-  const { activeKeys, totalConvs, totalMessages, totalTokens } = _useComputedStats(
+  const { activeKeys, totalConvs, totalMessages, totalTokens } = useComputedStats(
     project,
     conversations,
   );
@@ -89,7 +89,9 @@ function ProjectContent() {
             deleting={deleting}
             onDeleteConfirm={setDeleteConfirmSlug}
             onDelete={handleDeleteProject}
-            onProjectUpdated={async () => { await refreshProject(); }}
+            onProjectUpdated={async () => {
+              await refreshProject();
+            }}
           />
         </TabsContent>
 

--- a/packages/dashboard/src/app/dashboard/project/page.tsx
+++ b/packages/dashboard/src/app/dashboard/project/page.tsx
@@ -31,7 +31,8 @@ function ProjectContent() {
   const { copied, copy } = useCopiedText();
 
   // Data fetching
-  const { project, loading, conversations, convsLoading, refreshProject } = useProjectData(slug);
+  const { project, loading, conversations, convsLoading, setProject, refreshProject } =
+    useProjectData(slug);
 
   // UI state
   const { createdKey, setCreatedKey } = useNewKeyStorage(slug);
@@ -89,9 +90,7 @@ function ProjectContent() {
             deleting={deleting}
             onDeleteConfirm={setDeleteConfirmSlug}
             onDelete={handleDeleteProject}
-            onProjectUpdated={async () => {
-              await refreshProject();
-            }}
+            onProjectUpdated={(updated) => setProject(updated)}
           />
         </TabsContent>
 

--- a/packages/dashboard/src/app/dashboard/settings/organizations/members/_components.tsx
+++ b/packages/dashboard/src/app/dashboard/settings/organizations/members/_components.tsx
@@ -1,8 +1,8 @@
 // Re-export all members components
 
 export type { Role } from "./_invite-member-form";
-export { _InviteMemberForm } from "./_invite-member-form";
-export { _MembersList } from "./_members-list";
+export { InviteMemberForm } from "./_invite-member-form";
+export { MembersList } from "./_members-list";
 export { _MembersSkeleton } from "./_members-skeleton";
 export { _PageHeader } from "./_page-header";
 export { _PendingInvitationsList } from "./_pending-invitations-list";

--- a/packages/dashboard/src/app/dashboard/settings/organizations/members/_invite-member-form.tsx
+++ b/packages/dashboard/src/app/dashboard/settings/organizations/members/_invite-member-form.tsx
@@ -14,12 +14,12 @@ import {
 
 export type Role = "org:member" | "org:admin";
 
-export interface _InviteMemberFormProps {
+export interface InviteMemberFormProps {
   readonly isInviting: boolean;
   readonly onInvite: (email: string, role: Role) => Promise<void>;
 }
 
-export function _InviteMemberForm({ isInviting, onInvite }: _InviteMemberFormProps) {
+export function InviteMemberForm({ isInviting, onInvite }: InviteMemberFormProps) {
   const [emailAddress, setEmailAddress] = React.useState("");
   const [selectedRole, setSelectedRole] = React.useState<Role>("org:member");
 

--- a/packages/dashboard/src/app/dashboard/settings/organizations/members/_members-list.tsx
+++ b/packages/dashboard/src/app/dashboard/settings/organizations/members/_members-list.tsx
@@ -5,7 +5,7 @@ import { MemberCell } from "./_member-cell";
 import { MemberListCard } from "./_member-list-card";
 import { RoleBadge } from "./_role-badge";
 
-export interface _MembersListProps {
+export interface MembersListProps {
   readonly isLoading: boolean;
   readonly members: Array<{
     readonly id: string;
@@ -19,7 +19,7 @@ export interface _MembersListProps {
   readonly count?: number;
 }
 
-export function _MembersList({ isLoading, members, count }: _MembersListProps) {
+export function MembersList({ isLoading, members, count }: MembersListProps) {
   const memberData = React.useMemo(
     () =>
       members

--- a/packages/dashboard/src/app/dashboard/settings/organizations/members/page.tsx
+++ b/packages/dashboard/src/app/dashboard/settings/organizations/members/page.tsx
@@ -5,11 +5,11 @@ import * as React from "react";
 import { toast } from "sonner";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
-  _InviteMemberForm,
-  _MembersList,
   _MembersSkeleton,
   _PageHeader,
   _PendingInvitationsList,
+  InviteMemberForm,
+  MembersList,
 } from "./_components";
 import { useInviteMember } from "./_use-invite-member";
 
@@ -72,8 +72,8 @@ export default function OrganizationMembersPage() {
   return (
     <div className="space-y-6">
       <_PageHeader organizationName={organization.name} />
-      <_InviteMemberForm isInviting={isInviting} onInvite={inviteMember} />
-      <_MembersList
+      <InviteMemberForm isInviting={isInviting} onInvite={inviteMember} />
+      <MembersList
         isLoading={memberships?.isLoading ?? false}
         members={memberships?.data ?? null}
         count={memberships?.count}

--- a/packages/dashboard/src/app/page.tsx
+++ b/packages/dashboard/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { Footer } from "@/components/footer";
 import { HowItWorks } from "@/components/landing/how-it-works";
+import { LandingMotionConfig } from "@/components/landing/motion-config";
 import { UseCases } from "@/components/landing/use-cases";
 import { ApiEndpoints } from "./_api-endpoints";
 import { CodeExamples } from "./_code-examples";
@@ -9,19 +10,21 @@ import { Hero } from "./_hero";
 
 export default function LandingPage() {
   return (
-    <div className="min-h-screen bg-background text-foreground flex flex-col">
-      <Header />
+    <LandingMotionConfig>
+      <div className="min-h-screen bg-background text-foreground flex flex-col">
+        <Header />
 
-      <main className="flex-1">
-        <Hero />
-        <Features />
-        <HowItWorks />
-        <UseCases />
-        <CodeExamples />
-        <ApiEndpoints />
-      </main>
+        <main className="flex-1">
+          <Hero />
+          <Features />
+          <HowItWorks />
+          <UseCases />
+          <CodeExamples />
+          <ApiEndpoints />
+        </main>
 
-      <Footer />
-    </div>
+        <Footer />
+      </div>
+    </LandingMotionConfig>
   );
 }

--- a/packages/dashboard/src/components/analytics/area-chart.tsx
+++ b/packages/dashboard/src/components/analytics/area-chart.tsx
@@ -53,9 +53,7 @@ const createTooltip = (valueLabel: string, formatValue?: (value: number) => stri
     contentStyle={CHART_TOOLTIP_STYLE}
     labelFormatter={(label) => formatDateLabel(String(label))}
     formatter={(value) =>
-      formatValue
-        ? [formatValue(Number(value)), valueLabel]
-        : formatTooltipValue(value, valueLabel)
+      formatValue ? [formatValue(Number(value)), valueLabel] : formatTooltipValue(value, valueLabel)
     }
   />
 );

--- a/packages/dashboard/src/components/analytics/summary-cards.tsx
+++ b/packages/dashboard/src/components/analytics/summary-cards.tsx
@@ -23,7 +23,13 @@ export function SummaryCards({
     { icon: HashIcon, label: "Messages", value: totalMessages.toLocaleString() },
     { icon: CoinsIcon, label: "Tokens", value: totalTokens.toLocaleString() },
     ...(totalCostMicrodollars != null
-      ? [{ icon: DollarSignIcon, label: "Total Cost", value: formatCostMicrodollars(totalCostMicrodollars) }]
+      ? [
+          {
+            icon: DollarSignIcon,
+            label: "Total Cost",
+            value: formatCostMicrodollars(totalCostMicrodollars),
+          },
+        ]
       : []),
     { icon: KeyIcon, label: "API Keys", value: activeApiKeys },
   ];

--- a/packages/dashboard/src/components/landing/how-it-works.tsx
+++ b/packages/dashboard/src/components/landing/how-it-works.tsx
@@ -1,4 +1,12 @@
 import { DatabaseIcon, type LucideIcon, SearchIcon, SendIcon } from "lucide-react";
+import {
+  landingCard,
+  landingContainer,
+  landingHover,
+  landingItem,
+  MotionDiv,
+  MotionSection,
+} from "@/components/landing/motion";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
@@ -36,39 +44,46 @@ const steps: readonly Step[] = [
 
 export function HowItWorks() {
   return (
-    <section className="max-w-5xl mx-auto px-6 pb-20">
+    <MotionSection
+      className="max-w-5xl mx-auto px-6 pb-20"
+      animate="visible"
+      initial="hidden"
+      variants={landingContainer}
+    >
       <div className="flex flex-col gap-6">
-        <div className="flex flex-col gap-2">
+        <MotionDiv className="flex flex-col gap-2" variants={landingItem}>
           <h2 className="text-lg font-medium">How it works</h2>
           <p className="max-w-2xl text-sm text-muted-foreground">
             The workflow stays explicit: write context, persist state, read it back when the agent
             needs continuity.
           </p>
-        </div>
-        <div className="grid gap-4 sm:grid-cols-3">
+        </MotionDiv>
+        <MotionDiv className="grid gap-4 sm:grid-cols-3" variants={landingContainer}>
           {steps.map(({ number, title, description, endpoint, icon: Icon }) => (
-            <Card key={number}>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <span className="flex size-8 items-center justify-center rounded-lg bg-muted text-muted-foreground">
-                    <Icon aria-hidden="true" />
-                  </span>
-                  {title}
-                </CardTitle>
-                <CardDescription>
-                  <Badge variant="outline">Step {number}</Badge>
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="flex flex-col gap-4">
-                <p className="text-sm leading-relaxed text-muted-foreground">{description}</p>
-                <code className="truncate rounded-md bg-muted px-3 py-2 font-mono text-sm text-muted-foreground">
-                  {endpoint}
-                </code>
-              </CardContent>
-            </Card>
+            <MotionDiv key={number} variants={landingCard} whileHover={landingHover}>
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <span className="flex size-8 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                      <Icon aria-hidden="true" />
+                    </span>
+                    {title}
+                  </CardTitle>
+                  <CardDescription>
+                    <Badge variant="outline">Step {number}</Badge>
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="flex flex-col gap-4">
+                  <p className="text-sm leading-relaxed text-muted-foreground">{description}</p>
+                  <code className="truncate rounded-md bg-muted px-3 py-2 font-mono text-sm text-muted-foreground">
+                    {endpoint}
+                  </code>
+                </CardContent>
+              </Card>
+            </MotionDiv>
           ))}
-        </div>
+        </MotionDiv>
       </div>
-    </section>
+    </MotionSection>
   );
 }

--- a/packages/dashboard/src/components/landing/motion-config.tsx
+++ b/packages/dashboard/src/components/landing/motion-config.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { MotionConfig } from "motion/react";
+import type { ReactNode } from "react";
+
+type LandingMotionConfigProps = {
+  children: ReactNode;
+};
+
+export function LandingMotionConfig({ children }: LandingMotionConfigProps) {
+  return <MotionConfig reducedMotion="user">{children}</MotionConfig>;
+}

--- a/packages/dashboard/src/components/landing/motion.tsx
+++ b/packages/dashboard/src/components/landing/motion.tsx
@@ -1,0 +1,40 @@
+import {
+  div as MotionDiv,
+  header as MotionHeader,
+  section as MotionSection,
+} from "motion/react-client";
+
+export { MotionDiv, MotionHeader, MotionSection };
+
+export const landingContainer = {
+  hidden: {},
+  visible: {
+    transition: {
+      delayChildren: 0.05,
+      staggerChildren: 0.08,
+    },
+  },
+};
+
+export const landingItem = {
+  hidden: { opacity: 0, y: 18 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.42 },
+  },
+};
+
+export const landingCard = {
+  hidden: { opacity: 0, y: 20 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.42 },
+  },
+};
+
+export const landingHover = {
+  y: -3,
+  transition: { duration: 0.18 },
+};

--- a/packages/dashboard/src/components/landing/use-cases.tsx
+++ b/packages/dashboard/src/components/landing/use-cases.tsx
@@ -38,7 +38,6 @@ export function UseCases() {
                       alt=""
                       width={360}
                       height={180}
-                      loading="eager"
                       className="size-full object-contain"
                       aria-hidden="true"
                     />

--- a/packages/dashboard/src/components/landing/use-cases.tsx
+++ b/packages/dashboard/src/components/landing/use-cases.tsx
@@ -1,46 +1,61 @@
 import Image from "next/image";
+import {
+  landingCard,
+  landingContainer,
+  landingHover,
+  landingItem,
+  MotionDiv,
+  MotionSection,
+} from "@/components/landing/motion";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useCases } from "./use-cases-parts";
 
 export function UseCases() {
   return (
-    <section className="max-w-5xl mx-auto px-6 pb-20">
+    <MotionSection
+      className="max-w-5xl mx-auto px-6 pb-20"
+      animate="visible"
+      initial="hidden"
+      variants={landingContainer}
+    >
       <div className="flex flex-col gap-6">
-        <div className="flex flex-col gap-2">
+        <MotionDiv className="flex flex-col gap-2" variants={landingItem}>
           <h2 className="text-lg font-medium">Use cases</h2>
           <p className="max-w-2xl text-sm text-muted-foreground">
             AgentState is an operational layer for products where every session should become
             queryable product data.
           </p>
-        </div>
-        <div className="grid gap-4 sm:grid-cols-2">
+        </MotionDiv>
+        <MotionDiv className="grid gap-4 sm:grid-cols-2" variants={landingContainer}>
           {useCases.map((useCase) => (
-            <Card key={useCase.title}>
-              <CardContent>
-                <div className="flex aspect-[2/1] items-center justify-center rounded-lg bg-muted">
-                  <Image
-                    src={useCase.image}
-                    alt=""
-                    width={360}
-                    height={180}
-                    loading="eager"
-                    className="size-full object-contain"
-                    aria-hidden="true"
-                  />
-                </div>
-              </CardContent>
-              <CardHeader>
-                <CardTitle>{useCase.title}</CardTitle>
-                <CardDescription className="flex flex-col gap-2">
-                  <Badge variant="secondary">{useCase.tag}</Badge>
-                  <span>{useCase.description}</span>
-                </CardDescription>
-              </CardHeader>
-            </Card>
+            <MotionDiv key={useCase.title} variants={landingCard} whileHover={landingHover}>
+              <Card>
+                <CardContent>
+                  <div className="flex aspect-[2/1] items-center justify-center rounded-lg bg-muted">
+                    <Image
+                      src={useCase.image}
+                      alt=""
+                      width={360}
+                      height={180}
+                      loading="eager"
+                      className="size-full object-contain"
+                      aria-hidden="true"
+                    />
+                  </div>
+                </CardContent>
+                <CardHeader>
+                  <CardTitle>{useCase.title}</CardTitle>
+                  <CardDescription className="flex flex-col gap-2">
+                    <Badge variant="secondary">{useCase.tag}</Badge>
+                    <span>{useCase.description}</span>
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+            </MotionDiv>
           ))}
-        </div>
+        </MotionDiv>
       </div>
-    </section>
+    </MotionSection>
   );
 }


### PR DESCRIPTION
## Summary
- add Motion/Framer Motion wrappers to the AgentState homepage with reduced-motion support
- keep the shadcn-native landing composition while adding section/card motion
- expose agents.md in dashboard static output and clean dashboard Biome hook naming/formatting

## Verification
- bunx biome check packages/dashboard/src/
- cd packages/dashboard && bunx tsc --noEmit
- cd packages/dashboard && bun run build
- browser QA on local built output: desktop/mobile, light/dark, dashboard/docs/agents.md CTAs

## Summary by Sourcery

Add animated motion to the dashboard landing page while cleaning up dashboard hooks/components and exposing the agents.md content in the static output.

New Features:
- Introduce motion-based sections and cards across the landing page (hero, features, how-it-works, use-cases, code examples, API endpoints) with reduced-motion support via a shared motion config.
- Expose the agents.md documentation file via the dashboard’s public assets and wire CTAs to the static markdown output.

Enhancements:
- Refine dashboard hooks and components by renaming and re-exporting them without leading underscores for clearer public usage.
- Update dashboard project, conversations, domains, and organization members screens to use the new hook/component names and simplify some layout/formatting.
- Add shared landing motion utilities for consistent entrance and hover animations across homepage sections.

Build:
- Add the motion library dependency to the dashboard package for React-based animations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added smooth animations and transitions to landing page components (hero, features, how-it-works, use cases, code examples, and API endpoints).
  * Added new agents documentation.

* **Bug Fixes & Improvements**
  * Enhanced motion and animation performance across dashboard UI.
  * Refined styling and layout refinements for improved visual consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/agentstate/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->