### PR TITLE
feat(sdk): add framework state adapters

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -191,54 +191,97 @@ export class ChatAgent extends Agent<Env> {
 
 ---
 
+## AI SDK UI chat store
+
+Persist full `UIMessage[]` payloads directly in AgentState v2 state.
+
+```typescript
+import { AgentState } from "@agentstate/sdk";
+import { createAISDKChatStore } from "@agentstate/sdk/ai-sdk";
+
+const agentState = new AgentState({
+  apiKey: process.env.AGENTSTATE_API_KEY!,
+});
+
+const chatStore = createAISDKChatStore(agentState, {
+  stateKeyPrefix: "agentstate/ai-sdk/chat",
+});
+
+const chatId = await chatStore.createChat();
+await chatStore.saveChat({
+  chatId,
+  messages: [{ id: "m1", role: "user", content: "Hi there" }],
+});
+```
+
+## AI SDK RSC state store
+
+Use `@agentstate/sdk/ai-sdk` in Vercel AI RSC flows to persist full UI state and UI messages as v2 state payloads.
+
+```typescript
+import { createAISDKRSCStateStore } from "@agentstate/sdk/ai-sdk";
+import { AgentState } from "@agentstate/sdk";
+
+const agentState = new AgentState({
+  apiKey: process.env.AGENTSTATE_API_KEY!,
+});
+
+const rscStore = createAISDKRSCStateStore(agentState, {
+  stateKeyPrefix: "agentstate/ai-sdk/rsc",
+  stateKey: "thread-1",
+  mapAIStateToUIMessages: (state) => {
+    if (!state) return [];
+    const lastAiMessage = state?.lastMessage;
+    return lastAiMessage
+      ? [{ id: "state-msg", role: "assistant", content: String(lastAiMessage) }]
+      : [];
+  },
+});
+
+export const saveAIState = async () => {
+  await rscStore.onSetAIState({
+    state: { step: "next" },
+    done: true,
+  });
+};
+```
+
+## LangGraph (JavaScript)
+
+```typescript
+import { AgentState } from "@agentstate/sdk";
+import { AgentStateCheckpointSaver } from "@agentstate/sdk/langgraph";
+
+const client = new AgentState({ apiKey: process.env.AGENTSTATE_API_KEY! });
+const saver = new AgentStateCheckpointSaver(client);
+
+await saver.put(
+  { configurable: { thread_id: "thread-1", checkpoint_ns: "" } },
+  { id: "cp-1", values: {} },
+  { step: 0 },
+  {},
+);
+
+await saver.putWrites(
+  { configurable: { thread_id: "thread-1", checkpoint_id: "cp-1" } },
+  [["messages", [{ role: "assistant", content: "hello" }]]],
+  "main",
+);
+```
+
 ## LangGraph (Python)
 
-Use a custom checkpointer class with raw HTTP requests (no Python SDK yet).
-
 ```python
-import httpx
+from agentstate import AgentStateClient
+from agentstate.langgraph import AgentStateCheckpointSaver
 
-AGENTSTATE_URL = "https://agentstate.app/api"
+client = AgentStateClient(api_key="as_live_...")
+saver = AgentStateCheckpointSaver(client)
 
-
-class AgentStateSaver:
-    """LangGraph-compatible saver that persists conversations to AgentState."""
-
-    def __init__(self, api_key: str, base_url: str = AGENTSTATE_URL):
-        self.client = httpx.Client(
-            base_url=base_url,
-            headers={"Authorization": f"Bearer {api_key}"},
-        )
-
-    def save(self, conversation_id: str | None, messages: list[dict]) -> str:
-        if conversation_id is None:
-            resp = self.client.post("/v1/conversations", json={"messages": messages})
-            return resp.json()["id"]
-        self.client.post(
-            f"/v1/conversations/{conversation_id}/messages",
-            json={"messages": messages},
-        )
-        return conversation_id
-
-    def load(self, conversation_id: str) -> list[dict]:
-        resp = self.client.get(f"/v1/conversations/{conversation_id}")
-        return resp.json()["messages"]
-
-    def delete(self, conversation_id: str):
-        self.client.delete(f"/v1/conversations/{conversation_id}")
-
-
-# Usage with LangGraph
-saver = AgentStateSaver(api_key="as_live_...")
-
-# Save after each agent step
-conv_id = saver.save(None, [
-    {"role": "user", "content": "Plan a trip to Tokyo"},
-    {"role": "assistant", "content": "I'll help you plan a trip to Tokyo..."},
-])
-
-# Resume later
-history = saver.load(conv_id)
+config = {"configurable": {"thread_id": "thread-1", "checkpoint_ns": ""}}
+checkpoint = {"id": "cp-1", "values": {}}
+metadata = {"step": 0}
+new_config = saver.put(config, checkpoint, metadata, {})
 ```
 
 ---

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -46,6 +46,17 @@ The SDK uses the standard `fetch` API with no platform-specific dependencies. It
 | `generateTitle(id)` | `{ title: string }` | AI-generated title from message content |
 | `generateFollowUps(id)` | `{ questions: string[] }` | AI-generated follow-up questions |
 | `exportConversations(ids?)` | `{ data: ConversationWithMessages[], count: number }` | Bulk export (all or by IDs) |
+| `upsertState(stateKey, data, options?)` | `StateRecord` | Create/replace `/v2/states/{state_key}` |
+| `getState(stateKey, params?)` | `StateRecord` | Read latest or historical state |
+| `queryStates(query?)` | `StateListResponse<StateRecord>` | Query v2 states with tags/filters |
+| `deleteState(stateKey, params?)` | `{ deleted: true; event: StateEvent }` | Delete v2 state |
+| `listStateEvents(stateKey, params?, options?)` | `StateListResponse<StateEvent>` | Read state event stream |
+| `createStateLease(stateKey, data)` | `StateLease` | Create state lease |
+| `renewStateLease(id, data, options?)` | `StateLease` | Renew lease with `ttl_ms` |
+| `releaseStateLease(id, options?)` | `void` | Release lease |
+| `createCapabilityToken(data)` | `CapabilityTokenCreated` | Create v2 capability token |
+| `listCapabilityTokens()` | `CapabilityTokenListResponse` | List tokens |
+| `revokeCapabilityToken(id)` | `void` | Revoke token |
 
 ### Parameter Details
 
@@ -195,6 +206,11 @@ The following operations are available through the [REST API](./api-reference.md
 - **Public analytics summary** — `GET /v1/analytics/summary`
 - **Public analytics timeseries** — `GET /v1/analytics/timeseries`
 - **Public analytics tags** — `GET /v1/analytics/tags`
+
+The following state-framework adapters are available in subpaths:
+
+- `@agentstate/sdk/ai-sdk` — `createAISDKChatStore`, `createAISDKRSCStateStore`
+- `@agentstate/sdk/langgraph` — `AgentStateCheckpointSaver`
 
 Use the REST API directly for these. See the [API Reference](./api-reference.md) for details.
 

--- a/examples/ai-sdk-rsc/README.md
+++ b/examples/ai-sdk-rsc/README.md
@@ -1,0 +1,38 @@
+# AI SDK RSC State Store Example
+
+Persist RSC AI state and UI messages with `createAISDKRSCStateStore`.
+
+```ts
+import { AgentState } from "@agentstate/sdk";
+import { createAISDKRSCStateStore } from "@agentstate/sdk/ai-sdk";
+
+const client = new AgentState({
+  apiKey: process.env.AGENTSTATE_API_KEY!,
+});
+
+const store = createAISDKRSCStateStore(client, {
+  stateKeyPrefix: "agentstate/ai-sdk/rsc",
+  stateKey: "thread-1",
+  mapAIStateToUIMessages: (state) => {
+    if (!state) return [];
+    const nextState = state.next;
+    return nextState ? [{ id: "state-msg", role: "assistant", content: String(nextState) }] : [];
+  },
+});
+
+export async function saveState(state: { next?: string } | null) {
+  await store.saveAIState(state);
+}
+
+export async function onFinish(state: { next?: string } | null) {
+  await store.onSetAIState({ state, done: true });
+}
+
+export async function getUiState() {
+  return store.onGetUIState();
+}
+```
+
+Production guidance:
+- This is useful for server-rendered RSC handlers.
+- For AI SDK experimental RSC adapters, keep this in server code and pass through server actions.

--- a/examples/ai-sdk-ui/README.md
+++ b/examples/ai-sdk-ui/README.md
@@ -1,0 +1,39 @@
+# AI SDK UI Message Store Example
+
+Persist `UIMessage[]` in AgentState v2 state using `createAISDKChatStore`.
+
+```ts
+import { AgentState } from "@agentstate/sdk";
+import { createAISDKChatStore } from "@agentstate/sdk/ai-sdk";
+
+const client = new AgentState({
+  apiKey: process.env.AGENTSTATE_API_KEY!,
+});
+
+const store = createAISDKChatStore(client, {
+  stateKeyPrefix: "agentstate/ai-sdk/chat",
+});
+
+export async function createChat() {
+  const chatId = await store.createChat();
+  await store.saveChat({
+    chatId,
+    messages: [{ id: "m1", role: "user", content: "Hi!" }],
+  });
+  return chatId;
+}
+
+export async function loadChat(chatId: string) {
+  return store.loadChat(chatId);
+}
+
+export async function deleteChat(chatId: string) {
+  await store.deleteChat(chatId);
+}
+```
+
+Notes:
+- The adapter stores the full v2 state payload:
+  - `kind: "ai-sdk-chat"`
+  - `runtime: "ai-sdk"`
+  - `messages` (full `UIMessage[]`)

--- a/examples/langgraph-js/README.md
+++ b/examples/langgraph-js/README.md
@@ -1,0 +1,46 @@
+# LangGraph (JavaScript) Adapter Example
+
+Persist LangGraph checkpoints and pending writes using the `@agentstate/sdk/langgraph` adapter.
+
+```ts
+import { AgentState } from "@agentstate/sdk";
+import { AgentStateCheckpointSaver } from "@agentstate/sdk/langgraph";
+
+const client = new AgentState({
+  apiKey: process.env.AGENTSTATE_API_KEY!,
+});
+
+const saver = new AgentStateCheckpointSaver(client, {
+  agentId: "agentstate-sdk",
+  stateKeyPrefix: "agentstate/langgraph",
+});
+
+export async function saveCheckpoint(threadId: string) {
+  const config = {
+    configurable: { thread_id: threadId, checkpoint_ns: "" },
+  };
+  const nextConfig = await saver.put(
+    config,
+    { id: "cp-1", values: { step: "start" } },
+    { note: "checkpoint created" },
+    {},
+  );
+
+  await saver.putWrites(
+    nextConfig,
+    [["messages", [{ role: "assistant", content: "hello" }]]],
+    "task-id-1",
+  );
+
+  return nextConfig;
+}
+
+export async function loadCheckpoint(config: { configurable: { thread_id: string; checkpoint_ns?: string; checkpoint_id?: string } }) {
+  return saver.getTuple(config);
+}
+```
+
+Requirements:
+- Install `@agentstate/sdk`
+- Install optional peer `@langchain/langgraph-checkpoint`
+- (Optional) use `@agentstate/sdk/langgraph` for async workflows

--- a/examples/langgraph-python/README.md
+++ b/examples/langgraph-python/README.md
@@ -1,0 +1,31 @@
+# LangGraph (Python) Adapter Example
+
+Use AgentState as a LangGraph saver from Python with `agentstate[langgraph]`.
+
+```python
+from agentstate import AgentStateClient
+from agentstate.langgraph import AgentStateCheckpointSaver, AsyncAgentStateCheckpointSaver
+
+client = AgentStateClient(api_key="as_live_...")
+
+saver = AgentStateCheckpointSaver(client)
+
+config = {"configurable": {"thread_id": "thread-1", "checkpoint_ns": ""}}
+checkpoint = {"id": "cp-1", "values": {"step": "start"}}
+next_config = saver.put(config, checkpoint, {"note": "checkpoint created"}, {})
+
+saver.put_writes(
+    next_config,
+    [("messages", {"role": "assistant", "content": "hello"})],
+    task_id="task-main",
+)
+
+tuple_value = saver.get_tuple(next_config)
+print(tuple_value[0]["configurable"]["checkpoint_id"])
+```
+
+Install with:
+
+```bash
+pip install agentstate[langgraph]
+```

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -8,6 +8,17 @@ Python client for [AgentState](https://agentstate.app) API.
 pip install agentstate
 ```
 
+## Installation (with optional adapters)
+
+```bash
+pip install agentstate[langgraph]
+```
+
+The `langgraph` extra installs:
+
+- `langgraph`
+- `langgraph-checkpoint`
+
 ## Quick Start
 
 ```python
@@ -109,6 +120,74 @@ List conversations with pagination.
 - `cursor`: Pagination cursor from previous response
 
 Returns dict with `items` (list) and `next_cursor`.
+
+## State and framework adapters
+
+### `upsert_state(state_key: str, state: dict, idempotency_key=None)`
+
+Create or replace a v2 state record.
+
+- `state_key` is your caller-defined key, typically namespaced by thread/session.
+- `state` must include at least `agent_id` and `data` fields.
+
+### `get_state(state_key: str, at_sequence=None, at_time=None)`
+
+Read the latest v2 state for a key, or a historical version with:
+
+- `at_sequence` (int)
+- `at_time` (int, epoch millis)
+
+### `query_states(query=None)`
+
+Run a filtered v2 state query against `/v2/states/query`.
+
+### `delete_state(state_key: str, lease_id=None, idempotency_key=None)`
+
+Delete a v2 state key. Supports optional lease validation and idempotency.
+
+### `list_state_events(state_key: str, after=0, limit=50)`
+
+Read event history for a v2 state key.
+
+## LangGraph checkpoint savers
+
+### `agentstate.langgraph.AgentStateCheckpointSaver`
+
+LangGraph checkpoint saver that persists checkpoints and pending writes in AgentState v2 state records.
+
+```python
+from agentstate import AgentStateClient
+from agentstate.langgraph import AgentStateCheckpointSaver
+
+client = AgentStateClient(api_key="as_live_...")
+saver = AgentStateCheckpointSaver(client)
+
+config = {"configurable": {"thread_id": "thread-1"}}
+checkpoint = {"id": "checkpoint-1"}
+metadata = {"note": "start"}
+
+next_config = saver.put(config, checkpoint, metadata, {})
+```
+
+### `agentstate.langgraph.AsyncAgentStateCheckpointSaver`
+
+Async variant for async runtimes.
+
+```python
+import asyncio
+from agentstate import AgentStateClient
+from agentstate.langgraph import AsyncAgentStateCheckpointSaver
+
+
+async def main():
+    client = AgentStateClient(api_key="as_live_...")
+    saver = AsyncAgentStateCheckpointSaver(client)
+    config = {"configurable": {"thread_id": "thread-1", "checkpoint_id": "checkpoint-1"}}
+    await saver.aput_writes(config, [("messages", {"role": "user"})], "task-1")
+
+
+asyncio.run(main())
+```
 
 ## License
 

--- a/packages/python-sdk/agentstate/__init__.py
+++ b/packages/python-sdk/agentstate/__init__.py
@@ -1,6 +1,10 @@
 """AgentState Python SDK."""
 
 from agentstate.client import AgentStateClient
+from agentstate.langgraph import (
+    AgentStateCheckpointSaver,
+    AsyncAgentStateCheckpointSaver,
+)
 from agentstate.exceptions import (
     AgentStateError,
     AuthenticationError,
@@ -11,6 +15,8 @@ from agentstate.exceptions import (
 __version__ = "0.1.0"
 __all__ = [
     "AgentStateClient",
+    "AgentStateCheckpointSaver",
+    "AsyncAgentStateCheckpointSaver",
     "AgentStateError",
     "AuthenticationError",
     "NotFoundError",

--- a/packages/python-sdk/agentstate/client.py
+++ b/packages/python-sdk/agentstate/client.py
@@ -1,7 +1,11 @@
 """AgentState API client."""
 
+from __future__ import annotations
+
+import urllib.parse
+from typing import Any, Dict, List, Optional
+
 import httpx
-from typing import Optional, List, Dict, Any
 
 from agentstate.exceptions import (
     AgentStateError,
@@ -56,7 +60,7 @@ class AgentStateClient:
         self,
         messages: List[Dict[str, str]],
         external_id: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Create a new conversation.
 
@@ -76,7 +80,7 @@ class AgentStateClient:
 
         response = self.client.post(
             f"{self.base_url}/v1/conversations",
-            json=payload
+            json=payload,
         )
         return _handle_response(response)
 
@@ -89,15 +93,13 @@ class AgentStateClient:
         Returns:
             Conversation dict with full details
         """
-        response = self.client.get(
-            f"{self.base_url}/v1/conversations/{conversation_id}"
-        )
+        response = self.client.get(f"{self.base_url}/v1/conversations/{conversation_id}")
         return _handle_response(response)
 
     def list_conversations(
         self,
         limit: int = 20,
-        cursor: Optional[str] = None
+        cursor: Optional[str] = None,
     ) -> Dict[str, Any]:
         """List conversations with pagination.
 
@@ -114,6 +116,125 @@ class AgentStateClient:
 
         response = self.client.get(
             f"{self.base_url}/v1/conversations",
-            params=params
+            params=params,
+        )
+        return _handle_response(response)
+
+    def upsert_state(
+        self,
+        state_key: str,
+        state: Dict[str, Any],
+        idempotency_key: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Create or replace a v2 state record.
+
+        Args:
+            state_key: Caller-defined state key
+            state: Upsert request body (must include agent_id)
+            idempotency_key: Optional idempotency key
+
+        Returns:
+            Latest state record snapshot
+        """
+        headers = None
+        if idempotency_key:
+            headers = {"Idempotency-Key": idempotency_key}
+
+        response = self.client.put(
+            f"{self.base_url}/v2/states/{urllib.parse.quote(state_key, safe='')}"
+            ,
+            json=state,
+            headers=headers,
+        )
+        return _handle_response(response)
+
+    def get_state(
+        self,
+        state_key: str,
+        at_sequence: Optional[int] = None,
+        at_time: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Get latest or historical v2 state by key.
+
+        Args:
+            state_key: Caller-defined state key
+            at_sequence: Optional historical sequence cursor
+            at_time: Optional historical timestamp in millis
+
+        Returns:
+            State record snapshot
+        """
+        params: Dict[str, Any] = {}
+        if at_sequence is not None:
+            params["at_sequence"] = at_sequence
+        if at_time is not None:
+            params["at_time"] = at_time
+
+        response = self.client.get(
+            f"{self.base_url}/v2/states/{urllib.parse.quote(state_key, safe='')}",
+            params=params or None,
+        )
+        return _handle_response(response)
+
+    def query_states(self, query: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Query v2 states.
+
+        Args:
+            query: Optional state query request payload
+
+        Returns:
+            State list response
+        """
+        response = self.client.post(
+            f"{self.base_url}/v2/states/query",
+            json=query or {},
+        )
+        return _handle_response(response)
+
+    def delete_state(
+        self,
+        state_key: str,
+        lease_id: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Delete v2 state.
+
+        Args:
+            state_key: Caller-defined state key
+            lease_id: Optional active lease id
+            idempotency_key: Optional idempotency key
+
+        Returns:
+            Deletion confirmation
+        """
+        headers = {"Idempotency-Key": idempotency_key} if idempotency_key else None
+        params = {"lease_id": lease_id} if lease_id else None
+
+        response = self.client.delete(
+            f"{self.base_url}/v2/states/{urllib.parse.quote(state_key, safe='')}",
+            params=params,
+            headers=headers,
+        )
+        return _handle_response(response)
+
+    def list_state_events(
+        self,
+        state_key: str,
+        after: int = 0,
+        limit: int = 50,
+    ) -> Dict[str, Any]:
+        """List v2 state events for a state key.
+
+        Args:
+            state_key: Caller-defined state key
+            after: Sequence cursor. Return events after this sequence
+            limit: Maximum number of events
+
+        Returns:
+            State event stream response
+        """
+        response = self.client.get(
+            f"{self.base_url}/v2/states/{urllib.parse.quote(state_key, safe='')}/events",
+            params={"after": after, "limit": limit},
         )
         return _handle_response(response)

--- a/packages/python-sdk/agentstate/client.py
+++ b/packages/python-sdk/agentstate/client.py
@@ -141,8 +141,7 @@ class AgentStateClient:
             headers = {"Idempotency-Key": idempotency_key}
 
         response = self.client.put(
-            f"{self.base_url}/v2/states/{urllib.parse.quote(state_key, safe='')}"
-            ,
+            f"{self.base_url}/v2/states/{urllib.parse.quote(state_key, safe='')}",
             json=state,
             headers=headers,
         )

--- a/packages/python-sdk/agentstate/langgraph.py
+++ b/packages/python-sdk/agentstate/langgraph.py
@@ -6,14 +6,15 @@ import asyncio
 import base64
 import json
 import uuid
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple
+from typing import Any, AsyncGenerator, Dict, Iterator, List, Optional, Sequence, Tuple
 
 from agentstate.client import AgentStateClient
+from agentstate.exceptions import NotFoundError
 
 try:  # pragma: no cover - optional runtime dependency
     from langgraph.checkpoint.base import AsyncBaseCheckpointSaver as _AsyncBaseCheckpointSaver
     from langgraph.checkpoint.base import BaseCheckpointSaver as _BaseCheckpointSaver
-except Exception:  # pragma: no cover - optional dependency missing
+except ImportError:  # pragma: no cover - optional dependency missing
 
     class _BaseCheckpointSaver:  # noqa: D401
         """Fallback when langgraph-checkpoint is not installed."""
@@ -156,6 +157,10 @@ def _query_record_checkpoint_ns(payload: Dict[str, Any]) -> str:
     return _normalize_namespace(payload.get("checkpoint_ns"))
 
 
+def _tag_for_kind(kind: str) -> str:
+    return "checkpoint-write" if kind == WRITES_KIND else kind
+
+
 class AgentStateCheckpointSaver(_BaseCheckpointSaver):
     """LangGraph checkpoint saver that stores checkpoints in AgentState state records."""
 
@@ -175,7 +180,7 @@ class AgentStateCheckpointSaver(_BaseCheckpointSaver):
         checkpoint_ns: Optional[str],
         kind: str,
         *,
-        limit: int = LIST_LIMIT_DEFAULT,
+        limit: Optional[int] = LIST_LIMIT_DEFAULT,
         before: Optional[Dict[str, Any]] = None,
         after: Optional[Dict[str, Any]] = None,
         filter_data: Optional[Dict[str, Any]] = None,
@@ -183,10 +188,10 @@ class AgentStateCheckpointSaver(_BaseCheckpointSaver):
     ) -> List[Dict[str, Any]]:
         collected: List[Dict[str, Any]] = []
         seen: set[str] = set()
-        remaining = max(limit, 1)
+        remaining = max(limit or LIST_PAGE_SIZE, 1)
         normalized_filter = _normalize_filter(filter_data)
 
-        while len(collected) < limit:
+        while limit is None or len(collected) < limit:
             predicates = [
                 {"path": "$.kind", "equals": kind},
                 {"path": "$.runtime", "equals": RUNTIME},
@@ -200,11 +205,11 @@ class AgentStateCheckpointSaver(_BaseCheckpointSaver):
                     "tags": [
                         f"agentstate:{RUNTIME}",
                         f"agentstate:langgraph",
-                        f"agentstate:{kind}",
+                        f"agentstate:{_tag_for_kind(kind)}",
                         f"agentstate:thread:{thread_id}",
                     ],
                     "predicates": predicates,
-                    "limit": min(LIST_PAGE_SIZE, remaining),
+                    "limit": LIST_PAGE_SIZE if limit is None else min(LIST_PAGE_SIZE, remaining),
                     "cursor": cursor,
                 }
             )
@@ -229,7 +234,7 @@ class AgentStateCheckpointSaver(_BaseCheckpointSaver):
             if not next_cursor or not rows:
                 break
             cursor = next_cursor
-            remaining = limit - len(collected)
+            remaining = LIST_PAGE_SIZE if limit is None else limit - len(collected)
 
         sorted_rows = sorted(collected, key=lambda row: row.get("latest_sequence", 0), reverse=True)
 
@@ -261,7 +266,7 @@ class AgentStateCheckpointSaver(_BaseCheckpointSaver):
                 if split is not None:
                     sorted_rows = sorted_rows[:split]
 
-        return sorted_rows[:limit]
+        return sorted_rows if limit is None else sorted_rows[:limit]
 
     def _parse_pending_writes(self, thread_id: str, checkpoint_ns: str, checkpoint_id: str) -> List[Tuple[str, str, Any]]:
         if not checkpoint_id:
@@ -272,7 +277,7 @@ class AgentStateCheckpointSaver(_BaseCheckpointSaver):
             checkpoint_ns=checkpoint_ns,
             kind=WRITES_KIND,
             filter_data={"checkpoint_id": checkpoint_id},
-            limit=LIST_PAGE_SIZE,
+            limit=None,
         )
 
         writes: List[Tuple[str, str, Any]] = []
@@ -353,7 +358,7 @@ class AgentStateCheckpointSaver(_BaseCheckpointSaver):
             key = _build_checkpoint_key(self.state_key_prefix, thread_id, checkpoint_ns, checkpoint_id)
             try:
                 state = self.client.get_state(key)
-            except Exception:
+            except NotFoundError:
                 return None
             if isinstance(state, dict):
                 return self._to_tuple(thread_id, checkpoint_ns, state)
@@ -487,22 +492,31 @@ class AgentStateCheckpointSaver(_BaseCheckpointSaver):
         )
 
     def delete_thread(self, thread_id: str) -> None:
-        checkpoint_rows = self._query_records(
-            thread_id=thread_id,
-            checkpoint_ns=None,
-            kind=CHECKPOINT_KIND,
-            limit=1_000_000,
-        )
-        writes_rows = self._query_records(
-            thread_id=thread_id,
-            checkpoint_ns=None,
-            kind=WRITES_KIND,
-            limit=1_000_000,
-        )
-        for row in checkpoint_rows + writes_rows:
-            key = row.get("state_key")
-            if isinstance(key, str):
-                self.client.delete_state(key)
+        for kind in (WRITES_KIND, CHECKPOINT_KIND):
+            cursor: Optional[str] = None
+            while True:
+                rows = self._query_records(
+                    thread_id=thread_id,
+                    checkpoint_ns=None,
+                    kind=kind,
+                    limit=LIST_PAGE_SIZE,
+                    cursor=cursor,
+                )
+                if not rows:
+                    break
+
+                for row in rows:
+                    key = row.get("state_key")
+                    if isinstance(key, str):
+                        self.client.delete_state(key)
+
+                if len(rows) < LIST_PAGE_SIZE:
+                    break
+
+                latest_sequence = rows[-1].get("latest_sequence")
+                if not isinstance(latest_sequence, int):
+                    break
+                cursor = str(latest_sequence)
 
 
 class AsyncAgentStateCheckpointSaver(_AsyncBaseCheckpointSaver):
@@ -545,13 +559,23 @@ class AsyncAgentStateCheckpointSaver(_AsyncBaseCheckpointSaver):
         ],
         None,
     ]:
-        for item in self._sync.list(
-            config,
-            filter=filter,
-            before=before,
-            after=after,
-            limit=limit,
-        ):
+        """Run self._sync.list in self._run and yield the finite items result.
+
+        When limit is None, self._sync.list applies LIST_LIMIT_DEFAULT before
+        items is materialized.
+        """
+        items = await self._run(
+            lambda: list(
+                self._sync.list(
+                    config,
+                    filter=filter,
+                    before=before,
+                    after=after,
+                    limit=limit,
+                )
+            )
+        )
+        for item in items:
             yield item
 
     async def aput(self, config: Dict[str, Any], checkpoint: Dict[str, Any], metadata: Dict[str, Any], new_versions: Dict[str, Any]):  # noqa: ANN001

--- a/packages/python-sdk/agentstate/langgraph.py
+++ b/packages/python-sdk/agentstate/langgraph.py
@@ -1,0 +1,570 @@
+"""LangGraph checkpoint saver implementations backed by AgentState state storage."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import uuid
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple
+
+from agentstate.client import AgentStateClient
+
+try:  # pragma: no cover - optional runtime dependency
+    from langgraph.checkpoint.base import AsyncBaseCheckpointSaver as _AsyncBaseCheckpointSaver
+    from langgraph.checkpoint.base import BaseCheckpointSaver as _BaseCheckpointSaver
+except Exception:  # pragma: no cover - optional dependency missing
+
+    class _BaseCheckpointSaver:  # noqa: D401
+        """Fallback when langgraph-checkpoint is not installed."""
+
+    class _AsyncBaseCheckpointSaver:  # noqa: D401
+        """Fallback when langgraph-checkpoint is not installed."""
+
+
+CHECKPOINT_KIND = "checkpoint"
+WRITES_KIND = "checkpoint-writes"
+RUNTIME = "langgraph"
+CHECKPOINT_PREFIX_DEFAULT = "agentstate/langgraph"
+AGENT_ID_DEFAULT = "agentstate-sdk"
+ENCODING = "base64-json"
+LIST_LIMIT_DEFAULT = 50
+LIST_PAGE_SIZE = 100
+
+
+def _normalize_namespace(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _normalize_namespace_for_key(value: Any) -> str:
+    return _normalize_namespace(value) or "default"
+
+
+def _build_checkpoint_key(prefix: str, thread_id: str, checkpoint_ns: str, checkpoint_id: str) -> str:
+    return f"{prefix}/{thread_id}/{_normalize_namespace_for_key(checkpoint_ns)}/{checkpoint_id}"
+
+
+def _build_writes_key(
+    prefix: str,
+    thread_id: str,
+    checkpoint_ns: str,
+    checkpoint_id: str,
+    task_id: str,
+) -> str:
+    return f"{prefix}/{thread_id}/{_normalize_namespace_for_key(checkpoint_ns)}/writes/{checkpoint_id}/{task_id}"
+
+
+def _encode_envelope(value: Any) -> Dict[str, Any]:
+    json_value = json.dumps(value, separators=(",", ":"))
+    return {
+        "encoding": ENCODING,
+        "data": base64.b64encode(json_value.encode("utf-8")).decode("ascii"),
+    }
+
+
+def _decode_envelope(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return None
+    if value.get("encoding") != ENCODING:
+        return value
+    encoded = value.get("data")
+    if not isinstance(encoded, str):
+        return None
+    return json.loads(base64.b64decode(encoded).decode("utf-8"))
+
+
+def _safe_dict(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _safe_list(value: Any) -> List[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _safe_sequence(value: Any) -> Sequence[Any]:
+    return value if isinstance(value, list) or isinstance(value, tuple) else ()
+
+
+def _get_thread_id(config: Dict[str, Any]) -> str:
+    configurable = config.get("configurable", {})
+    if not isinstance(configurable, dict):
+        raise ValueError("LangGraph config requires configurable.thread_id")
+    thread_id = configurable.get("thread_id")
+    if not isinstance(thread_id, str) or not thread_id:
+        raise ValueError("LangGraph config requires configurable.thread_id")
+    return thread_id
+
+
+def _get_checkpoint_ns(config: Dict[str, Any]) -> str:
+    configurable = config.get("configurable", {})
+    if not isinstance(configurable, dict):
+        return ""
+    return _normalize_namespace(configurable.get("checkpoint_ns"))
+
+
+def _get_checkpoint_id(config: Dict[str, Any]) -> Optional[str]:
+    configurable = config.get("configurable", {})
+    if not isinstance(configurable, dict):
+        return None
+    checkpoint_id = configurable.get("checkpoint_id")
+    if isinstance(checkpoint_id, str):
+        return checkpoint_id
+    if isinstance(checkpoint_id, int):
+        return str(checkpoint_id)
+    return None
+
+
+def _extract_checkpoint_id(checkpoint: Dict[str, Any]) -> Optional[str]:
+    checkpoint_id = checkpoint.get("id")
+    return checkpoint_id if isinstance(checkpoint_id, str) else None
+
+
+def _extract_versions(checkpoint: Any) -> Dict[str, Any]:
+    result: Dict[str, Any] = {}
+    raw = _safe_dict(checkpoint)
+    if isinstance(raw.get("channel_versions"), dict):
+        result.update(raw["channel_versions"])
+    if isinstance(raw.get("versions"), dict):
+        result.update(raw["versions"])
+    return result
+
+
+def _normalize_writes(writes: Sequence[Tuple[str, Any]], task_id: str) -> List[Tuple[str, str, Any]]:
+    output: List[Tuple[str, str, Any]] = []
+    for item in writes:
+        if not isinstance(item, (list, tuple)) or len(item) < 2:
+            continue
+        channel = item[0]
+        value = item[1]
+        if isinstance(channel, str):
+            output.append((task_id, channel, value))
+    return output
+
+
+def _normalize_filter(filter_data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    return filter_data if isinstance(filter_data, dict) else {}
+
+
+def _match_filter(payload: Dict[str, Any], filters: Dict[str, Any]) -> bool:
+    for key, value in filters.items():
+        if payload.get(key) != value:
+            return False
+    return True
+
+
+def _query_record_checkpoint_ns(payload: Dict[str, Any]) -> str:
+    return _normalize_namespace(payload.get("checkpoint_ns"))
+
+
+class AgentStateCheckpointSaver(_BaseCheckpointSaver):
+    """LangGraph checkpoint saver that stores checkpoints in AgentState state records."""
+
+    def __init__(
+        self,
+        client: AgentStateClient,
+        agent_id: str = AGENT_ID_DEFAULT,
+        state_key_prefix: str = CHECKPOINT_PREFIX_DEFAULT,
+    ):
+        self.client = client
+        self.agent_id = agent_id
+        self.state_key_prefix = state_key_prefix
+
+    def _query_records(
+        self,
+        thread_id: str,
+        checkpoint_ns: Optional[str],
+        kind: str,
+        *,
+        limit: int = LIST_LIMIT_DEFAULT,
+        before: Optional[Dict[str, Any]] = None,
+        after: Optional[Dict[str, Any]] = None,
+        filter_data: Optional[Dict[str, Any]] = None,
+        cursor: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        collected: List[Dict[str, Any]] = []
+        seen: set[str] = set()
+        remaining = max(limit, 1)
+        normalized_filter = _normalize_filter(filter_data)
+
+        while len(collected) < limit:
+            predicates = [
+                {"path": "$.kind", "equals": kind},
+                {"path": "$.runtime", "equals": RUNTIME},
+                {"path": "$.thread_id", "equals": thread_id},
+            ]
+            if checkpoint_ns is not None:
+                predicates.append({"path": "$.checkpoint_ns", "equals": checkpoint_ns})
+            response = self.client.query_states(
+                {
+                    "agent_id": self.agent_id,
+                    "tags": [
+                        f"agentstate:{RUNTIME}",
+                        f"agentstate:langgraph",
+                        f"agentstate:{kind}",
+                        f"agentstate:thread:{thread_id}",
+                    ],
+                    "predicates": predicates,
+                    "limit": min(LIST_PAGE_SIZE, remaining),
+                    "cursor": cursor,
+                }
+            )
+            rows = response.get("data", []) if isinstance(response, dict) else []
+            if not isinstance(rows, list):
+                break
+
+            for row in rows:
+                if not isinstance(row, dict):
+                    continue
+                key = row.get("state_key")
+                if not isinstance(key, str) or key in seen:
+                    continue
+                seen.add(key)
+
+                payload = _safe_dict(row.get("data"))
+                if normalized_filter and not _match_filter(payload, normalized_filter):
+                    continue
+                collected.append(row)
+
+            next_cursor = _safe_dict(response.get("pagination")).get("next_cursor")
+            if not next_cursor or not rows:
+                break
+            cursor = next_cursor
+            remaining = limit - len(collected)
+
+        sorted_rows = sorted(collected, key=lambda row: row.get("latest_sequence", 0), reverse=True)
+
+        if before:
+            before_checkpoint_id = _get_checkpoint_id(before)
+            if before_checkpoint_id:
+                split = next(
+                    (
+                        index
+                        for index, row in enumerate(sorted_rows)
+                        if _safe_dict(row.get("data")).get("checkpoint_id") == before_checkpoint_id
+                    ),
+                    None,
+                )
+                if split is not None:
+                    sorted_rows = sorted_rows[split + 1 :]
+
+        if after:
+            after_checkpoint_id = _get_checkpoint_id(after)
+            if after_checkpoint_id:
+                split = next(
+                    (
+                        index
+                        for index, row in enumerate(sorted_rows)
+                        if _safe_dict(row.get("data")).get("checkpoint_id") == after_checkpoint_id
+                    ),
+                    None,
+                )
+                if split is not None:
+                    sorted_rows = sorted_rows[:split]
+
+        return sorted_rows[:limit]
+
+    def _parse_pending_writes(self, thread_id: str, checkpoint_ns: str, checkpoint_id: str) -> List[Tuple[str, str, Any]]:
+        if not checkpoint_id:
+            return []
+
+        rows = self._query_records(
+            thread_id=thread_id,
+            checkpoint_ns=checkpoint_ns,
+            kind=WRITES_KIND,
+            filter_data={"checkpoint_id": checkpoint_id},
+            limit=LIST_PAGE_SIZE,
+        )
+
+        writes: List[Tuple[str, str, Any]] = []
+        for row in rows:
+            payload = _safe_dict(row.get("data"))
+            encoded = payload.get("writes")
+            decoded = _decode_envelope(encoded)
+            for item in _safe_list(decoded):
+                if not isinstance(item, (list, tuple)) or len(item) < 3:
+                    continue
+                task_id = item[0]
+                channel = item[1]
+                value = item[2]
+                if isinstance(task_id, str) and isinstance(channel, str):
+                    writes.append((task_id, channel, value))
+        return writes
+
+    def _to_tuple(
+        self,
+        thread_id: str,
+        checkpoint_ns: str,
+        state: Dict[str, Any],
+    ) -> Tuple[
+        Dict[str, Any],
+        Dict[str, Any],
+        Dict[str, Any],
+        Optional[Dict[str, Any]],
+        Optional[List[Tuple[str, str, Any]]],
+    ]:
+        data = _safe_dict(state.get("data"))
+        checkpoint_id = data.get("checkpoint_id")
+        if not isinstance(checkpoint_id, str):
+            return (
+                {"configurable": {"thread_id": thread_id, "checkpoint_ns": checkpoint_ns}},
+                {},
+                {},
+                None,
+                None,
+            )
+
+        checkpoint = _decode_envelope(data.get("checkpoint"))
+        metadata = _decode_envelope(data.get("metadata"))
+        parent_id = data.get("parent_checkpoint_id")
+        parent_config = None
+        if isinstance(parent_id, str):
+            parent_config = {
+                "configurable": {
+                    "thread_id": thread_id,
+                    "checkpoint_ns": checkpoint_ns,
+                    "checkpoint_id": parent_id,
+                },
+            }
+
+        pending_writes = self._parse_pending_writes(thread_id, checkpoint_ns, checkpoint_id)
+
+        return (
+            {"configurable": {"thread_id": thread_id, "checkpoint_ns": checkpoint_ns, "checkpoint_id": checkpoint_id}},
+            _safe_dict(checkpoint),
+            _safe_dict(metadata),
+            parent_config,
+            pending_writes or None,
+        )
+
+    def get_tuple(self, config: Dict[str, Any]) -> Optional[
+        Tuple[
+            Dict[str, Any],
+            Dict[str, Any],
+            Dict[str, Any],
+            Optional[Dict[str, Any]],
+            Optional[List[Tuple[str, str, Any]]],
+        ]
+    ]:
+        thread_id = _get_thread_id(config)
+        checkpoint_ns = _get_checkpoint_ns(config)
+        checkpoint_id = _get_checkpoint_id(config)
+
+        if checkpoint_id:
+            key = _build_checkpoint_key(self.state_key_prefix, thread_id, checkpoint_ns, checkpoint_id)
+            try:
+                state = self.client.get_state(key)
+            except Exception:
+                return None
+            if isinstance(state, dict):
+                return self._to_tuple(thread_id, checkpoint_ns, state)
+            return None
+
+        records = self._query_records(thread_id, checkpoint_ns, CHECKPOINT_KIND, limit=1)
+        if not records:
+            return None
+        return self._to_tuple(thread_id, checkpoint_ns, records[0])
+
+    def list(
+        self,
+        config: Optional[Dict[str, Any]],
+        *,
+        filter: Optional[Dict[str, Any]] = None,
+        before: Optional[Dict[str, Any]] = None,
+        after: Optional[Dict[str, Any]] = None,
+        limit: Optional[int] = None,
+    ) -> Iterator[
+        Tuple[
+            Dict[str, Any],
+            Dict[str, Any],
+            Dict[str, Any],
+            Optional[Dict[str, Any]],
+            Optional[List[Tuple[str, str, Any]]],
+        ]
+    ]:
+        thread_id = _get_thread_id(config if config is not None else {})
+        checkpoint_ns = _get_checkpoint_ns(config if config is not None else {})
+        max_items = min(limit or LIST_LIMIT_DEFAULT, LIST_PAGE_SIZE)
+        rows = self._query_records(
+            thread_id=thread_id,
+            checkpoint_ns=checkpoint_ns,
+            kind=CHECKPOINT_KIND,
+            limit=max_items,
+            before=before,
+            after=after,
+            filter_data=_normalize_filter(filter),
+        )
+        for row in rows[:max_items]:
+            yield self._to_tuple(thread_id, checkpoint_ns, row)
+
+    def put(
+        self,
+        config: Dict[str, Any],
+        checkpoint: Dict[str, Any],
+        metadata: Dict[str, Any],
+        new_versions: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        thread_id = _get_thread_id(config)
+        checkpoint_ns = _get_checkpoint_ns(config)
+        parent_checkpoint_id = _get_checkpoint_id(config)
+        checkpoint_id = _extract_checkpoint_id(checkpoint) or uuid.uuid4().hex
+        versions = _extract_versions(new_versions)
+        if not versions:
+            versions = _extract_versions(checkpoint)
+
+        self.client.upsert_state(
+            _build_checkpoint_key(self.state_key_prefix, thread_id, checkpoint_ns, checkpoint_id),
+            {
+                "agent_id": self.agent_id,
+                "data": {
+                    "kind": CHECKPOINT_KIND,
+                    "runtime": RUNTIME,
+                    "thread_id": thread_id,
+                    "checkpoint_ns": checkpoint_ns,
+                    "checkpoint_id": checkpoint_id,
+                    "parent_checkpoint_id": parent_checkpoint_id,
+                    "checkpoint": _encode_envelope(checkpoint),
+                    "metadata": _encode_envelope(metadata),
+                    "versions": versions,
+                },
+                "metadata": {"runtime": RUNTIME, "kind": CHECKPOINT_KIND},
+                "tags": [
+                    "agentstate:langgraph",
+                    "agentstate:checkpoint",
+                    f"agentstate:thread:{thread_id}",
+                ],
+            },
+        )
+
+        return {
+            "configurable": {
+                "thread_id": thread_id,
+                "checkpoint_ns": checkpoint_ns,
+                "checkpoint_id": checkpoint_id,
+            },
+        }
+
+    def put_writes(
+        self,
+        config: Dict[str, Any],
+        writes: Sequence[Tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        thread_id = _get_thread_id(config)
+        checkpoint_ns = _get_checkpoint_ns(config)
+        checkpoint_id = _get_checkpoint_id(config)
+        if not checkpoint_id:
+            raise ValueError("Cannot store writes without config.configurable.checkpoint_id")
+
+        normalized_writes = _normalize_writes(writes, task_id)
+        self.client.upsert_state(
+            _build_writes_key(self.state_key_prefix, thread_id, checkpoint_ns, checkpoint_id, task_id),
+            {
+                "agent_id": self.agent_id,
+                "data": {
+                    "kind": WRITES_KIND,
+                    "runtime": RUNTIME,
+                    "thread_id": thread_id,
+                    "checkpoint_ns": checkpoint_ns,
+                    "checkpoint_id": checkpoint_id,
+                    "task_id": task_id,
+                    "task_path": task_path,
+                    "writes": _encode_envelope(normalized_writes),
+                },
+                "metadata": {
+                    "runtime": RUNTIME,
+                    "kind": WRITES_KIND,
+                    "task_id": task_id,
+                    "task_path": task_path,
+                    "checkpoint_id": checkpoint_id,
+                },
+                "tags": [
+                    "agentstate:langgraph",
+                    "agentstate:checkpoint-write",
+                    f"agentstate:thread:{thread_id}",
+                ],
+            },
+        )
+
+    def delete_thread(self, thread_id: str) -> None:
+        checkpoint_rows = self._query_records(
+            thread_id=thread_id,
+            checkpoint_ns=None,
+            kind=CHECKPOINT_KIND,
+            limit=1_000_000,
+        )
+        writes_rows = self._query_records(
+            thread_id=thread_id,
+            checkpoint_ns=None,
+            kind=WRITES_KIND,
+            limit=1_000_000,
+        )
+        for row in checkpoint_rows + writes_rows:
+            key = row.get("state_key")
+            if isinstance(key, str):
+                self.client.delete_state(key)
+
+
+class AsyncAgentStateCheckpointSaver(_AsyncBaseCheckpointSaver):
+    """Asynchronous variant of :class:`AgentStateCheckpointSaver`."""
+
+    def __init__(
+        self,
+        client: AgentStateClient,
+        agent_id: str = AGENT_ID_DEFAULT,
+        state_key_prefix: str = CHECKPOINT_PREFIX_DEFAULT,
+    ):
+        self._sync = AgentStateCheckpointSaver(
+            client,
+            agent_id=agent_id,
+            state_key_prefix=state_key_prefix,
+        )
+
+    def _run(self, func, *args, **kwargs):
+        loop = asyncio.get_running_loop()
+        return loop.run_in_executor(None, lambda: func(*args, **kwargs))
+
+    async def aget_tuple(self, config: Dict[str, Any]):  # noqa: ANN001
+        return await self._run(self._sync.get_tuple, config)
+
+    async def alist(
+        self,
+        config: Optional[Dict[str, Any]],
+        *,
+        filter: Optional[Dict[str, Any]] = None,
+        before: Optional[Dict[str, Any]] = None,
+        after: Optional[Dict[str, Any]] = None,
+        limit: Optional[int] = None,
+    ) -> AsyncGenerator[
+        Tuple[
+            Dict[str, Any],
+            Dict[str, Any],
+            Dict[str, Any],
+            Optional[Dict[str, Any]],
+            Optional[List[Tuple[str, str, Any]]],
+        ],
+        None,
+    ]:
+        for item in self._sync.list(
+            config,
+            filter=filter,
+            before=before,
+            after=after,
+            limit=limit,
+        ):
+            yield item
+
+    async def aput(self, config: Dict[str, Any], checkpoint: Dict[str, Any], metadata: Dict[str, Any], new_versions: Dict[str, Any]):  # noqa: ANN001
+        return await self._run(self._sync.put, config, checkpoint, metadata, new_versions)
+
+    async def aput_writes(
+        self,
+        config: Dict[str, Any],
+        writes: Sequence[Tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:  # noqa: ANN001
+        return await self._run(self._sync.put_writes, config, writes, task_id, task_path)
+
+    async def adelete_thread(self, thread_id: str) -> None:
+        return await self._run(self._sync.delete_thread, thread_id)

--- a/packages/python-sdk/agentstate/langgraph.py
+++ b/packages/python-sdk/agentstate/langgraph.py
@@ -186,40 +186,22 @@ class AgentStateCheckpointSaver(_BaseCheckpointSaver):
         filter_data: Optional[Dict[str, Any]] = None,
         cursor: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
+        page_limit = max(limit or LIST_PAGE_SIZE, 1)
         collected: List[Dict[str, Any]] = []
         seen: set[str] = set()
-        remaining = max(limit or LIST_PAGE_SIZE, 1)
+        remaining = page_limit
         normalized_filter = _normalize_filter(filter_data)
 
         while limit is None or len(collected) < limit:
-            predicates = [
-                {"path": "$.kind", "equals": kind},
-                {"path": "$.runtime", "equals": RUNTIME},
-                {"path": "$.thread_id", "equals": thread_id},
-            ]
-            if checkpoint_ns is not None:
-                predicates.append({"path": "$.checkpoint_ns", "equals": checkpoint_ns})
-            response = self.client.query_states(
-                {
-                    "agent_id": self.agent_id,
-                    "tags": [
-                        f"agentstate:{RUNTIME}",
-                        f"agentstate:langgraph",
-                        f"agentstate:{_tag_for_kind(kind)}",
-                        f"agentstate:thread:{thread_id}",
-                    ],
-                    "predicates": predicates,
-                    "limit": LIST_PAGE_SIZE if limit is None else min(LIST_PAGE_SIZE, remaining),
-                    "cursor": cursor,
-                }
+            rows, next_cursor = self._query_record_page(
+                thread_id=thread_id,
+                checkpoint_ns=checkpoint_ns,
+                kind=kind,
+                limit=LIST_PAGE_SIZE if limit is None else min(LIST_PAGE_SIZE, remaining),
+                cursor=cursor,
             )
-            rows = response.get("data", []) if isinstance(response, dict) else []
-            if not isinstance(rows, list):
-                break
 
             for row in rows:
-                if not isinstance(row, dict):
-                    continue
                 key = row.get("state_key")
                 if not isinstance(key, str) or key in seen:
                     continue
@@ -230,7 +212,6 @@ class AgentStateCheckpointSaver(_BaseCheckpointSaver):
                     continue
                 collected.append(row)
 
-            next_cursor = _safe_dict(response.get("pagination")).get("next_cursor")
             if not next_cursor or not rows:
                 break
             cursor = next_cursor
@@ -267,6 +248,44 @@ class AgentStateCheckpointSaver(_BaseCheckpointSaver):
                     sorted_rows = sorted_rows[:split]
 
         return sorted_rows if limit is None else sorted_rows[:limit]
+
+    def _query_record_page(
+        self,
+        thread_id: str,
+        checkpoint_ns: Optional[str],
+        kind: str,
+        *,
+        limit: int,
+        cursor: Optional[str] = None,
+    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+        predicates = [
+            {"path": "$.kind", "equals": kind},
+            {"path": "$.runtime", "equals": RUNTIME},
+            {"path": "$.thread_id", "equals": thread_id},
+        ]
+        if checkpoint_ns is not None:
+            predicates.append({"path": "$.checkpoint_ns", "equals": checkpoint_ns})
+
+        response = self.client.query_states(
+            {
+                "agent_id": self.agent_id,
+                "tags": [
+                    f"agentstate:{RUNTIME}",
+                    "agentstate:langgraph",
+                    f"agentstate:{_tag_for_kind(kind)}",
+                    f"agentstate:thread:{thread_id}",
+                ],
+                "predicates": predicates,
+                "limit": limit,
+                "cursor": cursor,
+            }
+        )
+        rows = response.get("data", []) if isinstance(response, dict) else []
+        next_cursor = _safe_dict(response.get("pagination")).get("next_cursor") if isinstance(response, dict) else None
+        return (
+            [row for row in rows if isinstance(row, dict)] if isinstance(rows, list) else [],
+            next_cursor if isinstance(next_cursor, str) else None,
+        )
 
     def _parse_pending_writes(self, thread_id: str, checkpoint_ns: str, checkpoint_id: str) -> List[Tuple[str, str, Any]]:
         if not checkpoint_id:
@@ -373,7 +392,7 @@ class AgentStateCheckpointSaver(_BaseCheckpointSaver):
         self,
         config: Optional[Dict[str, Any]],
         *,
-        filter: Optional[Dict[str, Any]] = None,
+        filter: Optional[Dict[str, Any]] = None,  # noqa: A002
         before: Optional[Dict[str, Any]] = None,
         after: Optional[Dict[str, Any]] = None,
         limit: Optional[int] = None,
@@ -495,7 +514,7 @@ class AgentStateCheckpointSaver(_BaseCheckpointSaver):
         for kind in (WRITES_KIND, CHECKPOINT_KIND):
             cursor: Optional[str] = None
             while True:
-                rows = self._query_records(
+                rows, next_cursor = self._query_record_page(
                     thread_id=thread_id,
                     checkpoint_ns=None,
                     kind=kind,
@@ -510,13 +529,9 @@ class AgentStateCheckpointSaver(_BaseCheckpointSaver):
                     if isinstance(key, str):
                         self.client.delete_state(key)
 
-                if len(rows) < LIST_PAGE_SIZE:
+                if not next_cursor:
                     break
-
-                latest_sequence = rows[-1].get("latest_sequence")
-                if not isinstance(latest_sequence, int):
-                    break
-                cursor = str(latest_sequence)
+                cursor = next_cursor
 
 
 class AsyncAgentStateCheckpointSaver(_AsyncBaseCheckpointSaver):
@@ -545,7 +560,7 @@ class AsyncAgentStateCheckpointSaver(_AsyncBaseCheckpointSaver):
         self,
         config: Optional[Dict[str, Any]],
         *,
-        filter: Optional[Dict[str, Any]] = None,
+        filter: Optional[Dict[str, Any]] = None,  # noqa: A002
         before: Optional[Dict[str, Any]] = None,
         after: Optional[Dict[str, Any]] = None,
         limit: Optional[int] = None,

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -3,7 +3,8 @@ name = "agentstate"
 version = "0.1.0"
 description = "AgentState API client for Python"
 readme = "README.md"
-requires-python = ">=3.8"
+# LangGraph optional dependencies no longer resolve for Python 3.8.
+requires-python = ">=3.9"
 dependencies = [
     "httpx>=0.25.0",
 ]

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -13,6 +13,10 @@ dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
 ]
+langgraph = [
+    "langgraph>=0.2.0",
+    "langgraph-checkpoint>=1.0.0",
+]
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/packages/python-sdk/tests/test_client.py
+++ b/packages/python-sdk/tests/test_client.py
@@ -1,5 +1,8 @@
 """Tests for AgentStateClient."""
 
+import urllib.parse
+from unittest.mock import Mock, patch
+
 import pytest
 from agentstate import AgentStateClient
 from agentstate.exceptions import (
@@ -7,7 +10,6 @@ from agentstate.exceptions import (
     NotFoundError,
     ValidationError,
 )
-from unittest.mock import Mock, patch
 
 
 @pytest.fixture
@@ -147,6 +149,11 @@ def test_upsert_state():
 
     assert result["state_key"] == "thread-1"
     mock_put.assert_called_once()
+    assert mock_put.call_args.args[0].endswith(
+        f"/v2/states/{urllib.parse.quote('thread-1', safe='')}"
+    )
+    assert mock_put.call_args.kwargs["json"]["agent_id"] == "agentstate-sdk"
+    assert mock_put.call_args.kwargs["headers"] == {"Idempotency-Key": "idem-1"}
 
 
 def test_query_states():
@@ -163,6 +170,8 @@ def test_query_states():
 
     assert result["data"] == []
     mock_post.assert_called_once()
+    assert mock_post.call_args.args[0].endswith("/v2/states/query")
+    assert mock_post.call_args.kwargs["json"] == {"agent_id": "agentstate-sdk"}
 
 
 def test_get_state():
@@ -179,6 +188,10 @@ def test_get_state():
 
     assert state["state_key"] == "thread-1"
     mock_get.assert_called_once()
+    assert mock_get.call_args.args[0].endswith(
+        f"/v2/states/{urllib.parse.quote('thread-1', safe='')}"
+    )
+    assert mock_get.call_args.kwargs["params"] == {"at_sequence": 12, "at_time": 1000}
 
 
 def test_delete_state():
@@ -195,6 +208,11 @@ def test_delete_state():
 
     assert state["deleted"] is True
     mock_delete.assert_called_once()
+    assert mock_delete.call_args.args[0].endswith(
+        f"/v2/states/{urllib.parse.quote('thread-1', safe='')}"
+    )
+    assert mock_delete.call_args.kwargs["params"] == {"lease_id": "lease-1"}
+    assert mock_delete.call_args.kwargs["headers"] == {"Idempotency-Key": "idem-1"}
 
 
 def test_list_state_events():
@@ -211,3 +229,7 @@ def test_list_state_events():
 
     assert events["data"] == []
     mock_get.assert_called_once()
+    assert mock_get.call_args.args[0].endswith(
+        f"/v2/states/{urllib.parse.quote('thread-1', safe='')}/events"
+    )
+    assert mock_get.call_args.kwargs["params"] == {"after": 10, "limit": 25}

--- a/packages/python-sdk/tests/test_client.py
+++ b/packages/python-sdk/tests/test_client.py
@@ -123,3 +123,91 @@ def test_context_manager(mock_httpx):
         pass
 
     mock_close.assert_called_once()
+
+
+def test_upsert_state():
+    """Test upsert_state maps to the v2 endpoint."""
+    client = AgentStateClient(api_key="as_live_test123")
+    mock_put = Mock()
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {"state_key": "thread-1"}
+    mock_put.return_value = response
+    client.client.put = mock_put
+
+    result = client.upsert_state(
+        "thread-1",
+        {
+            "agent_id": "agentstate-sdk",
+            "data": {"kind": "checkpoint"},
+            "metadata": {"runtime": "langgraph"},
+        },
+        idempotency_key="idem-1",
+    )
+
+    assert result["state_key"] == "thread-1"
+    mock_put.assert_called_once()
+
+
+def test_query_states():
+    """Test query_states hits /v2/states/query."""
+    client = AgentStateClient(api_key="as_live_test123")
+    mock_post = Mock()
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {"data": [], "pagination": {"next_cursor": None}}
+    mock_post.return_value = response
+    client.client.post = mock_post
+
+    result = client.query_states({"agent_id": "agentstate-sdk"})
+
+    assert result["data"] == []
+    mock_post.assert_called_once()
+
+
+def test_get_state():
+    """Test get_state supports at_sequence and at_time queries."""
+    client = AgentStateClient(api_key="as_live_test123")
+    mock_get = Mock()
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {"state_key": "thread-1"}
+    mock_get.return_value = response
+    client.client.get = mock_get
+
+    state = client.get_state("thread-1", at_sequence=12, at_time=1000)
+
+    assert state["state_key"] == "thread-1"
+    mock_get.assert_called_once()
+
+
+def test_delete_state():
+    """Test delete_state can send idempotency and optional lease data."""
+    client = AgentStateClient(api_key="as_live_test123")
+    mock_delete = Mock()
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {"deleted": True}
+    mock_delete.return_value = response
+    client.client.delete = mock_delete
+
+    state = client.delete_state("thread-1", lease_id="lease-1", idempotency_key="idem-1")
+
+    assert state["deleted"] is True
+    mock_delete.assert_called_once()
+
+
+def test_list_state_events():
+    """Test state event listing endpoint."""
+    client = AgentStateClient(api_key="as_live_test123")
+    mock_get = Mock()
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {"data": [], "pagination": {"next_cursor": None}}
+    mock_get.return_value = response
+    client.client.get = mock_get
+
+    events = client.list_state_events("thread-1", after=10, limit=25)
+
+    assert events["data"] == []
+    mock_get.assert_called_once()

--- a/packages/python-sdk/tests/test_langgraph.py
+++ b/packages/python-sdk/tests/test_langgraph.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from agentstate.exceptions import NotFoundError
 from agentstate.langgraph import AgentStateCheckpointSaver, AsyncAgentStateCheckpointSaver
 
 
@@ -90,6 +91,26 @@ def test_sync_get_tuple_includes_pending_writes():
     assert pending_writes[0][1] == "messages"
 
 
+def test_sync_get_tuple_returns_none_only_for_missing_checkpoint():
+    client = Mock()
+    client.get_state = Mock(side_effect=NotFoundError("missing"))
+
+    saver = AgentStateCheckpointSaver(client)
+    result = saver.get_tuple({"configurable": {"thread_id": "thread-1", "checkpoint_id": "missing"}})
+
+    assert result is None
+
+
+def test_sync_get_tuple_raises_non_missing_errors():
+    client = Mock()
+    client.get_state = Mock(side_effect=RuntimeError("network down"))
+
+    saver = AgentStateCheckpointSaver(client)
+
+    with pytest.raises(RuntimeError):
+        saver.get_tuple({"configurable": {"thread_id": "thread-1", "checkpoint_id": "cp-1"}})
+
+
 def test_sync_list_with_before_filter():
     first = _checkpoint_record("cp-1")
     second = _checkpoint_record("cp-2")
@@ -145,8 +166,8 @@ def test_sync_delete_thread_uses_namespace_unaware_query():
     client = Mock()
     client.query_states = Mock(
         side_effect=[
-            {"data": [checkpoint_default, checkpoint_other], "pagination": {"next_cursor": None}},
             {"data": [writes], "pagination": {"next_cursor": None}},
+            {"data": [checkpoint_default, checkpoint_other], "pagination": {"next_cursor": None}},
         ]
     )
     client.delete_state = Mock()
@@ -167,12 +188,18 @@ async def test_async_saver_delegates_to_sync():
     client.query_states = Mock(return_value={"data": [_checkpoint_record("cp-1")]})
     async_saver = AsyncAgentStateCheckpointSaver(client)
 
-    async_saver._sync.get_tuple = Mock(return_value=("tuple-config", {}, {}, None, None))
+    tuple_config = {"configurable": {"thread_id": "thread-1"}}
+    async_saver._sync.get_tuple = Mock(return_value=(tuple_config, {}, {}, None, None))
     async_saver._sync.put = Mock(return_value={"configurable": {"thread_id": "thread-1"}})
     async_saver._sync.put_writes = Mock(return_value=None)
     async_saver._sync.delete_thread = Mock(return_value=None)
     async_saver._sync.list = Mock(
-        return_value=iter([("tuple-config", {}, {}, None, None), ("tuple-config2", {}, {}, None, None)])
+        return_value=iter(
+            [
+                (tuple_config, {}, {}, None, None),
+                ({"configurable": {"thread_id": "thread-2"}}, {}, {}, None, None),
+            ]
+        )
     )
 
     tuple_value = await async_saver.aget_tuple({"configurable": {"thread_id": "thread-1"}})

--- a/packages/python-sdk/tests/test_langgraph.py
+++ b/packages/python-sdk/tests/test_langgraph.py
@@ -1,0 +1,195 @@
+"""Tests for AgentState LangGraph checkpoint adapters."""
+
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from agentstate.langgraph import AgentStateCheckpointSaver, AsyncAgentStateCheckpointSaver
+
+
+def _encode(value):
+    return {
+        "encoding": "base64-json",
+        "data": base64.b64encode(json.dumps(value, separators=(",", ":")).encode()).decode(),
+    }
+
+
+def _checkpoint_record(checkpoint_id, thread_id="thread-1", checkpoint_ns=""):
+    return {
+        "state_key": f"agentstate/langgraph/{thread_id}/{checkpoint_ns or 'default'}/{checkpoint_id}",
+        "data": {
+            "kind": "checkpoint",
+            "runtime": "langgraph",
+            "thread_id": thread_id,
+            "checkpoint_ns": checkpoint_ns,
+            "checkpoint_id": checkpoint_id,
+            "parent_checkpoint_id": None,
+            "checkpoint": _encode({"state": f"checkpoint-{checkpoint_id}"}),
+            "metadata": _encode({}),
+            "versions": {},
+        },
+        "metadata": {"runtime": "langgraph", "kind": "checkpoint"},
+        "latest_sequence": 100,
+    }
+
+
+def _pending_write_record(checkpoint_id, thread_id="thread-1", task_id="task-1", checkpoint_ns=""):
+    return {
+        "state_key": f"agentstate/langgraph/{thread_id}/{checkpoint_ns or 'default'}/writes/{checkpoint_id}/{task_id}",
+        "data": {
+            "kind": "checkpoint-writes",
+            "runtime": "langgraph",
+            "thread_id": thread_id,
+            "checkpoint_ns": checkpoint_ns,
+            "checkpoint_id": checkpoint_id,
+            "task_id": task_id,
+            "task_path": "",
+            "writes": _encode([["", "messages", {"agent": "ok"}]]),
+        },
+        "metadata": {"kind": "checkpoint-write", "task_id": task_id, "checkpoint_id": checkpoint_id},
+        "latest_sequence": 99,
+    }
+
+
+def test_sync_put_and_put_writes_store_expected_payload():
+    client = Mock()
+    client.upsert_state = Mock()
+
+    saver = AgentStateCheckpointSaver(client)
+    checkpoint = {"id": "cp-1"}
+    saver.put({"configurable": {"thread_id": "thread-1", "checkpoint_id": "cp-1"}}, checkpoint, {}, {})
+    saver.put_writes({"configurable": {"thread_id": "thread-1", "checkpoint_ns": "", "checkpoint_id": "cp-1"}}, [("messages", "x")], "task-1")
+
+    assert client.upsert_state.call_count == 2
+    checkpoint_key = client.upsert_state.call_args_list[0].args[0]
+    writes_key = client.upsert_state.call_args_list[1].args[0]
+    assert checkpoint_key.startswith("agentstate/langgraph/thread-1/")
+    assert writes_key.endswith("/writes/cp-1/task-1")
+
+
+def test_sync_get_tuple_includes_pending_writes():
+    client = Mock()
+    client.get_state = Mock(return_value=_checkpoint_record("cp-1"))
+    client.query_states = Mock(return_value={"data": [_pending_write_record("cp-1")]})
+
+    saver = AgentStateCheckpointSaver(client)
+    result = saver.get_tuple({"configurable": {"thread_id": "thread-1", "checkpoint_id": "cp-1"}})
+
+    assert result is not None
+    config, checkpoint, metadata, parent_config, pending_writes = result
+    assert config["configurable"]["checkpoint_id"] == "cp-1"
+    assert isinstance(checkpoint, dict)
+    assert checkpoint.get("state") == "checkpoint-cp-1"
+    assert metadata == {}
+    assert parent_config is None
+    assert pending_writes is not None
+    assert pending_writes[0][1] == "messages"
+
+
+def test_sync_list_with_before_filter():
+    first = _checkpoint_record("cp-1")
+    second = _checkpoint_record("cp-2")
+    first["latest_sequence"] = 2
+    second["latest_sequence"] = 3
+    client = Mock()
+    client.query_states = Mock(
+        side_effect=[
+            {"data": [first, second], "pagination": {"next_cursor": None}},
+            {"data": [_pending_write_record("cp-2"), _pending_write_record("cp-1")]},
+        ]
+    )
+    saver = AgentStateCheckpointSaver(client)
+
+    entries = list(
+        saver.list(
+            {"configurable": {"thread_id": "thread-1"}},
+            before={"configurable": {"thread_id": "thread-1", "checkpoint_id": "cp-2"}},
+        )
+    )
+
+    assert len(entries) == 1
+    assert entries[0][0]["configurable"]["checkpoint_id"] == "cp-1"
+
+
+def test_sync_list_with_filter():
+    first = _checkpoint_record("cp-1")
+    second = _checkpoint_record("cp-2")
+    first["data"]["runtime"] = "langgraph"
+    second["data"]["runtime"] = "legacy"
+    client = Mock()
+    client.query_states = Mock(return_value={"data": [first, second], "pagination": {"next_cursor": None}})
+    client.get_state = Mock()
+    client.upsert_state = Mock()
+    client.delete_state = Mock()
+
+    saver = AgentStateCheckpointSaver(client)
+    entries = list(
+        saver.list(
+            {"configurable": {"thread_id": "thread-1"}},
+            filter={"runtime": "langgraph"},
+        )
+    )
+
+    assert len(entries) == 1
+    assert entries[0][0]["configurable"]["checkpoint_id"] == "cp-1"
+
+
+def test_sync_delete_thread_uses_namespace_unaware_query():
+    checkpoint_default = _checkpoint_record("cp-1", checkpoint_ns="")
+    checkpoint_other = _checkpoint_record("cp-2", checkpoint_ns="subflow")
+    writes = _pending_write_record("cp-1")
+    client = Mock()
+    client.query_states = Mock(
+        side_effect=[
+            {"data": [checkpoint_default, checkpoint_other], "pagination": {"next_cursor": None}},
+            {"data": [writes], "pagination": {"next_cursor": None}},
+        ]
+    )
+    client.delete_state = Mock()
+
+    saver = AgentStateCheckpointSaver(client)
+    saver.delete_thread("thread-1")
+
+    assert client.query_states.call_count == 2
+    assert client.delete_state.call_count == 3
+    deleted_keys = [call.args[0] for call in client.delete_state.call_args_list if call.args]
+    assert any("cp-1" in str(key) for key in deleted_keys)
+    assert any("cp-2" in str(key) for key in deleted_keys)
+
+
+@pytest.mark.asyncio
+async def test_async_saver_delegates_to_sync():
+    client = Mock()
+    client.query_states = Mock(return_value={"data": [_checkpoint_record("cp-1")]})
+    async_saver = AsyncAgentStateCheckpointSaver(client)
+
+    async_saver._sync.get_tuple = Mock(return_value=("tuple-config", {}, {}, None, None))
+    async_saver._sync.put = Mock(return_value={"configurable": {"thread_id": "thread-1"}})
+    async_saver._sync.put_writes = Mock(return_value=None)
+    async_saver._sync.delete_thread = Mock(return_value=None)
+    async_saver._sync.list = Mock(
+        return_value=iter([("tuple-config", {}, {}, None, None), ("tuple-config2", {}, {}, None, None)])
+    )
+
+    tuple_value = await async_saver.aget_tuple({"configurable": {"thread_id": "thread-1"}})
+    assert tuple_value[0]["configurable"]["thread_id"] == "thread-1"
+
+    new_config = await async_saver.aput(
+        {"configurable": {"thread_id": "thread-1"}},
+        {"id": "cp-new"},
+        {},
+        {},
+    )
+    assert new_config["configurable"]["thread_id"] == "thread-1"
+
+    await async_saver.aput_writes({"configurable": {"thread_id": "thread-1", "checkpoint_id": "cp-1"}}, [("messages", "x")], "task-1")
+    await async_saver.adelete_thread("thread-1")
+
+    rows = []
+    async for item in async_saver.alist({"configurable": {"thread_id": "thread-1"}}):
+        rows.append(item)
+    assert len(rows) == 2

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -8,6 +8,12 @@ TypeScript SDK for AgentState — conversation history database-as-a-service for
 npm install @agentstate/sdk
 ```
 
+Install optional LangGraph support when using the checkpoint adapter:
+
+```bash
+npm install @agentstate/sdk @langchain/langgraph-checkpoint
+```
+
 ## Quick Start
 
 ```typescript
@@ -53,9 +59,9 @@ console.log(saved.messages);
 
 - `exportConversations(ids?)` — Export all or selected conversations with messages
 
-### State Platform (planned)
+### State Platform
 
-These helpers target the planned `/v2/*` state platform contract:
+These helpers target `/v2/states`:
 
 - `upsertState(stateKey, data, options?)` — Create or replace state for a key
 - `getState(stateKey, params?)` — Read latest or historical state
@@ -79,7 +85,7 @@ const capability = await client.createCapabilityToken({
   name: "session watcher",
   state_key: state.state_key,
   scopes: ["state:watch", "lease:write"],
-  ttl_seconds: 3600,
+  expires_at: Date.now() + 60 * 60 * 1000,
 });
 
 const events = await client.listStateEvents(state.state_key, { after: 0 }, {
@@ -101,6 +107,41 @@ const claim = await client.createClaim({
 
 await client.verifyClaim(claim.id);
 ```
+
+## AI SDK and LangGraph state adapters
+
+### `@agentstate/sdk/ai-sdk`
+
+```ts
+import {
+  createAISDKChatStore,
+  createAISDKRSCStateStore,
+} from "@agentstate/sdk/ai-sdk";
+
+const chatStore = createAISDKChatStore(client, {
+  stateKeyPrefix: "agentstate/ai-sdk/chat",
+});
+
+const rscStore = createAISDKRSCStateStore(client, {
+  stateKey: "thread-1",
+});
+```
+
+### `@agentstate/sdk/langgraph`
+
+```ts
+import { AgentStateCheckpointSaver } from "@agentstate/sdk/langgraph";
+
+const saver = new AgentStateCheckpointSaver(client);
+await saver.put(
+  { configurable: { thread_id: "thread-1", checkpoint_ns: "" } },
+  { id: "cp-1" },
+  {},
+  {},
+);
+```
+
+See [agentstate LangGraph runtime docs](../../docs/integration.md) for example usage.
 
 ## Error Handling
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -10,11 +10,29 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
+    },
+    "./ai-sdk": {
+      "types": "./dist/ai-sdk.d.ts",
+      "import": "./dist/ai-sdk.mjs",
+      "require": "./dist/ai-sdk.js"
+    },
+    "./langgraph": {
+      "types": "./dist/langgraph.d.ts",
+      "import": "./dist/langgraph.mjs",
+      "require": "./dist/langgraph.js"
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts",
+    "build": "tsup src/index.ts src/ai-sdk.ts src/langgraph.ts --format cjs,esm --dts",
     "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@langchain/langgraph-checkpoint": "^1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@langchain/langgraph-checkpoint": {
+      "optional": true
+    }
   },
   "files": [
     "dist"

--- a/packages/sdk/src/ai-sdk.ts
+++ b/packages/sdk/src/ai-sdk.ts
@@ -1,4 +1,4 @@
-import { AgentState, type JsonObject } from "./index";
+import { type AgentState, AgentStateError, type JsonObject } from "./index";
 
 type UIMessage = Record<string, unknown> & {
   id?: string;
@@ -46,7 +46,7 @@ export interface AISDKRSCStateStore {
 }
 
 function buildChatKey(prefix: string, chatId: string): string {
-  return `${prefix}/${chatId}`;
+  return `${prefix}/${encodeURIComponent(chatId)}`;
 }
 
 function defaultChatId(): string {
@@ -63,6 +63,10 @@ function ensureArray(value: unknown): UIMessage[] {
   return [];
 }
 
+function isMissingState(error: unknown): boolean {
+  return error instanceof AgentStateError && error.status === 404;
+}
+
 export function createAISDKChatStore(
   client: AgentState,
   options: ChatStoreOptions = {},
@@ -72,7 +76,7 @@ export function createAISDKChatStore(
   const generateChatId = options.generateChatId ?? defaultChatId;
 
   async function saveMessages(chatId: string, messages: UIMessage[]): Promise<void> {
-    const payload: JsonObject = {
+    const payload = {
       kind: "ai-sdk-chat",
       runtime: "ai-sdk",
       messages,
@@ -80,17 +84,21 @@ export function createAISDKChatStore(
 
     await client.upsertState(buildChatKey(stateKeyPrefix, chatId), {
       agent_id: agentId,
-      data: payload,
+      data: payload as unknown as JsonObject,
       metadata: { adapter: "ai-sdk-chat", format: "v2-ui-messages" },
       tags: ["agentstate:ai-sdk", "agentstate:ui", `agentstate:thread:${chatId}`],
     });
   }
 
   async function loadMessages(chatId: string): Promise<UIMessage[]> {
-    const state = await client.getState(buildChatKey(stateKeyPrefix, chatId)).catch(() => ({
-      data: {},
-    }));
-    const data = (state as Partial<JsonObject> & { data?: unknown }).data;
+    let state: unknown;
+    try {
+      state = await client.getState(buildChatKey(stateKeyPrefix, chatId));
+    } catch (error) {
+      if (!isMissingState(error)) throw error;
+      state = { data: {} };
+    }
+    const data = (state as unknown as Partial<JsonObject> & { data?: unknown }).data;
     return ensureArray((data as JsonObject)?.messages);
   }
 
@@ -105,7 +113,13 @@ export function createAISDKChatStore(
       return loadMessages(chatId);
     },
 
-    saveChat: async ({ chatId, messages }: { chatId: string; messages: UIMessage[] }): Promise<void> => {
+    saveChat: async ({
+      chatId,
+      messages,
+    }: {
+      chatId: string;
+      messages: UIMessage[];
+    }): Promise<void> => {
       await saveMessages(chatId, messages);
     },
 
@@ -116,7 +130,7 @@ export function createAISDKChatStore(
 }
 
 function defaultRscStateKey(prefix: string, stateKey: string): string {
-  return `${prefix}/${stateKey}`;
+  return `${prefix}/${encodeURIComponent(stateKey)}`;
 }
 
 export function createAISDKRSCStateStore(
@@ -132,19 +146,19 @@ export function createAISDKRSCStateStore(
 
   async function loadStoredRSCState(): Promise<RSCStatePayload> {
     const state = await client.getState(stateKey);
-    const data = (state as Partial<JsonObject> & { data?: unknown }).data as JsonObject | undefined;
+    const data = (state as unknown as { data?: JsonObject }).data;
     return {
       kind: "ai-sdk-rsc",
       runtime: "ai-sdk",
-      ai_state: ((data ?? {}) as JsonObject).ai_state as JsonObject | null ?? null,
-      ui_messages: ensureArray(((data ?? {}) as JsonObject).ui_messages),
+      ai_state: (data?.ai_state as JsonObject | null | undefined) ?? null,
+      ui_messages: ensureArray(data?.ui_messages),
     };
   }
 
   async function saveState(payload: RSCStatePayload): Promise<void> {
     await client.upsertState(stateKey, {
       agent_id: agentId,
-      data: payload,
+      data: payload as unknown as JsonObject,
       metadata: { adapter: "ai-sdk-rsc", format: "v2-ui-messages" },
       tags: ["agentstate:ai-sdk", "agentstate:rsc", `agentstate:rsc:${options.stateKey}`],
     });
@@ -152,12 +166,18 @@ export function createAISDKRSCStateStore(
 
   return {
     loadAIState: async () => {
-      const state = await loadStoredRSCState().catch(() => ({
-        kind: "ai-sdk-rsc" as const,
-        runtime: "ai-sdk" as const,
-        ai_state: null,
-        ui_messages: [],
-      }));
+      let state: RSCStatePayload;
+      try {
+        state = await loadStoredRSCState();
+      } catch (error) {
+        if (!isMissingState(error)) throw error;
+        state = {
+          kind: "ai-sdk-rsc",
+          runtime: "ai-sdk",
+          ai_state: null,
+          ui_messages: [],
+        };
+      }
       return state.ai_state;
     },
 
@@ -181,12 +201,18 @@ export function createAISDKRSCStateStore(
     },
 
     onGetUIState: async () => {
-      const state = await loadStoredRSCState().catch(() => ({
-        kind: "ai-sdk-rsc" as const,
-        runtime: "ai-sdk" as const,
-        ai_state: null,
-        ui_messages: [],
-      }));
+      let state: RSCStatePayload;
+      try {
+        state = await loadStoredRSCState();
+      } catch (error) {
+        if (!isMissingState(error)) throw error;
+        state = {
+          kind: "ai-sdk-rsc",
+          runtime: "ai-sdk",
+          ai_state: null,
+          ui_messages: [],
+        };
+      }
       return state.ui_messages;
     },
   };

--- a/packages/sdk/src/ai-sdk.ts
+++ b/packages/sdk/src/ai-sdk.ts
@@ -1,0 +1,193 @@
+import { AgentState, type JsonObject } from "./index";
+
+type UIMessage = Record<string, unknown> & {
+  id?: string;
+  role?: string;
+};
+
+interface ChatStoreStatePayload {
+  kind: "ai-sdk-chat";
+  runtime: "ai-sdk";
+  messages: UIMessage[];
+}
+
+interface RSCStatePayload {
+  kind: "ai-sdk-rsc";
+  runtime: "ai-sdk";
+  ai_state: JsonObject | null;
+  ui_messages: UIMessage[];
+}
+
+interface ChatStoreOptions {
+  agentId?: string;
+  stateKeyPrefix?: string;
+  generateChatId?: () => string;
+}
+
+interface RSCStoreOptions {
+  stateKey: string;
+  agentId?: string;
+  stateKeyPrefix?: string;
+  mapAIStateToUIMessages?: (state: JsonObject | null) => UIMessage[];
+}
+
+export interface AISDKChatStore {
+  createChat: () => Promise<string>;
+  loadChat: (chatId: string) => Promise<UIMessage[]>;
+  saveChat: (input: { chatId: string; messages: UIMessage[] }) => Promise<void>;
+  deleteChat: (chatId: string) => Promise<void>;
+}
+
+export interface AISDKRSCStateStore {
+  loadAIState: () => Promise<JsonObject | null>;
+  saveAIState: (state: JsonObject | null) => Promise<void>;
+  onSetAIState: (params: { state: JsonObject | null; done: boolean }) => Promise<void>;
+  onGetUIState: () => Promise<UIMessage[]>;
+}
+
+function buildChatKey(prefix: string, chatId: string): string {
+  return `${prefix}/${chatId}`;
+}
+
+function defaultChatId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function ensureArray(value: unknown): UIMessage[] {
+  if (Array.isArray(value)) {
+    return value as UIMessage[];
+  }
+  return [];
+}
+
+export function createAISDKChatStore(
+  client: AgentState,
+  options: ChatStoreOptions = {},
+): AISDKChatStore {
+  const agentId = options.agentId ?? "agentstate-sdk";
+  const stateKeyPrefix = options.stateKeyPrefix ?? "agentstate/ai-sdk/chat";
+  const generateChatId = options.generateChatId ?? defaultChatId;
+
+  async function saveMessages(chatId: string, messages: UIMessage[]): Promise<void> {
+    const payload: JsonObject = {
+      kind: "ai-sdk-chat",
+      runtime: "ai-sdk",
+      messages,
+    } as ChatStoreStatePayload;
+
+    await client.upsertState(buildChatKey(stateKeyPrefix, chatId), {
+      agent_id: agentId,
+      data: payload,
+      metadata: { adapter: "ai-sdk-chat", format: "v2-ui-messages" },
+      tags: ["agentstate:ai-sdk", "agentstate:ui", `agentstate:thread:${chatId}`],
+    });
+  }
+
+  async function loadMessages(chatId: string): Promise<UIMessage[]> {
+    const state = await client.getState(buildChatKey(stateKeyPrefix, chatId)).catch(() => ({
+      data: {},
+    }));
+    const data = (state as Partial<JsonObject> & { data?: unknown }).data;
+    return ensureArray((data as JsonObject)?.messages);
+  }
+
+  return {
+    createChat: async () => {
+      const chatId = generateChatId();
+      await saveMessages(chatId, []);
+      return chatId;
+    },
+
+    loadChat: async (chatId: string): Promise<UIMessage[]> => {
+      return loadMessages(chatId);
+    },
+
+    saveChat: async ({ chatId, messages }: { chatId: string; messages: UIMessage[] }): Promise<void> => {
+      await saveMessages(chatId, messages);
+    },
+
+    deleteChat: async (chatId: string): Promise<void> => {
+      await client.deleteState(buildChatKey(stateKeyPrefix, chatId));
+    },
+  };
+}
+
+function defaultRscStateKey(prefix: string, stateKey: string): string {
+  return `${prefix}/${stateKey}`;
+}
+
+export function createAISDKRSCStateStore(
+  client: AgentState,
+  options: RSCStoreOptions,
+): AISDKRSCStateStore {
+  const agentId = options.agentId ?? "agentstate-sdk";
+  const stateKey = defaultRscStateKey(
+    options.stateKeyPrefix ?? "agentstate/ai-sdk/rsc",
+    options.stateKey,
+  );
+  const mapStateToUI = options.mapAIStateToUIMessages ?? (() => []);
+
+  async function loadStoredRSCState(): Promise<RSCStatePayload> {
+    const state = await client.getState(stateKey);
+    const data = (state as Partial<JsonObject> & { data?: unknown }).data as JsonObject | undefined;
+    return {
+      kind: "ai-sdk-rsc",
+      runtime: "ai-sdk",
+      ai_state: ((data ?? {}) as JsonObject).ai_state as JsonObject | null ?? null,
+      ui_messages: ensureArray(((data ?? {}) as JsonObject).ui_messages),
+    };
+  }
+
+  async function saveState(payload: RSCStatePayload): Promise<void> {
+    await client.upsertState(stateKey, {
+      agent_id: agentId,
+      data: payload,
+      metadata: { adapter: "ai-sdk-rsc", format: "v2-ui-messages" },
+      tags: ["agentstate:ai-sdk", "agentstate:rsc", `agentstate:rsc:${options.stateKey}`],
+    });
+  }
+
+  return {
+    loadAIState: async () => {
+      const state = await loadStoredRSCState().catch(() => ({
+        kind: "ai-sdk-rsc" as const,
+        runtime: "ai-sdk" as const,
+        ai_state: null,
+        ui_messages: [],
+      }));
+      return state.ai_state;
+    },
+
+    saveAIState: async (state: JsonObject | null) => {
+      await saveState({
+        kind: "ai-sdk-rsc",
+        runtime: "ai-sdk",
+        ai_state: state,
+        ui_messages: mapStateToUI(state),
+      });
+    },
+
+    onSetAIState: async ({ state, done }) => {
+      if (!done) return;
+      await saveState({
+        kind: "ai-sdk-rsc",
+        runtime: "ai-sdk",
+        ai_state: state,
+        ui_messages: mapStateToUI(state),
+      });
+    },
+
+    onGetUIState: async () => {
+      const state = await loadStoredRSCState().catch(() => ({
+        kind: "ai-sdk-rsc" as const,
+        runtime: "ai-sdk" as const,
+        ai_state: null,
+        ui_messages: [],
+      }));
+      return state.ui_messages;
+    },
+  };
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -133,7 +133,7 @@ export interface CreateStateLeaseRequest {
 }
 
 export interface RenewStateLeaseRequest {
-  ttl_seconds?: number;
+  ttl_ms?: number;
 }
 
 export interface StateLease {
@@ -149,10 +149,9 @@ export interface StateLease {
 }
 
 export interface CreateCapabilityTokenRequest {
-  name?: string;
-  state_key?: string;
+  name: string;
   scopes: CapabilityTokenScope[];
-  ttl_seconds?: number;
+  expires_at?: number;
 }
 
 export interface CapabilityToken {

--- a/packages/sdk/src/langgraph.ts
+++ b/packages/sdk/src/langgraph.ts
@@ -1,0 +1,552 @@
+import { AgentState, type JsonObject } from "./index";
+
+type Checkpoint = Record<string, unknown>;
+type RunnableConfig = {
+  configurable: {
+    thread_id: string;
+    checkpoint_ns?: string;
+    checkpoint_id?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+type Base64Envelope = {
+  encoding: "base64-json";
+  data: string;
+};
+
+type CheckpointRecord = {
+  kind: "checkpoint";
+  runtime: "langgraph";
+  thread_id: string;
+  checkpoint_ns: string;
+  checkpoint_id: string;
+  parent_checkpoint_id: string | null;
+  checkpoint: Base64Envelope;
+  metadata: Base64Envelope;
+  versions: JsonObject;
+};
+
+type PendingWriteRecord = {
+  kind: "checkpoint-writes";
+  runtime: "langgraph";
+  thread_id: string;
+  checkpoint_ns: string;
+  checkpoint_id: string;
+  task_id: string;
+  task_path: string;
+  writes: Base64Envelope;
+};
+
+type StoredState = {
+  state_key: string;
+  data: JsonObject;
+  metadata: JsonObject | null;
+  latest_sequence: number;
+};
+
+type PendingWriteTuple = [string, string, unknown];
+
+type CheckpointTuple = {
+  config: RunnableConfig;
+  checkpoint: Checkpoint;
+  metadata: unknown;
+  parentConfig?: RunnableConfig;
+  pendingWrites?: Array<PendingWriteTuple>;
+};
+
+export interface AGENTSTATELangGraphOptions {
+  agentId?: string;
+  stateKeyPrefix?: string;
+}
+
+type ListOptions = {
+  limit?: number;
+  after?: string | RunnableConfig;
+  before?: string | RunnableConfig;
+  filter?: Record<string, unknown>;
+};
+
+const DEFAULT_NAMESPACE = "";
+const DEFAULT_AGENT_ID = "agentstate-sdk";
+const DEFAULT_PREFIX = "agentstate/langgraph";
+const DEFAULT_LIST_LIMIT = 50;
+const PAGE_SIZE = 100;
+const BASE_RUNTIME = "langgraph";
+
+const BaseCheckpointSaver = class {};
+
+type CheckpointTagType = "checkpoint" | "checkpoint-write";
+type RunnableConfigLike = string | RunnableConfig;
+
+function checkpointIdFromConfig(value: RunnableConfigLike | undefined): string {
+  if (!value) return "";
+  return typeof value === "string" ? value : getCheckpointId(value);
+}
+
+function kindToTag(kind: "checkpoint" | "checkpoint-writes"): CheckpointTagType {
+  return kind === "checkpoint-writes" ? "checkpoint-write" : "checkpoint";
+}
+
+function encodeBase64(value: unknown): string {
+  const json = JSON.stringify(value);
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(json, "utf-8").toString("base64");
+  }
+
+  return btoa(unescape(encodeURIComponent(json)));
+}
+
+function decodeBase64(data: string): unknown {
+  if (typeof Buffer !== "undefined") {
+    return JSON.parse(Buffer.from(data, "base64").toString("utf-8"));
+  }
+
+  return JSON.parse(decodeURIComponent(escape(atob(data))));
+}
+
+function normalizeNamespace(value?: string): string {
+  return value || DEFAULT_NAMESPACE;
+}
+
+function normalizeNamespaceForKey(value?: string): string {
+  return normalizeNamespace(value) || "default";
+}
+
+function createStateKey(prefix: string, threadId: string, checkpointNs: string, checkpointId: string): string {
+  return `${prefix}/${threadId}/${normalizeNamespaceForKey(checkpointNs)}/${checkpointId}`;
+}
+
+function createWriteStateKey(
+  prefix: string,
+  threadId: string,
+  checkpointNs: string,
+  checkpointId: string,
+  taskId: string,
+): string {
+  return `${prefix}/${threadId}/${normalizeNamespaceForKey(checkpointNs)}/writes/${checkpointId}/${taskId}`;
+}
+
+function toTags(runtime: CheckpointTagType, threadId: string): string[] {
+  return [
+    `agentstate:${BASE_RUNTIME}`,
+    `agentstate:${runtime}`,
+    `agentstate:thread:${threadId}`,
+  ];
+}
+
+function ensureString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function getThreadId(config: RunnableConfig): string {
+  if (!config.configurable?.thread_id || typeof config.configurable.thread_id !== "string") {
+    throw new Error("LangGraph config missing required configurable.thread_id");
+  }
+  return config.configurable.thread_id;
+}
+
+function getCheckpointId(config: RunnableConfig): string {
+  return ensureString(config.configurable.checkpoint_id);
+}
+
+function getStateKeyPrefix(config: RunnableConfig): string {
+  return normalizeNamespace(config.configurable.checkpoint_ns);
+}
+
+function buildConfig(threadId: string, checkpointNs: string, checkpointId: string): RunnableConfig {
+  return {
+    configurable: {
+      thread_id: threadId,
+      checkpoint_ns: checkpointNs,
+      checkpoint_id: checkpointId,
+    },
+  };
+}
+
+function extractVersions(checkpoint: unknown): JsonObject {
+  if (!checkpoint || typeof checkpoint !== "object") {
+    return {};
+  }
+
+  const raw = checkpoint as Record<string, unknown>;
+  const channelVersions = (raw.channel_versions as JsonObject) ?? {};
+  const runtimeVersions = (raw.versions as JsonObject) ?? {};
+  return { ...channelVersions, ...runtimeVersions };
+}
+
+function normalizePendingWrites(writes: unknown, taskId: string): PendingWriteTuple[] {
+  if (!Array.isArray(writes)) return [];
+
+  const entries: PendingWriteTuple[] = [];
+
+  for (const item of writes) {
+    if (!Array.isArray(item)) continue;
+
+    const tuple = item as Array<unknown>;
+    if (tuple.length === 2 && typeof tuple[0] === "string") {
+      entries.push([taskId, tuple[0], tuple[1]]);
+      continue;
+    }
+
+    if (tuple.length >= 3 && typeof tuple[0] === "string" && typeof tuple[1] === "string") {
+      entries.push([tuple[0], tuple[1], tuple[2]]);
+      continue;
+    }
+  }
+
+  return entries;
+}
+
+function normalizeTupleWrites(value: unknown): Array<PendingWriteTuple> {
+  if (!Array.isArray(value)) return [];
+
+  const output: Array<PendingWriteTuple> = [];
+
+  for (const item of value) {
+    if (!Array.isArray(item)) continue;
+    const tuple = item as Array<unknown>;
+    if (tuple.length >= 3 && typeof tuple[0] === "string" && typeof tuple[1] === "string") {
+      output.push([tuple[0], tuple[1], tuple[2]]);
+    }
+  }
+
+  return output;
+}
+
+function extractCheckpointId(checkpoint: Checkpoint): string {
+  return ensureString((checkpoint as Record<string, unknown>).id);
+}
+
+type QueryStateResponse = {
+  data: StoredState[];
+  pagination?: { next_cursor?: string | null };
+};
+
+export class AgentStateCheckpointSaver extends BaseCheckpointSaver {
+  private readonly client: AgentState;
+  private readonly agentId: string;
+  private readonly stateKeyPrefix: string;
+
+  constructor(client: AgentState, options: AGENTSTATELangGraphOptions = {}) {
+    super();
+    this.client = client;
+    this.agentId = options.agentId ?? DEFAULT_AGENT_ID;
+    this.stateKeyPrefix = options.stateKeyPrefix ?? DEFAULT_PREFIX;
+  }
+
+  private async queryRecords(
+    threadId: string,
+    checkpointNs: string | null,
+    options: {
+      limit: number;
+      before?: RunnableConfigLike;
+      after?: RunnableConfigLike;
+      kind: "checkpoint" | "checkpoint-writes";
+      extraPredicates?: Array<{ path: string; equals: unknown }>;
+      filter?: Record<string, unknown>;
+    },
+  ): Promise<StoredState[]> {
+    const limit = options.limit;
+    const collected: StoredState[] = [];
+    let cursor: string | undefined;
+
+    const normalizedBefore = checkpointIdFromConfig(options.before);
+    const normalizedAfter = checkpointIdFromConfig(options.after);
+    const filterPredicates = options.filter
+      ? Object.entries(options.filter).map(([key, value]) => ({
+          path: key.startsWith("$.") ? key : `$.${key}`,
+          equals: value,
+        }))
+      : [];
+
+    const kindPredicates = [
+      { path: "$.kind", equals: options.kind },
+      { path: "$.runtime", equals: BASE_RUNTIME },
+      { path: "$.thread_id", equals: threadId },
+    ];
+    if (checkpointNs !== null) {
+      kindPredicates.push({ path: "$.checkpoint_ns", equals: checkpointNs });
+    }
+
+    const predicates = options.extraPredicates
+      ? kindPredicates.concat(options.extraPredicates)
+      : kindPredicates;
+    const filteredPredicates = filterPredicates.length
+      ? predicates.concat(filterPredicates)
+      : predicates;
+
+    while (collected.length < limit) {
+      const response = await this.client.queryStates({
+        agent_id: this.agentId,
+        tags: toTags(kindToTag(options.kind), threadId),
+        predicates: filteredPredicates,
+        limit: Math.min(PAGE_SIZE, limit - collected.length),
+        cursor,
+      }) as QueryStateResponse;
+
+      const rows = (response.data ?? []) as StoredState[];
+      collected.push(...rows);
+
+      const nextCursor = response.pagination?.next_cursor;
+      if (!nextCursor || rows.length === 0) {
+        break;
+      }
+
+      cursor = nextCursor;
+    }
+
+    const sorted = collected
+      .slice()
+      .sort((left, right) => right.latest_sequence - left.latest_sequence)
+      .filter((row, index, all) => index === all.findIndex((entry) => (entry.state_key === row.state_key)));
+
+    let filtered = sorted;
+
+    if (normalizedBefore && options.kind === "checkpoint") {
+      const beforeState = sorted.findIndex((state) => {
+        const tuple = this.parseCheckpointState(state);
+        return tuple.checkpoint_id === normalizedBefore;
+      });
+
+      if (beforeState >= 0) {
+        filtered = sorted.slice(beforeState + 1);
+      }
+    }
+
+    if (normalizedAfter && options.kind === "checkpoint") {
+      const afterState = sorted.findIndex((state) => {
+        const tuple = this.parseCheckpointState(state);
+        return tuple.checkpoint_id === normalizedAfter;
+      });
+
+      if (afterState >= 0) {
+        filtered = sorted.slice(0, afterState);
+      }
+    }
+
+    return filtered.slice(0, limit);
+  }
+
+  private parseCheckpointState(state: StoredState): CheckpointRecord {
+    const data = state.data as JsonObject;
+    if (data.kind !== "checkpoint" || data.runtime !== BASE_RUNTIME) {
+      throw new Error("Invalid checkpoint state record");
+    }
+    return data as unknown as CheckpointRecord;
+  }
+
+  private parseWriteState(state: StoredState): PendingWriteRecord {
+    const data = state.data as JsonObject;
+    if (data.kind !== "checkpoint-writes" || data.runtime !== BASE_RUNTIME) {
+      throw new Error("Invalid checkpoint write record");
+    }
+    return data as unknown as PendingWriteRecord;
+  }
+
+  private parseCheckpointTuple(state: StoredState): Omit<CheckpointTuple, "pendingWrites"> {
+    const record = this.parseCheckpointState(state);
+    return {
+      config: buildConfig(record.thread_id, record.checkpoint_ns, record.checkpoint_id),
+      checkpoint: decodeBase64(record.checkpoint.data) as Checkpoint,
+      metadata: decodeBase64(record.metadata.data),
+      parentConfig: record.parent_checkpoint_id
+        ? buildConfig(record.thread_id, record.checkpoint_ns, record.parent_checkpoint_id)
+        : undefined,
+    };
+  }
+
+  private async parsePendingWrites(threadId: string, checkpointNs: string, checkpointId: string): Promise<Array<PendingWriteTuple>> {
+    const rows = await this.queryRecords(threadId, checkpointNs, {
+      kind: "checkpoint-writes",
+      limit: PAGE_SIZE,
+      extraPredicates: [{ path: "$.checkpoint_id", equals: checkpointId }],
+    });
+
+    return rows
+      .flatMap((row) => {
+        const writeEnvelope = this.parseWriteState(row);
+        const decoded = decodeBase64(writeEnvelope.writes.data);
+        return normalizeTupleWrites(decoded);
+      })
+      .filter((entry): entry is PendingWriteTuple =>
+        Array.isArray(entry) && entry.length === 3 && typeof entry[0] === "string" && typeof entry[1] === "string");
+  }
+
+  private async getLatestCheckpoint(threadId: string, checkpointNs: string): Promise<StoredState | undefined> {
+    const rows = await this.queryRecords(threadId, checkpointNs, {
+      kind: "checkpoint",
+      limit: 1,
+    });
+
+    return rows[0];
+  }
+
+  async getTuple(config: RunnableConfig): Promise<CheckpointTuple | undefined> {
+    const threadId = getThreadId(config);
+    const checkpointNs = getStateKeyPrefix(config);
+
+    const configuredCheckpointId = getCheckpointId(config);
+    let state: StoredState | undefined;
+
+    if (configuredCheckpointId) {
+      const stateKey = createStateKey(
+        this.stateKeyPrefix,
+        threadId,
+        checkpointNs,
+        configuredCheckpointId,
+      );
+      try {
+        state = (await this.client.getState(stateKey)) as unknown as StoredState;
+      } catch {
+        return undefined;
+      }
+    } else {
+      state = await this.getLatestCheckpoint(threadId, checkpointNs);
+    }
+
+    if (!state) return undefined;
+
+    const tuple = this.parseCheckpointTuple(state);
+    const pendingWrites = await this.parsePendingWrites(
+      threadId,
+      checkpointNs,
+      ensureString(this.parseCheckpointState(state).checkpoint_id),
+    );
+
+    return pendingWrites.length ? { ...tuple, pendingWrites } : tuple;
+  }
+
+  async *list(config: RunnableConfig, options: ListOptions = {}): AsyncGenerator<CheckpointTuple> {
+    const threadId = getThreadId(config);
+    const checkpointNs = getStateKeyPrefix(config);
+    const limit = Math.min(options.limit ?? DEFAULT_LIST_LIMIT, PAGE_SIZE);
+
+    const records = await this.queryRecords(threadId, checkpointNs, {
+      kind: "checkpoint",
+      limit,
+      after: options.after,
+      before: options.before,
+      filter: options.filter,
+    });
+
+    const filtered = records.slice(0, limit);
+
+    for (const state of filtered) {
+      const tuple = this.parseCheckpointTuple(state);
+      const pendingWrites = await this.parsePendingWrites(
+        threadId,
+        checkpointNs,
+        ensureString(this.parseCheckpointState(state).checkpoint_id),
+      );
+
+      yield pendingWrites.length
+        ? { ...tuple, pendingWrites }
+        : tuple;
+    }
+  }
+
+  async put(
+    config: RunnableConfig,
+    checkpoint: Checkpoint,
+    metadata: unknown = null,
+    newVersions: JsonObject = {},
+  ): Promise<RunnableConfig> {
+    const threadId = getThreadId(config);
+    const checkpointNs = getStateKeyPrefix(config);
+    const checkpointId = extractCheckpointId(checkpoint) || `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    const parentCheckpointId = getCheckpointId(config) || null;
+
+    const checkpointVersions = extractVersions(checkpoint);
+    const versionData = Object.keys(newVersions ?? {}).length > 0 ? newVersions : checkpointVersions;
+
+    await this.client.upsertState(createStateKey(this.stateKeyPrefix, threadId, checkpointNs, checkpointId), {
+      agent_id: this.agentId,
+      data: {
+        kind: "checkpoint",
+        runtime: BASE_RUNTIME,
+        thread_id: threadId,
+        checkpoint_ns: checkpointNs,
+        checkpoint_id: checkpointId,
+        parent_checkpoint_id: parentCheckpointId,
+        checkpoint: {
+          encoding: "base64-json",
+          data: encodeBase64(checkpoint),
+        },
+        metadata: {
+          encoding: "base64-json",
+          data: encodeBase64(metadata),
+        },
+        versions: versionData,
+      },
+      metadata: {
+        runtime: BASE_RUNTIME,
+        kind: "checkpoint",
+      },
+      tags: toTags("checkpoint", threadId),
+    });
+
+    return buildConfig(threadId, checkpointNs, checkpointId);
+  }
+
+  async putWrites(
+    config: RunnableConfig,
+    writes: unknown,
+    taskId: string,
+    taskPath = "",
+  ): Promise<void> {
+    const threadId = getThreadId(config);
+    const checkpointNs = getStateKeyPrefix(config);
+    const checkpointId = getCheckpointId(config);
+
+    if (!checkpointId) {
+      throw new Error("Cannot save pending writes without checkpoint_id in config");
+    }
+
+    const pendingWrites = normalizePendingWrites(writes, taskId);
+
+    await this.client.upsertState(
+      createWriteStateKey(this.stateKeyPrefix, threadId, checkpointNs, checkpointId, taskId),
+      {
+        agent_id: this.agentId,
+        data: {
+          kind: "checkpoint-writes",
+          runtime: BASE_RUNTIME,
+          thread_id: threadId,
+          checkpoint_ns: checkpointNs,
+          checkpoint_id: checkpointId,
+          task_id: taskId,
+          task_path: taskPath,
+          writes: {
+            encoding: "base64-json",
+            data: encodeBase64(pendingWrites),
+          },
+        },
+        metadata: {
+          runtime: BASE_RUNTIME,
+          kind: "checkpoint-write",
+        },
+        tags: toTags("checkpoint-write", threadId),
+      },
+    );
+  }
+
+  async deleteThread(threadId: string): Promise<void> {
+    const checkpoints = await this.queryRecords(threadId, null, {
+      kind: "checkpoint",
+      limit: 1000000,
+    });
+
+    const writes = await this.queryRecords(threadId, null, {
+      kind: "checkpoint-writes",
+      limit: 1000000,
+    });
+
+    const keys = [...checkpoints, ...writes].map((state) => state.state_key);
+
+    await Promise.all(
+      keys.map((key) => this.client.deleteState(key).catch(() => undefined)),
+    );
+  }
+}

--- a/packages/sdk/src/langgraph.ts
+++ b/packages/sdk/src/langgraph.ts
@@ -1,4 +1,15 @@
-import { AgentState, type JsonObject } from "./index";
+import { type AgentState, AgentStateError, type JsonObject, type JsonValue } from "./index";
+
+declare const Buffer:
+  | {
+      from(
+        data: string,
+        encoding: "base64" | "utf-8",
+      ): {
+        toString(encoding: "base64" | "utf-8"): string;
+      };
+    }
+  | undefined;
 
 type Checkpoint = Record<string, unknown>;
 type RunnableConfig = {
@@ -114,7 +125,12 @@ function normalizeNamespaceForKey(value?: string): string {
   return normalizeNamespace(value) || "default";
 }
 
-function createStateKey(prefix: string, threadId: string, checkpointNs: string, checkpointId: string): string {
+function createStateKey(
+  prefix: string,
+  threadId: string,
+  checkpointNs: string,
+  checkpointId: string,
+): string {
   return `${prefix}/${threadId}/${normalizeNamespaceForKey(checkpointNs)}/${checkpointId}`;
 }
 
@@ -129,11 +145,7 @@ function createWriteStateKey(
 }
 
 function toTags(runtime: CheckpointTagType, threadId: string): string[] {
-  return [
-    `agentstate:${BASE_RUNTIME}`,
-    `agentstate:${runtime}`,
-    `agentstate:thread:${threadId}`,
-  ];
+  return [`agentstate:${BASE_RUNTIME}`, `agentstate:${runtime}`, `agentstate:thread:${threadId}`];
 }
 
 function ensureString(value: unknown): string {
@@ -192,7 +204,6 @@ function normalizePendingWrites(writes: unknown, taskId: string): PendingWriteTu
 
     if (tuple.length >= 3 && typeof tuple[0] === "string" && typeof tuple[1] === "string") {
       entries.push([tuple[0], tuple[1], tuple[2]]);
-      continue;
     }
   }
 
@@ -224,6 +235,47 @@ type QueryStateResponse = {
   pagination?: { next_cursor?: string | null };
 };
 
+type QueryKind = "checkpoint" | "checkpoint-writes";
+type QueryPredicate = { path: string; equals: JsonValue };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function deepEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+      return false;
+    }
+    return left.every((value, index) => deepEqual(value, right[index]));
+  }
+
+  if (isRecord(left) || isRecord(right)) {
+    if (!isRecord(left) || !isRecord(right)) return false;
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+    if (leftKeys.length !== rightKeys.length) return false;
+    return leftKeys.every((key) => Object.hasOwn(right, key) && deepEqual(left[key], right[key]));
+  }
+
+  return false;
+}
+
+function matchesFilter(data: JsonObject, filter?: Record<string, unknown>): boolean {
+  if (!filter) return true;
+
+  return Object.entries(filter).every(([key, value]) => {
+    const dataKey = key.startsWith("$.") ? key.slice(2) : key;
+    return deepEqual(data[dataKey], value);
+  });
+}
+
+function isMissingState(error: unknown): boolean {
+  return error instanceof AgentStateError && error.status === 404;
+}
+
 export class AgentStateCheckpointSaver extends BaseCheckpointSaver {
   private readonly client: AgentState;
   private readonly agentId: string;
@@ -240,11 +292,11 @@ export class AgentStateCheckpointSaver extends BaseCheckpointSaver {
     threadId: string,
     checkpointNs: string | null,
     options: {
-      limit: number;
+      limit?: number;
       before?: RunnableConfigLike;
       after?: RunnableConfigLike;
       kind: "checkpoint" | "checkpoint-writes";
-      extraPredicates?: Array<{ path: string; equals: unknown }>;
+      extraPredicates?: QueryPredicate[];
       filter?: Record<string, unknown>;
     },
   ): Promise<StoredState[]> {
@@ -254,14 +306,14 @@ export class AgentStateCheckpointSaver extends BaseCheckpointSaver {
 
     const normalizedBefore = checkpointIdFromConfig(options.before);
     const normalizedAfter = checkpointIdFromConfig(options.after);
-    const filterPredicates = options.filter
+    const filterPredicates: QueryPredicate[] = options.filter
       ? Object.entries(options.filter).map(([key, value]) => ({
           path: key.startsWith("$.") ? key : `$.${key}`,
-          equals: value,
+          equals: value as JsonValue,
         }))
       : [];
 
-    const kindPredicates = [
+    const kindPredicates: QueryPredicate[] = [
       { path: "$.kind", equals: options.kind },
       { path: "$.runtime", equals: BASE_RUNTIME },
       { path: "$.thread_id", equals: threadId },
@@ -277,17 +329,19 @@ export class AgentStateCheckpointSaver extends BaseCheckpointSaver {
       ? predicates.concat(filterPredicates)
       : predicates;
 
-    while (collected.length < limit) {
-      const response = await this.client.queryStates({
+    while (limit === undefined || collected.length < limit) {
+      const response = (await this.client.queryStates({
         agent_id: this.agentId,
         tags: toTags(kindToTag(options.kind), threadId),
         predicates: filteredPredicates,
-        limit: Math.min(PAGE_SIZE, limit - collected.length),
+        limit: limit === undefined ? PAGE_SIZE : Math.min(PAGE_SIZE, limit - collected.length),
         cursor,
-      }) as QueryStateResponse;
+      })) as QueryStateResponse;
 
       const rows = (response.data ?? []) as StoredState[];
-      collected.push(...rows);
+      collected.push(
+        ...rows.filter((row) => matchesFilter(row.data as JsonObject, options.filter)),
+      );
 
       const nextCursor = response.pagination?.next_cursor;
       if (!nextCursor || rows.length === 0) {
@@ -299,34 +353,40 @@ export class AgentStateCheckpointSaver extends BaseCheckpointSaver {
 
     const sorted = collected
       .slice()
-      .sort((left, right) => right.latest_sequence - left.latest_sequence)
-      .filter((row, index, all) => index === all.findIndex((entry) => (entry.state_key === row.state_key)));
+      .sort((left, right) => right.latest_sequence - left.latest_sequence);
+    const deduped: StoredState[] = [];
+    const seen = new Set<string>();
+    for (const row of sorted) {
+      if (seen.has(row.state_key)) continue;
+      seen.add(row.state_key);
+      deduped.push(row);
+    }
 
-    let filtered = sorted;
+    let filtered = deduped;
 
     if (normalizedBefore && options.kind === "checkpoint") {
-      const beforeState = sorted.findIndex((state) => {
+      const beforeState = filtered.findIndex((state) => {
         const tuple = this.parseCheckpointState(state);
         return tuple.checkpoint_id === normalizedBefore;
       });
 
       if (beforeState >= 0) {
-        filtered = sorted.slice(beforeState + 1);
+        filtered = filtered.slice(beforeState + 1);
       }
     }
 
     if (normalizedAfter && options.kind === "checkpoint") {
-      const afterState = sorted.findIndex((state) => {
+      const afterState = filtered.findIndex((state) => {
         const tuple = this.parseCheckpointState(state);
         return tuple.checkpoint_id === normalizedAfter;
       });
 
       if (afterState >= 0) {
-        filtered = sorted.slice(0, afterState);
+        filtered = filtered.slice(0, afterState);
       }
     }
 
-    return filtered.slice(0, limit);
+    return limit === undefined ? filtered : filtered.slice(0, limit);
   }
 
   private parseCheckpointState(state: StoredState): CheckpointRecord {
@@ -357,10 +417,13 @@ export class AgentStateCheckpointSaver extends BaseCheckpointSaver {
     };
   }
 
-  private async parsePendingWrites(threadId: string, checkpointNs: string, checkpointId: string): Promise<Array<PendingWriteTuple>> {
+  private async parsePendingWrites(
+    threadId: string,
+    checkpointNs: string,
+    checkpointId: string,
+  ): Promise<Array<PendingWriteTuple>> {
     const rows = await this.queryRecords(threadId, checkpointNs, {
       kind: "checkpoint-writes",
-      limit: PAGE_SIZE,
       extraPredicates: [{ path: "$.checkpoint_id", equals: checkpointId }],
     });
 
@@ -370,11 +433,19 @@ export class AgentStateCheckpointSaver extends BaseCheckpointSaver {
         const decoded = decodeBase64(writeEnvelope.writes.data);
         return normalizeTupleWrites(decoded);
       })
-      .filter((entry): entry is PendingWriteTuple =>
-        Array.isArray(entry) && entry.length === 3 && typeof entry[0] === "string" && typeof entry[1] === "string");
+      .filter(
+        (entry): entry is PendingWriteTuple =>
+          Array.isArray(entry) &&
+          entry.length === 3 &&
+          typeof entry[0] === "string" &&
+          typeof entry[1] === "string",
+      );
   }
 
-  private async getLatestCheckpoint(threadId: string, checkpointNs: string): Promise<StoredState | undefined> {
+  private async getLatestCheckpoint(
+    threadId: string,
+    checkpointNs: string,
+  ): Promise<StoredState | undefined> {
     const rows = await this.queryRecords(threadId, checkpointNs, {
       kind: "checkpoint",
       limit: 1,
@@ -399,7 +470,8 @@ export class AgentStateCheckpointSaver extends BaseCheckpointSaver {
       );
       try {
         state = (await this.client.getState(stateKey)) as unknown as StoredState;
-      } catch {
+      } catch (error) {
+        if (!isMissingState(error)) throw error;
         return undefined;
       }
     } else {
@@ -441,9 +513,7 @@ export class AgentStateCheckpointSaver extends BaseCheckpointSaver {
         ensureString(this.parseCheckpointState(state).checkpoint_id),
       );
 
-      yield pendingWrites.length
-        ? { ...tuple, pendingWrites }
-        : tuple;
+      yield pendingWrites.length ? { ...tuple, pendingWrites } : tuple;
     }
   }
 
@@ -455,37 +525,42 @@ export class AgentStateCheckpointSaver extends BaseCheckpointSaver {
   ): Promise<RunnableConfig> {
     const threadId = getThreadId(config);
     const checkpointNs = getStateKeyPrefix(config);
-    const checkpointId = extractCheckpointId(checkpoint) || `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    const checkpointId =
+      extractCheckpointId(checkpoint) || `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
     const parentCheckpointId = getCheckpointId(config) || null;
 
     const checkpointVersions = extractVersions(checkpoint);
-    const versionData = Object.keys(newVersions ?? {}).length > 0 ? newVersions : checkpointVersions;
+    const versionData =
+      Object.keys(newVersions ?? {}).length > 0 ? newVersions : checkpointVersions;
 
-    await this.client.upsertState(createStateKey(this.stateKeyPrefix, threadId, checkpointNs, checkpointId), {
-      agent_id: this.agentId,
-      data: {
-        kind: "checkpoint",
-        runtime: BASE_RUNTIME,
-        thread_id: threadId,
-        checkpoint_ns: checkpointNs,
-        checkpoint_id: checkpointId,
-        parent_checkpoint_id: parentCheckpointId,
-        checkpoint: {
-          encoding: "base64-json",
-          data: encodeBase64(checkpoint),
+    await this.client.upsertState(
+      createStateKey(this.stateKeyPrefix, threadId, checkpointNs, checkpointId),
+      {
+        agent_id: this.agentId,
+        data: {
+          kind: "checkpoint",
+          runtime: BASE_RUNTIME,
+          thread_id: threadId,
+          checkpoint_ns: checkpointNs,
+          checkpoint_id: checkpointId,
+          parent_checkpoint_id: parentCheckpointId,
+          checkpoint: {
+            encoding: "base64-json",
+            data: encodeBase64(checkpoint),
+          },
+          metadata: {
+            encoding: "base64-json",
+            data: encodeBase64(metadata),
+          },
+          versions: versionData,
         },
         metadata: {
-          encoding: "base64-json",
-          data: encodeBase64(metadata),
+          runtime: BASE_RUNTIME,
+          kind: "checkpoint",
         },
-        versions: versionData,
+        tags: toTags("checkpoint", threadId),
       },
-      metadata: {
-        runtime: BASE_RUNTIME,
-        kind: "checkpoint",
-      },
-      tags: toTags("checkpoint", threadId),
-    });
+    );
 
     return buildConfig(threadId, checkpointNs, checkpointId);
   }
@@ -532,21 +607,46 @@ export class AgentStateCheckpointSaver extends BaseCheckpointSaver {
     );
   }
 
+  private async deleteRecords(threadId: string, kind: QueryKind): Promise<void> {
+    let cursor: string | undefined;
+
+    while (true) {
+      const response = (await this.client.queryStates({
+        agent_id: this.agentId,
+        tags: toTags(kindToTag(kind), threadId),
+        predicates: [
+          { path: "$.kind", equals: kind },
+          { path: "$.runtime", equals: BASE_RUNTIME },
+          { path: "$.thread_id", equals: threadId },
+        ],
+        limit: PAGE_SIZE,
+        cursor,
+      })) as QueryStateResponse;
+
+      const rows = (response.data ?? []) as StoredState[];
+      if (!rows.length) return;
+
+      const keys = Array.from(new Set(rows.map((state) => state.state_key)));
+      const results = await Promise.allSettled(keys.map((key) => this.client.deleteState(key)));
+      const failed = results.filter(
+        (result): result is PromiseRejectedResult => result.status === "rejected",
+      );
+      if (failed.length) {
+        const reasons = failed
+          .map((result) => result.reason)
+          .map((reason) => (reason instanceof Error ? reason.message : String(reason)))
+          .join("; ");
+        throw new Error(`Failed to delete ${failed.length} ${kind} state record(s): ${reasons}`);
+      }
+
+      const nextCursor = response.pagination?.next_cursor;
+      if (!nextCursor) return;
+      cursor = nextCursor;
+    }
+  }
+
   async deleteThread(threadId: string): Promise<void> {
-    const checkpoints = await this.queryRecords(threadId, null, {
-      kind: "checkpoint",
-      limit: 1000000,
-    });
-
-    const writes = await this.queryRecords(threadId, null, {
-      kind: "checkpoint-writes",
-      limit: 1000000,
-    });
-
-    const keys = [...checkpoints, ...writes].map((state) => state.state_key);
-
-    await Promise.all(
-      keys.map((key) => this.client.deleteState(key).catch(() => undefined)),
-    );
+    await this.deleteRecords(threadId, "checkpoint-writes");
+    await this.deleteRecords(threadId, "checkpoint");
   }
 }

--- a/packages/sdk/tests/ai-sdk.test.ts
+++ b/packages/sdk/tests/ai-sdk.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
-import {
-  createAISDKChatStore,
-  createAISDKRSCStateStore,
-} from "../src/ai-sdk";
+import { createAISDKChatStore, createAISDKRSCStateStore } from "../src/ai-sdk";
+import { AgentStateError } from "../src/index";
 
 const CHAT_STATE = {
   data: {
@@ -23,24 +21,44 @@ describe("AgentState AI SDK adapters", () => {
 
     const store = createAISDKChatStore(client as any, {
       stateKeyPrefix: "agentstate/ai-sdk/chat",
-      generateChatId: () => "chat-1",
+      generateChatId: () => "chat/1",
     });
 
     await store.createChat();
-    const loaded = await store.loadChat("chat-1");
+    const loaded = await store.loadChat("chat/1");
 
     expect(client.upsertState).toHaveBeenCalledTimes(1);
-    expect(client.getState).toHaveBeenCalledWith("agentstate/ai-sdk/chat/chat-1");
+    expect(client.getState).toHaveBeenCalledWith("agentstate/ai-sdk/chat/chat%2F1");
     expect(loaded).toEqual(CHAT_STATE.data.messages);
 
     await store.saveChat({
-      chatId: "chat-1",
+      chatId: "chat/1",
       messages: [{ id: "m2", role: "assistant", content: "hey" }],
     });
     expect(client.upsertState).toHaveBeenCalledTimes(2);
 
-    await store.deleteChat("chat-1");
-    expect(client.deleteState).toHaveBeenCalledWith("agentstate/ai-sdk/chat/chat-1");
+    await store.deleteChat("chat/1");
+    expect(client.deleteState).toHaveBeenCalledWith("agentstate/ai-sdk/chat/chat%2F1");
+  });
+
+  it("returns empty chat messages only when the state is missing", async () => {
+    const missingClient = {
+      upsertState: vi.fn().mockResolvedValue(undefined),
+      getState: vi.fn().mockRejectedValue(new AgentStateError("missing", "NOT_FOUND", 404)),
+      deleteState: vi.fn().mockResolvedValue(undefined),
+    };
+    const missingStore = createAISDKChatStore(missingClient as any);
+
+    await expect(missingStore.loadChat("missing")).resolves.toEqual([]);
+
+    const failedClient = {
+      upsertState: vi.fn().mockResolvedValue(undefined),
+      getState: vi.fn().mockRejectedValue(new AgentStateError("denied", "UNAUTHORIZED", 401)),
+      deleteState: vi.fn().mockResolvedValue(undefined),
+    };
+    const failedStore = createAISDKChatStore(failedClient as any);
+
+    await expect(failedStore.loadChat("private")).rejects.toMatchObject({ status: 401 });
   });
 
   it("uses RSC adapter to map AI state into UI messages", async () => {
@@ -71,10 +89,10 @@ describe("AgentState AI SDK adapters", () => {
     const uiMessages = await store.onGetUIState();
 
     expect(uiMessages).toHaveLength(1);
-    expect(uiMessages[0].content).toBe("beta");
+    expect(uiMessages[0].content).toBe("from-load");
     expect(client.upsertState).toHaveBeenCalledTimes(2);
 
     const loadState = await store.loadAIState();
-    expect(loadState).toEqual({ step: "alpha" });
+    expect(loadState).toEqual({ step: "first" });
   });
 });

--- a/packages/sdk/tests/ai-sdk.test.ts
+++ b/packages/sdk/tests/ai-sdk.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createAISDKChatStore,
+  createAISDKRSCStateStore,
+} from "../src/ai-sdk";
+
+const CHAT_STATE = {
+  data: {
+    kind: "ai-sdk-chat",
+    runtime: "ai-sdk",
+    messages: [{ id: "m1", role: "user", content: "hello" }],
+  },
+};
+
+describe("AgentState AI SDK adapters", () => {
+  it("stores and loads UI chat messages as full v2 state payload", async () => {
+    const client = {
+      upsertState: vi.fn().mockResolvedValue(undefined),
+      getState: vi.fn().mockResolvedValue(CHAT_STATE),
+      deleteState: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const store = createAISDKChatStore(client as any, {
+      stateKeyPrefix: "agentstate/ai-sdk/chat",
+      generateChatId: () => "chat-1",
+    });
+
+    await store.createChat();
+    const loaded = await store.loadChat("chat-1");
+
+    expect(client.upsertState).toHaveBeenCalledTimes(1);
+    expect(client.getState).toHaveBeenCalledWith("agentstate/ai-sdk/chat/chat-1");
+    expect(loaded).toEqual(CHAT_STATE.data.messages);
+
+    await store.saveChat({
+      chatId: "chat-1",
+      messages: [{ id: "m2", role: "assistant", content: "hey" }],
+    });
+    expect(client.upsertState).toHaveBeenCalledTimes(2);
+
+    await store.deleteChat("chat-1");
+    expect(client.deleteState).toHaveBeenCalledWith("agentstate/ai-sdk/chat/chat-1");
+  });
+
+  it("uses RSC adapter to map AI state into UI messages", async () => {
+    const client = {
+      upsertState: vi.fn().mockResolvedValue(undefined),
+      getState: vi.fn().mockResolvedValue({
+        data: {
+          kind: "ai-sdk-rsc",
+          runtime: "ai-sdk",
+          ai_state: { step: "first" },
+          ui_messages: [{ id: "x", role: "assistant", content: "from-load" }],
+        },
+      }),
+      deleteState: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const store = createAISDKRSCStateStore(client as any, {
+      stateKey: "rsc-thread-1",
+      stateKeyPrefix: "agentstate/ai-sdk/rsc",
+      mapAIStateToUIMessages: (state) => {
+        if (!state) return [];
+        return [{ id: "mapped", role: "assistant", content: String(state.step) }];
+      },
+    });
+
+    await store.saveAIState({ step: "alpha" });
+    await store.onSetAIState({ state: { step: "beta" }, done: true });
+    const uiMessages = await store.onGetUIState();
+
+    expect(uiMessages).toHaveLength(1);
+    expect(uiMessages[0].content).toBe("beta");
+    expect(client.upsertState).toHaveBeenCalledTimes(2);
+
+    const loadState = await store.loadAIState();
+    expect(loadState).toEqual({ step: "alpha" });
+  });
+});

--- a/packages/sdk/tests/langgraph.test.ts
+++ b/packages/sdk/tests/langgraph.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { AgentStateError } from "../src/index";
 import { AgentStateCheckpointSaver } from "../src/langgraph";
 
 const CHECKPOINT_STATE = {
@@ -71,7 +72,10 @@ describe("AgentState LangGraph saver", () => {
     const saver = new AgentStateCheckpointSaver(client as any);
 
     const tuples = [];
-    for await (const tuple of saver.list({ configurable: { thread_id: "thread-1" }, before: { configurable: { thread_id: "thread-1", checkpoint_id: "cp-1" } } })) {
+    for await (const tuple of saver.list(
+      { configurable: { thread_id: "thread-1" } },
+      { before: { configurable: { thread_id: "thread-1", checkpoint_id: "cp-1" } } },
+    )) {
       tuples.push(tuple);
     }
 
@@ -89,10 +93,16 @@ describe("AgentState LangGraph saver", () => {
     };
 
     const client = {
-      queryStates: vi.fn().mockResolvedValueOnce({
-        data: [first, second],
-        pagination: { next_cursor: null },
-      }),
+      queryStates: vi
+        .fn()
+        .mockResolvedValueOnce({
+          data: [first, second],
+          pagination: { next_cursor: null },
+        })
+        .mockResolvedValue({
+          data: [],
+          pagination: { next_cursor: null },
+        }),
       getState: vi.fn(),
       upsertState: vi.fn(),
       deleteState: vi.fn(),
@@ -108,20 +118,65 @@ describe("AgentState LangGraph saver", () => {
     }
 
     expect((client.queryStates as any).mock.calls[0][0].predicates).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ path: "$.runtime", equals: "langgraph" }),
-      ]),
+      expect.arrayContaining([expect.objectContaining({ path: "$.runtime", equals: "langgraph" })]),
     );
     expect(tuples.length).toBe(1);
     expect(tuples[0].config.configurable.checkpoint_id).toBe("cp-1");
   });
 
+  it("returns undefined only for missing configured checkpoints", async () => {
+    const missingClient = {
+      getState: vi.fn().mockRejectedValue(new AgentStateError("missing", "NOT_FOUND", 404)),
+      queryStates: vi.fn(),
+      upsertState: vi.fn(),
+      deleteState: vi.fn(),
+    };
+    const missingSaver = new AgentStateCheckpointSaver(missingClient as any);
+
+    await expect(
+      missingSaver.getTuple({ configurable: { thread_id: "thread-1", checkpoint_id: "missing" } }),
+    ).resolves.toBeUndefined();
+
+    const failedClient = {
+      getState: vi.fn().mockRejectedValue(new AgentStateError("denied", "UNAUTHORIZED", 401)),
+      queryStates: vi.fn(),
+      upsertState: vi.fn(),
+      deleteState: vi.fn(),
+    };
+    const failedSaver = new AgentStateCheckpointSaver(failedClient as any);
+
+    await expect(
+      failedSaver.getTuple({ configurable: { thread_id: "thread-1", checkpoint_id: "cp-1" } }),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
   it("deletes checkpoints and write rows for an entire thread", async () => {
+    const writeState = {
+      state_key: "agentstate/langgraph/thread-1/default/writes/cp-1/task-1",
+      data: {
+        kind: "checkpoint-writes",
+        runtime: "langgraph",
+        thread_id: "thread-1",
+        checkpoint_ns: "",
+        checkpoint_id: "cp-1",
+        task_id: "task-1",
+        task_path: "",
+        writes: { encoding: "base64-json", data: "W10=" },
+      },
+      metadata: {},
+      latest_sequence: 3,
+    };
     const client = {
-      queryStates: vi.fn().mockResolvedValue({
-        data: [CHECKPOINT_STATE, SECOND_STATE],
-        pagination: { next_cursor: null },
-      }),
+      queryStates: vi
+        .fn()
+        .mockResolvedValueOnce({
+          data: [writeState],
+          pagination: { next_cursor: null },
+        })
+        .mockResolvedValueOnce({
+          data: [CHECKPOINT_STATE, SECOND_STATE],
+          pagination: { next_cursor: null },
+        }),
       deleteState: vi.fn().mockResolvedValue(undefined),
       upsertState: vi.fn(),
       getState: vi.fn(),
@@ -130,6 +185,28 @@ describe("AgentState LangGraph saver", () => {
     const saver = new AgentStateCheckpointSaver(client as any);
     await saver.deleteThread("thread-1");
 
-    expect(client.deleteState).toHaveBeenCalledTimes(2);
+    expect(client.deleteState).toHaveBeenCalledTimes(3);
+  });
+
+  it("fails thread deletion when any state delete fails", async () => {
+    const client = {
+      queryStates: vi
+        .fn()
+        .mockResolvedValueOnce({
+          data: [],
+          pagination: { next_cursor: null },
+        })
+        .mockResolvedValueOnce({
+          data: [CHECKPOINT_STATE],
+          pagination: { next_cursor: null },
+        }),
+      deleteState: vi.fn().mockRejectedValue(new Error("delete failed")),
+      upsertState: vi.fn(),
+      getState: vi.fn(),
+    };
+
+    const saver = new AgentStateCheckpointSaver(client as any);
+
+    await expect(saver.deleteThread("thread-1")).rejects.toThrow("Failed to delete");
   });
 });

--- a/packages/sdk/tests/langgraph.test.ts
+++ b/packages/sdk/tests/langgraph.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { AgentStateCheckpointSaver } from "../src/langgraph";
+
+const CHECKPOINT_STATE = {
+  state_key: "agentstate/langgraph/thread-1/default/cp-1",
+  data: {
+    kind: "checkpoint",
+    runtime: "langgraph",
+    thread_id: "thread-1",
+    checkpoint_ns: "",
+    checkpoint_id: "cp-1",
+    parent_checkpoint_id: null,
+    checkpoint: { encoding: "base64-json", data: "eyJzdGF0ZXMiOnt9fQ==" },
+    metadata: { encoding: "base64-json", data: "e30=" },
+    versions: {},
+  },
+  metadata: {},
+  latest_sequence: 2,
+};
+
+const SECOND_STATE = {
+  ...CHECKPOINT_STATE,
+  state_key: "agentstate/langgraph/thread-1/default/cp-2",
+  data: {
+    ...CHECKPOINT_STATE.data,
+    checkpoint_id: "cp-2",
+    checkpoint: { encoding: "base64-json", data: "eyJ2IjoiYW5vdGhlciJ9" },
+  },
+  latest_sequence: 1,
+};
+
+describe("AgentState LangGraph saver", () => {
+  it("stores checkpoints and pending writes in dedicated v2 envelopes", async () => {
+    const client = {
+      upsertState: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const saver = new AgentStateCheckpointSaver(client as any, { agentId: "agentstate-sdk" });
+    await saver.put(
+      { configurable: { thread_id: "thread-1", checkpoint_ns: "" } },
+      { id: "cp-1" },
+      { tag: "initial" },
+      {},
+    );
+    await saver.putWrites(
+      { configurable: { thread_id: "thread-1", checkpoint_id: "cp-1" } },
+      [["messages", "hello"]],
+      "task-1",
+    );
+
+    expect(client.upsertState).toHaveBeenCalledTimes(2);
+    expect((client.upsertState as any).mock.calls[1][0]).toContain("/writes/cp-1/task-1");
+  });
+
+  it("lists checkpoints before a cursor config", async () => {
+    const client = {
+      queryStates: vi
+        .fn()
+        .mockResolvedValueOnce({
+          data: [CHECKPOINT_STATE, SECOND_STATE],
+          pagination: { next_cursor: null },
+        })
+        .mockResolvedValueOnce({ data: [], pagination: { next_cursor: null } })
+        .mockResolvedValueOnce({ data: [], pagination: { next_cursor: null } }),
+      getState: vi.fn(),
+      upsertState: vi.fn(),
+      deleteState: vi.fn(),
+    };
+
+    const saver = new AgentStateCheckpointSaver(client as any);
+
+    const tuples = [];
+    for await (const tuple of saver.list({ configurable: { thread_id: "thread-1" }, before: { configurable: { thread_id: "thread-1", checkpoint_id: "cp-1" } } })) {
+      tuples.push(tuple);
+    }
+
+    expect(tuples.length).toBe(1);
+    expect(tuples[0].config.configurable.checkpoint_id).toBe("cp-2");
+  });
+
+  it("supports list filter predicates", async () => {
+    const first = { ...CHECKPOINT_STATE, data: { ...CHECKPOINT_STATE.data, runtime: "langgraph" } };
+    const second = {
+      ...CHECKPOINT_STATE,
+      state_key: "agentstate/langgraph/thread-1/default/cp-filtered",
+      data: { ...CHECKPOINT_STATE.data, runtime: "legacy" },
+      latest_sequence: 1,
+    };
+
+    const client = {
+      queryStates: vi.fn().mockResolvedValueOnce({
+        data: [first, second],
+        pagination: { next_cursor: null },
+      }),
+      getState: vi.fn(),
+      upsertState: vi.fn(),
+      deleteState: vi.fn(),
+    };
+
+    const saver = new AgentStateCheckpointSaver(client as any);
+    const tuples = [];
+    for await (const tuple of saver.list(
+      { configurable: { thread_id: "thread-1" } },
+      { filter: { runtime: "langgraph" } },
+    )) {
+      tuples.push(tuple);
+    }
+
+    expect((client.queryStates as any).mock.calls[0][0].predicates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "$.runtime", equals: "langgraph" }),
+      ]),
+    );
+    expect(tuples.length).toBe(1);
+    expect(tuples[0].config.configurable.checkpoint_id).toBe("cp-1");
+  });
+
+  it("deletes checkpoints and write rows for an entire thread", async () => {
+    const client = {
+      queryStates: vi.fn().mockResolvedValue({
+        data: [CHECKPOINT_STATE, SECOND_STATE],
+        pagination: { next_cursor: null },
+      }),
+      deleteState: vi.fn().mockResolvedValue(undefined),
+      upsertState: vi.fn(),
+      getState: vi.fn(),
+    };
+
+    const saver = new AgentStateCheckpointSaver(client as any);
+    await saver.deleteThread("thread-1");
+
+    expect(client.deleteState).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -454,7 +454,7 @@ export interface CreateStateLeaseRequest {
 }
 
 export interface RenewStateLeaseRequest {
-  ttl_seconds?: number;
+  ttl_ms?: number;
 }
 
 export interface StateLeaseResponse {
@@ -470,10 +470,9 @@ export interface StateLeaseResponse {
 }
 
 export interface CreateCapabilityTokenRequest {
-  name?: string;
-  state_key?: string;
+  name: string;
   scopes: CapabilityTokenScope[];
-  ttl_seconds?: number;
+  expires_at?: number;
 }
 
 export interface CapabilityTokenResponse {


### PR DESCRIPTION
## Summary
- Add optional AI SDK adapters for chat persistence and RSC AI/UI state backed by AgentState v2 records.
- Add LangGraph checkpoint savers for TypeScript and Python, including checkpoint, pending write, list, put, delete-thread, and tuple support.
- Add Python v2 state client methods and align TS SDK state contracts for lease renewal and capability token creation.
- Update docs, package exports, extras, and examples for the new adapter subpaths.

## Testing
- Added and updated unit coverage for AI SDK stores, LangGraph saver behavior, v2 state client methods, and delete/list filtering paths.
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI SDK and LangGraph integrations: chat & RSC state stores and checkpoint savers added for persisting AI state.

* **Documentation**
  * Expanded integration and SDK docs with examples and installation notes for AI SDK, RSC, and LangGraph adapters across JS/TS and Python.

* **Public API**
  * SDK type changes: lease/token request fields updated and some token fields now required (adjusted client interfaces).

* **Tests**
  * Added unit and integration tests covering new state adapters and checkpoint savers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/agentstate/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->