### PR TITLE
feat(dashboard): update docs and auth topbar

### DIFF
--- a/packages/dashboard/src/app/_code-examples.tsx
+++ b/packages/dashboard/src/app/_code-examples.tsx
@@ -47,8 +47,13 @@ export function CodeExamples() {
         </MotionDiv>
         <MotionDiv className="grid gap-4 sm:grid-cols-2" variants={landingContainer}>
           {examples.map((example) => (
-            <MotionDiv key={example.label} variants={landingCard} whileHover={landingHover}>
-              <Card size="sm">
+            <MotionDiv
+              className="min-w-0"
+              key={example.label}
+              variants={landingCard}
+              whileHover={landingHover}
+            >
+              <Card className="min-w-0" size="sm">
                 <CardHeader>
                   <CardTitle>{example.title}</CardTitle>
                   <CardDescription className="flex flex-col gap-2">

--- a/packages/dashboard/src/app/_header.tsx
+++ b/packages/dashboard/src/app/_header.tsx
@@ -1,8 +1,7 @@
-import { ArrowRightIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { MotionHeader } from "@/components/landing/motion";
-import { Button } from "@/components/ui/button";
+import { TopbarAuth } from "@/components/topbar-auth";
 
 export function Header() {
   return (
@@ -39,10 +38,7 @@ export function Header() {
           >
             GitHub
           </Link>
-          <Button size="sm" nativeButton={false} render={<Link href="/dashboard" />}>
-            Dashboard
-            <ArrowRightIcon data-icon="inline-end" />
-          </Button>
+          <TopbarAuth />
         </div>
       </div>
     </MotionHeader>

--- a/packages/dashboard/src/app/docs/_AuthSection.tsx
+++ b/packages/dashboard/src/app/docs/_AuthSection.tsx
@@ -1,16 +1,47 @@
+import { CopyButton } from "@/components/copy-button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+const authHeader = "Authorization: Bearer <your-api-key>";
+const createConversation = `curl -X POST https://agentstate.app/api/v1/conversations \\
+  -H "Authorization: Bearer <your-api-key>" \\
+  -H "Content-Type: application/json" \\
+  -d '{"messages":[{"role":"user","content":"Remember this session."}]}'`;
+
 export function AuthSection() {
   return (
-    <section className="mb-8">
-      <h2 className="text-xs font-mono text-muted-foreground uppercase tracking-widest mb-3">
-        Authentication
-      </h2>
-      <p className="text-sm text-muted-foreground mb-3">Pass your API key in every request:</p>
-      <pre className="font-mono text-xs text-foreground/80 bg-card border border-border rounded px-4 py-3">
-        {`Authorization: Bearer <your-api-key>`}
-      </pre>
-      <p className="text-xs text-muted-foreground mt-3">
-        Base URL: <code className="font-mono text-foreground/70">https://agentstate.app/api</code>
-      </p>
-    </section>
+    <Card id="quick-start">
+      <CardHeader>
+        <CardTitle>Quick start</CardTitle>
+        <CardDescription>
+          Use a project API key as a Bearer token. API responses use snake_case fields.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-4">
+        <div className="grid gap-2 sm:grid-cols-[9rem_1fr_auto] sm:items-center">
+          <Badge variant="outline">Base URL</Badge>
+          <code className="truncate font-mono text-sm text-foreground/80">
+            https://agentstate.app/api
+          </code>
+          <CopyButton text="https://agentstate.app/api" />
+        </div>
+        <div className="grid gap-2 sm:grid-cols-[9rem_1fr_auto] sm:items-center">
+          <Badge variant="outline">Header</Badge>
+          <code className="truncate font-mono text-sm text-foreground/80">{authHeader}</code>
+          <CopyButton text={authHeader} />
+        </div>
+        <div className="grid gap-3">
+          <div className="flex items-center justify-between gap-3">
+            <span className="font-mono text-xs font-medium text-muted-foreground uppercase tracking-widest">
+              Create a conversation
+            </span>
+            <CopyButton text={createConversation} />
+          </div>
+          <pre className="overflow-x-auto rounded-lg border border-border bg-muted/40 p-4 font-mono text-xs leading-relaxed text-foreground/80">
+            {createConversation}
+          </pre>
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/packages/dashboard/src/app/docs/_DocsFooter.tsx
+++ b/packages/dashboard/src/app/docs/_DocsFooter.tsx
@@ -1,17 +1,31 @@
-import Link from "next/link";
+import { ArrowRightIcon, FileTextIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
 
 export function DocsFooter() {
   return (
-    <div className="border-t border-border pt-6 text-xs text-muted-foreground font-mono">
-      Machine-readable:{" "}
-      <Link
-        href="https://agentstate.app/agents.md"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-foreground/60 hover:text-foreground transition-colors"
-      >
-        agents.md
-      </Link>
-    </div>
+    <Card>
+      <CardContent className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+        <div className="flex items-start gap-3">
+          <FileTextIcon className="mt-0.5 size-4 text-muted-foreground" aria-hidden="true" />
+          <div className="grid gap-1">
+            <p className="text-sm font-medium">Machine-readable integration guide</p>
+            <p className="text-sm text-muted-foreground">
+              Give agents a compact, plain-text reference for runtime integration.
+            </p>
+          </div>
+        </div>
+        <Button
+          nativeButton={false}
+          // biome-ignore lint/a11y/useAnchorContent: Base UI injects the Button children into this render anchor.
+          render={<a href="/agents.md" />}
+          size="sm"
+          variant="outline"
+        >
+          agents.md
+          <ArrowRightIcon data-icon="inline-end" />
+        </Button>
+      </CardContent>
+    </Card>
   );
 }

--- a/packages/dashboard/src/app/docs/_DocsHeader.tsx
+++ b/packages/dashboard/src/app/docs/_DocsHeader.tsx
@@ -1,25 +1,40 @@
 import { ArrowLeftIcon } from "lucide-react";
+import Image from "next/image";
 import Link from "next/link";
+import { TopbarAuth } from "@/components/topbar-auth";
 
 export function DocsHeader() {
   return (
-    <header className="bg-card/80 backdrop-blur-sm border-b border-border px-6 py-3 sticky top-0 z-50">
-      <div className="max-w-3xl mx-auto flex items-center justify-between">
+    <header className="sticky top-0 z-50 border-b border-border bg-card/80 px-6 py-3 backdrop-blur-sm">
+      <div className="mx-auto flex max-w-6xl items-center justify-between">
         <div className="flex items-center gap-2">
-          <Link href="/" className="text-muted-foreground hover:text-foreground transition-colors">
-            <ArrowLeftIcon className="h-4 w-4" />
+          <Link
+            aria-label="Back to homepage"
+            className="text-muted-foreground transition-colors hover:text-foreground"
+            href="/"
+          >
+            <ArrowLeftIcon className="size-4" />
           </Link>
-          <span className="font-mono text-sm font-semibold tracking-tight">API Reference</span>
+          <Image
+            aria-hidden="true"
+            alt=""
+            className="size-6"
+            height={24}
+            src="/logo.svg"
+            width={24}
+          />
+          <span className="font-mono text-sm font-semibold tracking-tight">AgentState Docs</span>
         </div>
         <div className="flex items-center gap-5">
           <Link
+            className="hidden text-sm text-muted-foreground transition-colors hover:text-foreground sm:block"
             href="https://github.com/duyet/agentstate"
-            target="_blank"
             rel="noopener noreferrer"
-            className="text-sm text-muted-foreground hover:text-foreground transition-colors hidden sm:block"
+            target="_blank"
           >
             GitHub
           </Link>
+          <TopbarAuth />
         </div>
       </div>
     </header>

--- a/packages/dashboard/src/app/docs/_EndpointsTable.tsx
+++ b/packages/dashboard/src/app/docs/_EndpointsTable.tsx
@@ -1,52 +1,54 @@
-import { endpoints, methodColor } from "./_endpoints-data";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { endpoints } from "./_endpoints-data";
 
 export function EndpointsTable() {
   return (
-    <section className="mb-8">
-      <h2 className="text-xs font-mono text-muted-foreground uppercase tracking-widest mb-3">
-        Endpoints
-      </h2>
-      <div className="rounded border border-border overflow-hidden">
-        <table className="w-full" aria-label="API endpoints">
-          <thead>
-            <tr className="border-b border-border bg-card">
-              <th className="text-left px-4 py-2.5 text-xs font-mono text-muted-foreground font-medium w-16">
-                Method
-              </th>
-              <th className="text-left px-4 py-2.5 text-xs font-mono text-muted-foreground font-medium">
-                Endpoint
-              </th>
-              <th className="text-left px-4 py-2.5 text-xs font-mono text-muted-foreground font-medium hidden sm:table-cell">
-                Description
-              </th>
-            </tr>
-          </thead>
-          <tbody>
+    <Card id="endpoints">
+      <CardHeader>
+        <CardTitle>Endpoint surface</CardTitle>
+        <CardDescription>
+          Conversation history, retrieval, automation, and export routes for agent runtimes.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Table aria-label="API endpoints" className="table-fixed">
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-24">Method</TableHead>
+              <TableHead>Endpoint</TableHead>
+              <TableHead className="hidden w-36 md:table-cell">Group</TableHead>
+              <TableHead className="hidden w-72 lg:table-cell">Description</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
             {endpoints.map((ep) => (
-              <tr
-                key={`${ep.method}-${ep.path}`}
-                className={`${
-                  endpoints.indexOf(ep) < endpoints.length - 1 ? "border-b border-border" : ""
-                } hover:bg-muted/20 transition-colors`}
-              >
-                <td className="px-4 py-3">
-                  <span
-                    className={`font-mono text-xs font-bold ${methodColor[ep.method] ?? "text-foreground"}`}
-                  >
-                    {ep.method}
-                  </span>
-                </td>
-                <td className="px-4 py-3">
-                  <code className="font-mono text-xs text-foreground/85 break-all">{ep.path}</code>
-                </td>
-                <td className="px-4 py-3 hidden sm:table-cell">
-                  <span className="text-xs text-muted-foreground">{ep.description}</span>
-                </td>
-              </tr>
+              <TableRow key={`${ep.method}-${ep.path}`}>
+                <TableCell>
+                  <Badge variant="outline">{ep.method}</Badge>
+                </TableCell>
+                <TableCell className="whitespace-normal break-all font-mono text-xs">
+                  {ep.path}
+                </TableCell>
+                <TableCell className="hidden md:table-cell">
+                  <Badge variant="secondary">{ep.group}</Badge>
+                </TableCell>
+                <TableCell className="hidden whitespace-normal text-muted-foreground lg:table-cell">
+                  {ep.description}
+                </TableCell>
+              </TableRow>
             ))}
-          </tbody>
-        </table>
-      </div>
-    </section>
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
   );
 }

--- a/packages/dashboard/src/app/docs/_MessageFormatSection.tsx
+++ b/packages/dashboard/src/app/docs/_MessageFormatSection.tsx
@@ -1,16 +1,34 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
 export function MessageFormatSection() {
   return (
-    <section className="mb-8">
-      <h2 className="text-xs font-mono text-muted-foreground uppercase tracking-widest mb-3">
-        Message Format
-      </h2>
-      <pre className="font-mono text-xs text-foreground/80 bg-card border border-border rounded px-4 py-3 overflow-x-auto">
-        {`{
+    <Card id="message-format">
+      <CardHeader>
+        <CardTitle>Message format</CardTitle>
+        <CardDescription>
+          Store model turns, tool outputs, and caller metadata in the same conversation timeline.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_16rem]">
+        <pre className="overflow-x-auto rounded-lg border border-border bg-muted/40 p-4 font-mono text-xs leading-relaxed text-foreground/80">
+          {`{
   "role": "user | assistant | system | tool",
   "content": "message text",
   "metadata": {}
 }`}
-      </pre>
-    </section>
+        </pre>
+        <div className="grid content-start gap-3">
+          {["Cursor pagination", "External ID lookup", "Metadata search", "Audit export"].map(
+            (item) => (
+              <div className="flex items-center justify-between gap-3" key={item}>
+                <span className="text-sm text-muted-foreground">{item}</span>
+                <Badge variant="secondary">Ready</Badge>
+              </div>
+            ),
+          )}
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/packages/dashboard/src/app/docs/_endpoints-data.ts
+++ b/packages/dashboard/src/app/docs/_endpoints-data.ts
@@ -2,6 +2,7 @@ export interface Endpoint {
   method: "GET" | "POST" | "PUT" | "DELETE";
   path: string;
   description: string;
+  group: "Conversations" | "Messages" | "Automation" | "Bulk";
 }
 
 export const endpoints: Endpoint[] = [
@@ -9,52 +10,60 @@ export const endpoints: Endpoint[] = [
     method: "POST",
     path: "/api/v1/conversations",
     description: "Create a new conversation with optional initial messages.",
+    group: "Conversations",
   },
   {
     method: "GET",
     path: "/api/v1/conversations",
     description: "List all conversations for the authenticated project.",
+    group: "Conversations",
   },
   {
     method: "GET",
     path: "/api/v1/conversations/:id",
     description: "Get a conversation and all its messages.",
+    group: "Conversations",
   },
   {
     method: "GET",
     path: "/api/v1/conversations/by-external-id/:eid",
     description: "Look up a conversation by your own external identifier.",
+    group: "Conversations",
   },
   {
     method: "PUT",
     path: "/api/v1/conversations/:id",
     description: "Update conversation title or metadata.",
+    group: "Conversations",
   },
   {
     method: "DELETE",
     path: "/api/v1/conversations/:id",
     description: "Delete a conversation and all its messages. Irreversible.",
+    group: "Conversations",
+  },
+  {
+    method: "POST",
+    path: "/api/v1/conversations/export",
+    description: "Export selected conversations with messages for audit or backup.",
+    group: "Bulk",
   },
   {
     method: "POST",
     path: "/api/v1/conversations/:id/messages",
     description: "Append one or more messages to an existing conversation.",
+    group: "Messages",
   },
   {
     method: "POST",
     path: "/api/v1/conversations/:id/generate-title",
     description: "Use AI to generate a descriptive title from conversation content.",
+    group: "Automation",
   },
   {
     method: "POST",
     path: "/api/v1/conversations/:id/follow-ups",
     description: "Use AI to suggest follow-up questions based on the conversation.",
+    group: "Automation",
   },
 ];
-
-export const methodColor: Record<Endpoint["method"], string> = {
-  GET: "text-emerald-500",
-  POST: "text-blue-400",
-  PUT: "text-amber-400",
-  DELETE: "text-red-400",
-};

--- a/packages/dashboard/src/app/docs/page.tsx
+++ b/packages/dashboard/src/app/docs/page.tsx
@@ -1,9 +1,66 @@
+import {
+  ArrowRightIcon,
+  BookOpenIcon,
+  DatabaseIcon,
+  KeyRoundIcon,
+  MessageSquareTextIcon,
+  RouteIcon,
+  ShieldCheckIcon,
+  TerminalSquareIcon,
+} from "lucide-react";
+import Link from "next/link";
 import { Footer } from "@/components/footer";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
 import { AuthSection } from "./_AuthSection";
 import { DocsFooter } from "./_DocsFooter";
 import { DocsHeader } from "./_DocsHeader";
 import { EndpointsTable } from "./_EndpointsTable";
 import { MessageFormatSection } from "./_MessageFormatSection";
+
+const docNav = [
+  ["Quick start", "#quick-start"],
+  ["Message format", "#message-format"],
+  ["Endpoints", "#endpoints"],
+] as const;
+
+const overviewCards = [
+  {
+    title: "Bearer auth",
+    description: "API keys are project-scoped and passed on every request.",
+    icon: KeyRoundIcon,
+  },
+  {
+    title: "Conversation store",
+    description: "Persist agent messages, metadata, and external IDs at the edge.",
+    icon: DatabaseIcon,
+  },
+  {
+    title: "Retrieval API",
+    description: "List, fetch, search, export, and append without rebuilding memory plumbing.",
+    icon: RouteIcon,
+  },
+];
+
+const workflowCards = [
+  {
+    title: "Send",
+    description: "Create or append messages from your agent runtime.",
+    icon: MessageSquareTextIcon,
+  },
+  {
+    title: "Store",
+    description: "Keep conversation state keyed by AgentState IDs or your external IDs.",
+    icon: DatabaseIcon,
+  },
+  {
+    title: "Retrieve",
+    description: "Fetch full history before the next agent turn.",
+    icon: RouteIcon,
+  },
+];
 
 export default function DocsPage() {
   return (
@@ -11,20 +68,130 @@ export default function DocsPage() {
       <DocsHeader />
 
       <main className="flex-1">
-        <div className="max-w-3xl mx-auto px-6 py-12">
-          <div className="mb-6">
-            <h1 className="text-lg font-semibold tracking-tight text-foreground mb-1">
-              API Reference
-            </h1>
-            <p className="text-sm text-muted-foreground">
-              REST API. All endpoints require a Bearer token.
-            </p>
-          </div>
+        <div className="mx-auto grid max-w-6xl gap-8 px-6 py-10 lg:grid-cols-[13rem_minmax(0,1fr)]">
+          <aside className="hidden lg:block">
+            <div className="sticky top-20 grid gap-4">
+              <div className="grid gap-2">
+                <Badge variant="outline">REST API</Badge>
+                <Badge variant="secondary">Bearer token</Badge>
+              </div>
+              <Separator />
+              <nav aria-label="Docs sections" className="grid gap-1">
+                {docNav.map(([label, href]) => (
+                  <Link
+                    className="rounded-md px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                    href={href}
+                    key={href}
+                  >
+                    {label}
+                  </Link>
+                ))}
+              </nav>
+            </div>
+          </aside>
 
-          <AuthSection />
-          <MessageFormatSection />
-          <EndpointsTable />
-          <DocsFooter />
+          <div className="grid gap-6">
+            <section className="grid gap-5">
+              <div className="grid gap-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="outline">
+                    <ShieldCheckIcon data-icon="inline-start" />
+                    Authenticated
+                  </Badge>
+                  <Badge variant="outline">
+                    <TerminalSquareIcon data-icon="inline-start" />
+                    JSON over HTTPS
+                  </Badge>
+                </div>
+                <div className="grid gap-2">
+                  <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+                    AgentState API Reference
+                  </h1>
+                  <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+                    Store, retrieve, and audit AI agent conversation history through a compact REST
+                    API designed for production runtimes.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <Button nativeButton={false} render={<Link href="/dashboard" />}>
+                  Open dashboard
+                  <ArrowRightIcon data-icon="inline-end" />
+                </Button>
+                <Button
+                  nativeButton={false}
+                  // biome-ignore lint/a11y/useAnchorContent: Base UI injects the Button children into this render anchor.
+                  render={<a href="/agents.md" />}
+                  variant="outline"
+                >
+                  agents.md
+                  <BookOpenIcon data-icon="inline-end" />
+                </Button>
+              </div>
+
+              <div className="grid gap-3 md:grid-cols-3">
+                {overviewCards.map(({ title, description, icon: Icon }) => (
+                  <Card key={title} size="sm">
+                    <CardHeader>
+                      <div className="flex items-center gap-2">
+                        <Icon className="size-4 text-muted-foreground" aria-hidden="true" />
+                        <CardTitle>{title}</CardTitle>
+                      </div>
+                      <CardDescription>{description}</CardDescription>
+                    </CardHeader>
+                  </Card>
+                ))}
+              </div>
+            </section>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Runtime contract</CardTitle>
+                <CardDescription>
+                  The stable path is `/api/v1/*`; every protected route uses the same API-key
+                  authorization model.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-3 sm:grid-cols-3">
+                {[
+                  ["Base", "https://agentstate.app/api"],
+                  ["Content", "application/json"],
+                  ["Errors", "{ error: { code, message } }"],
+                ].map(([label, value]) => (
+                  <div className="grid gap-1 rounded-lg border border-border p-3" key={label}>
+                    <span className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+                      {label}
+                    </span>
+                    <code className="break-all font-mono text-xs text-foreground/80">{value}</code>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+
+            <AuthSection />
+            <MessageFormatSection />
+            <EndpointsTable />
+            <Card>
+              <CardHeader>
+                <CardTitle>Core workflow</CardTitle>
+                <CardDescription>
+                  The storage loop is intentionally small: send messages, persist state, retrieve
+                  context.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-3 md:grid-cols-3">
+                {workflowCards.map(({ title, description, icon: Icon }) => (
+                  <div className="grid gap-2 rounded-lg border border-border p-4" key={title}>
+                    <Icon className="size-4 text-muted-foreground" aria-hidden="true" />
+                    <p className="text-sm font-medium">{title}</p>
+                    <p className="text-sm text-muted-foreground">{description}</p>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+            <DocsFooter />
+          </div>
         </div>
       </main>
 

--- a/packages/dashboard/src/components/topbar-auth.tsx
+++ b/packages/dashboard/src/components/topbar-auth.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { SignInButton, UserButton, useAuth } from "@clerk/react";
+import { ArrowRightIcon, CircleUserRoundIcon, LogInIcon } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+function BlankAvatar() {
+  return (
+    <Button aria-label="Signed-out account" disabled size="icon-sm" type="button" variant="outline">
+      <CircleUserRoundIcon data-icon="only" />
+    </Button>
+  );
+}
+
+export function TopbarAuth() {
+  const { isLoaded, isSignedIn } = useAuth();
+
+  if (isLoaded && isSignedIn) {
+    return (
+      <div className="flex items-center gap-2">
+        <Button
+          nativeButton={false}
+          render={<Link href="/dashboard" />}
+          size="sm"
+          variant="outline"
+        >
+          Dashboard
+          <ArrowRightIcon data-icon="inline-end" />
+        </Button>
+        <UserButton />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <SignInButton mode="modal">
+        <Button size="sm" type="button" variant="outline">
+          Login
+          <LogInIcon data-icon="inline-end" />
+        </Button>
+      </SignInButton>
+      <BlankAvatar />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add Clerk-aware public topbar auth: signed-out users see Login plus a blank avatar placeholder; signed-in users see Dashboard plus Clerk `UserButton`.
- Redesign `/docs` as a dense shadcn-based API reference with cards, badges, copy actions, endpoint table, and docs topbar.
- Fix homepage integration code cards so mobile viewports do not create horizontal overflow.

## Verification
- `bunx biome check packages/dashboard/src/`
- `cd packages/dashboard && bunx tsc --noEmit`
- `cd packages/dashboard && bun run build`
- Browser QA on `/` and `/docs/` at desktop/mobile widths in light/dark themes: no console errors, no horizontal overflow, signed-out topbar shows enabled Login and blank avatar.
- `curl -I http://localhost:3000/agents.md`
- `curl -I http://localhost:3000/docs/`
