### PR TITLE
fix(dashboard): polish auth topbar interactions

### DIFF
--- a/packages/dashboard/src/app/_header.tsx
+++ b/packages/dashboard/src/app/_header.tsx
@@ -26,7 +26,7 @@ export function Header() {
         <div className="flex items-center gap-5">
           <Link
             href="/docs"
-            className="text-sm text-muted-foreground hover:text-foreground transition-colors hidden sm:block"
+            className="hidden min-h-10 items-center text-sm text-muted-foreground transition-colors hover:text-foreground sm:flex"
           >
             Docs
           </Link>
@@ -34,7 +34,7 @@ export function Header() {
             href="https://github.com/duyet/agentstate"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-sm text-muted-foreground hover:text-foreground transition-colors hidden sm:block"
+            className="hidden min-h-10 items-center text-sm text-muted-foreground transition-colors hover:text-foreground sm:flex"
           >
             GitHub
           </Link>

--- a/packages/dashboard/src/app/_hero.tsx
+++ b/packages/dashboard/src/app/_hero.tsx
@@ -56,10 +56,10 @@ export function Hero() {
             <Badge variant="outline">Agent memory</Badge>
           </MotionDiv>
           <MotionDiv className="flex flex-col gap-4" variants={landingItem}>
-            <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl md:text-6xl">
+            <h1 className="text-4xl font-semibold tracking-tight text-balance sm:text-5xl md:text-6xl">
               AgentState
             </h1>
-            <p className="max-w-2xl text-lg leading-relaxed text-muted-foreground sm:text-xl">
+            <p className="max-w-2xl text-lg leading-relaxed text-pretty text-muted-foreground sm:text-xl">
               Conversation history database-as-a-service for AI agents. Store threads, retrieve
               context, monitor usage, and ship without building another chat-history backend.
             </p>
@@ -126,11 +126,11 @@ export function Hero() {
               <Separator />
               <div className="grid grid-cols-2 gap-3">
                 <div className="flex flex-col gap-1">
-                  <span className="text-2xl font-semibold">21</span>
+                  <span className="text-2xl font-semibold tabular-nums">21</span>
                   <span className="text-sm text-muted-foreground">char IDs</span>
                 </div>
                 <div className="flex flex-col gap-1">
-                  <span className="text-2xl font-semibold">SHA-256</span>
+                  <span className="text-2xl font-semibold tabular-nums">SHA-256</span>
                   <span className="text-sm text-muted-foreground">key hashes</span>
                 </div>
               </div>

--- a/packages/dashboard/src/app/docs/_DocsHeader.tsx
+++ b/packages/dashboard/src/app/docs/_DocsHeader.tsx
@@ -2,19 +2,22 @@ import { ArrowLeftIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { TopbarAuth } from "@/components/topbar-auth";
+import { Button } from "@/components/ui/button";
 
 export function DocsHeader() {
   return (
     <header className="sticky top-0 z-50 border-b border-border bg-card/80 px-6 py-3 backdrop-blur-sm">
       <div className="mx-auto flex max-w-6xl items-center justify-between">
         <div className="flex items-center gap-2">
-          <Link
-            aria-label="Back to homepage"
-            className="text-muted-foreground transition-colors hover:text-foreground"
-            href="/"
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-10"
+            nativeButton={false}
+            render={<Link href="/" aria-label="Back to homepage" />}
           >
-            <ArrowLeftIcon className="size-4" />
-          </Link>
+            <ArrowLeftIcon data-icon="inline-start" />
+          </Button>
           <Image
             aria-hidden="true"
             alt=""
@@ -27,7 +30,7 @@ export function DocsHeader() {
         </div>
         <div className="flex items-center gap-5">
           <Link
-            className="hidden text-sm text-muted-foreground transition-colors hover:text-foreground sm:block"
+            className="hidden min-h-10 items-center text-sm text-muted-foreground transition-colors hover:text-foreground sm:flex"
             href="https://github.com/duyet/agentstate"
             rel="noopener noreferrer"
             target="_blank"

--- a/packages/dashboard/src/app/docs/page.tsx
+++ b/packages/dashboard/src/app/docs/page.tsx
@@ -104,10 +104,10 @@ export default function DocsPage() {
                   </Badge>
                 </div>
                 <div className="grid gap-2">
-                  <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+                  <h1 className="text-3xl font-semibold tracking-tight text-balance text-foreground sm:text-4xl">
                     AgentState API Reference
                   </h1>
-                  <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+                  <p className="max-w-2xl text-sm leading-6 text-pretty text-muted-foreground">
                     Store, retrieve, and audit AI agent conversation history through a compact REST
                     API designed for production runtimes.
                   </p>

--- a/packages/dashboard/src/components/landing/use-cases.tsx
+++ b/packages/dashboard/src/components/landing/use-cases.tsx
@@ -32,7 +32,7 @@ export function UseCases() {
             <MotionDiv key={useCase.title} variants={landingCard} whileHover={landingHover}>
               <Card>
                 <CardContent>
-                  <div className="flex aspect-[2/1] items-center justify-center rounded-lg bg-muted">
+                  <div className="flex aspect-[2/1] items-center justify-center rounded-lg bg-muted ring-1 ring-border/80">
                     <Image
                       src={useCase.image}
                       alt=""

--- a/packages/dashboard/src/components/theme-toggle.tsx
+++ b/packages/dashboard/src/components/theme-toggle.tsx
@@ -2,6 +2,7 @@
 
 import { MoonIcon, SunIcon } from "lucide-react";
 import { useEffect, useState } from "react";
+import { Button } from "./ui/button";
 
 interface ThemeToggleProps {
   /** Icon size in Tailwind class format. Defaults to "h-3.5 w-3.5". */
@@ -25,16 +26,15 @@ export function ThemeToggle({ size = "h-3.5 w-3.5", className }: ThemeToggleProp
   }
 
   return (
-    <button
+    <Button
       type="button"
       onClick={toggle}
       aria-label="Toggle theme"
-      className={
-        className ||
-        "p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-      }
+      size="icon"
+      variant="ghost"
+      className={className || "size-10 text-muted-foreground hover:text-foreground"}
     >
       {isDark ? <SunIcon className={size} /> : <MoonIcon className={size} />}
-    </button>
+    </Button>
   );
 }

--- a/packages/dashboard/src/components/topbar-auth.tsx
+++ b/packages/dashboard/src/components/topbar-auth.tsx
@@ -7,7 +7,14 @@ import { Button } from "@/components/ui/button";
 
 function BlankAvatar() {
   return (
-    <Button aria-label="Signed-out account" disabled size="icon-sm" type="button" variant="outline">
+    <Button
+      aria-label="Signed-out account"
+      className="size-10"
+      disabled
+      size="icon"
+      type="button"
+      variant="outline"
+    >
       <CircleUserRoundIcon data-icon="only" />
     </Button>
   );
@@ -16,10 +23,23 @@ function BlankAvatar() {
 export function TopbarAuth() {
   const { isLoaded, isSignedIn } = useAuth();
 
+  if (!isLoaded) {
+    return (
+      <div className="flex items-center gap-2" aria-busy="true">
+        <Button className="min-h-10" disabled size="sm" type="button" variant="outline">
+          Login
+          <LogInIcon data-icon="inline-end" />
+        </Button>
+        <BlankAvatar />
+      </div>
+    );
+  }
+
   if (isLoaded && isSignedIn) {
     return (
       <div className="flex items-center gap-2">
         <Button
+          className="min-h-10"
           nativeButton={false}
           render={<Link href="/dashboard" />}
           size="sm"
@@ -28,7 +48,13 @@ export function TopbarAuth() {
           Dashboard
           <ArrowRightIcon data-icon="inline-end" />
         </Button>
-        <UserButton />
+        <UserButton
+          appearance={{
+            elements: {
+              userButtonAvatarBox: "size-10",
+            },
+          }}
+        />
       </div>
     );
   }
@@ -36,7 +62,7 @@ export function TopbarAuth() {
   return (
     <div className="flex items-center gap-2">
       <SignInButton mode="modal">
-        <Button size="sm" type="button" variant="outline">
+        <Button className="min-h-10" size="sm" type="button" variant="outline">
           Login
           <LogInIcon data-icon="inline-end" />
         </Button>

--- a/packages/dashboard/src/components/ui/badge.tsx
+++ b/packages/dashboard/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[background-color,border-color,color,box-shadow] duration-150 ease-out focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
   {
     variants: {
       variant: {

--- a/packages/dashboard/src/components/ui/button.tsx
+++ b/packages/dashboard/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-[background-color,border-color,color,box-shadow,opacity,transform] duration-150 ease-out outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/packages/dashboard/src/components/ui/card.tsx
+++ b/packages/dashboard/src/components/ui/card.tsx
@@ -54,7 +54,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-title"
       className={cn(
-        "text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        "text-base leading-snug font-medium text-balance group-data-[size=sm]/card:text-sm",
         className,
       )}
       {...props}
@@ -66,7 +66,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-sm text-muted-foreground", className)}
+      className={cn("text-sm text-pretty text-muted-foreground", className)}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- polish Clerk topbar auth states for login, blank avatar, dashboard, and user avatar sizing
- replace broad shadcn transitions with scoped press feedback
- add balanced text, tabular stats, and static SVG image outlines on landing/docs surfaces

## Verification
- `bunx biome check packages/dashboard/src/`
- `cd packages/dashboard && bunx tsc --noEmit`
- `cd packages/dashboard && bun run build`
- Browser smoke: `/` and `/docs/` at mobile and desktop widths
