### PR TITLE
fix(dashboard): align operations cards

### DIFF
--- a/packages/dashboard/src/app/_features.tsx
+++ b/packages/dashboard/src/app/_features.tsx
@@ -69,8 +69,13 @@ export function Features() {
         </MotionDiv>
         <MotionDiv className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4" variants={landingContainer}>
           {features.map(({ title, badge, icon: Icon, description }) => (
-            <MotionDiv key={title} variants={landingCard} whileHover={landingHover}>
-              <Card>
+            <MotionDiv
+              className="h-full"
+              key={title}
+              variants={landingCard}
+              whileHover={landingHover}
+            >
+              <Card className="h-full">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <span className="flex size-8 items-center justify-center rounded-lg bg-muted text-muted-foreground">


### PR DESCRIPTION
## Summary
- stretch Operations snapshot motion wrappers and cards to fill the grid row
- keep existing content, shadcn card composition, and Framer Motion behavior unchanged

## Verification
- `bunx biome check packages/dashboard/src/`
- `cd packages/dashboard && bunx tsc --noEmit`
- `cd packages/dashboard && bun run build`
- Browser check: Operations snapshot card heights measured `[208, 208, 208, 208]`
