### PR TITLE
chore: add sdk example and dashboard lint fixes

### DIFF
--- a/examples/ai-sdk-rsc/main.ts
+++ b/examples/ai-sdk-rsc/main.ts
@@ -1,5 +1,5 @@
-import { AgentState } from "../../packages/sdk/src/index";
 import { createAISDKRSCStateStore } from "../../packages/sdk/src/ai-sdk";
+import { AgentState } from "../../packages/sdk/src/index";
 
 type ChatMessage = {
   id?: string;
@@ -7,10 +7,7 @@ type ChatMessage = {
   content: string;
 };
 
-type Client = Pick<
-  AgentState,
-  "upsertState" | "getState" | "deleteState"
->;
+type Client = Pick<AgentState, "upsertState" | "getState" | "deleteState">;
 
 export type AiSDKRSCExampleResult = {
   stateKey: string;
@@ -79,7 +76,7 @@ async function main(): Promise<void> {
   console.log(JSON.stringify(result, null, 2));
 }
 
-if (process.argv[1]?.endsWith("examples/ai-sdk-rsc/main.ts")) {
+if (process.argv[1]?.replaceAll("\\", "/").endsWith("examples/ai-sdk-rsc/main.ts")) {
   main().catch((error) => {
     console.error(error);
     process.exitCode = 1;

--- a/examples/ai-sdk-rsc/main.ts
+++ b/examples/ai-sdk-rsc/main.ts
@@ -1,0 +1,87 @@
+import { AgentState } from "../../packages/sdk/src/index";
+import { createAISDKRSCStateStore } from "../../packages/sdk/src/ai-sdk";
+
+type ChatMessage = {
+  id?: string;
+  role: string;
+  content: string;
+};
+
+type Client = Pick<
+  AgentState,
+  "upsertState" | "getState" | "deleteState"
+>;
+
+export type AiSDKRSCExampleResult = {
+  stateKey: string;
+  aiState: Record<string, unknown> | null;
+  uiMessages: ChatMessage[];
+};
+
+export async function runAiSdkRscExample(
+  client: Client,
+  options?: {
+    stateKey?: string;
+  },
+): Promise<AiSDKRSCExampleResult> {
+  const stateKeyPrefix = "agentstate/examples/ai-sdk/rsc";
+  const stateKey = options?.stateKey ?? "rsc-thread-1";
+
+  const store = createAISDKRSCStateStore(client, {
+    stateKeyPrefix,
+    stateKey,
+    mapAIStateToUIMessages: (state) => {
+      if (!state || !("step" in state)) {
+        return [];
+      }
+
+      return [
+        {
+          id: "ui-step",
+          role: "assistant",
+          content: `Step: ${String((state as Record<string, unknown>).step)}`,
+        },
+      ];
+    },
+  });
+
+  await store.saveAIState({
+    step: "collect",
+    payload: { example: "rsc" },
+  });
+
+  await store.onSetAIState({
+    state: {
+      step: "response-ready",
+      payload: { example: "rsc" },
+    },
+    done: true,
+  });
+
+  const uiMessages = await store.onGetUIState();
+  const aiState = await store.loadAIState();
+
+  return {
+    stateKey,
+    aiState,
+    uiMessages,
+  };
+}
+
+async function main(): Promise<void> {
+  const apiKey = process.env.AGENTSTATE_API_KEY;
+  if (!apiKey) {
+    throw new Error("AGENTSTATE_API_KEY is required");
+  }
+
+  const client = new AgentState({ apiKey });
+  const result = await runAiSdkRscExample(client);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+if (process.argv[1]?.endsWith("examples/ai-sdk-rsc/main.ts")) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/examples/ai-sdk-ui/main.ts
+++ b/examples/ai-sdk-ui/main.ts
@@ -1,0 +1,74 @@
+import { AgentState } from "../../packages/sdk/src/index";
+import { createAISDKChatStore } from "../../packages/sdk/src/ai-sdk";
+
+type ChatMessage = {
+  id?: string;
+  role: string;
+  content: string;
+};
+
+type Client = Pick<
+  AgentState,
+  "upsertState" | "getState" | "deleteState"
+>;
+
+export type AiSDKUIExampleResult = {
+  chatId: string;
+  messages: ChatMessage[];
+};
+
+export async function runAiSdkChatExample(
+  client: Client,
+  options?: {
+    chatId?: string;
+    messages?: ChatMessage[];
+  },
+): Promise<AiSDKUIExampleResult> {
+  const stateKeyPrefix = "agentstate/examples/ai-sdk/ui";
+
+  const store = createAISDKChatStore(client, {
+    stateKeyPrefix,
+    generateChatId: () => options?.chatId ?? "ai-sdk-ui-chat-1",
+  });
+
+  const chatId = await store.createChat();
+  const initialMessages = options?.messages ?? [
+    { id: "m-1", role: "user", content: "Hello from CLI" },
+    { id: "m-2", role: "assistant", content: "Hello from AgentState" },
+  ];
+
+  await store.saveChat({ chatId, messages: initialMessages });
+  const loaded = await store.loadChat(chatId);
+
+  const updatedMessages = [
+    ...loaded,
+    { id: "m-3", role: "assistant", content: "This message is persisted as UIMessage[]" },
+  ];
+  await store.saveChat({ chatId, messages: updatedMessages });
+
+  const finalMessages = await store.loadChat(chatId);
+  await store.deleteChat(chatId);
+
+  return {
+    chatId,
+    messages: finalMessages,
+  };
+}
+
+async function main(): Promise<void> {
+  const apiKey = process.env.AGENTSTATE_API_KEY;
+  if (!apiKey) {
+    throw new Error("AGENTSTATE_API_KEY is required");
+  }
+
+  const client = new AgentState({ apiKey });
+  const result = await runAiSdkChatExample(client);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+if (process.argv[1]?.endsWith("examples/ai-sdk-ui/main.ts")) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/examples/ai-sdk-ui/main.ts
+++ b/examples/ai-sdk-ui/main.ts
@@ -1,5 +1,5 @@
-import { AgentState } from "../../packages/sdk/src/index";
 import { createAISDKChatStore } from "../../packages/sdk/src/ai-sdk";
+import { AgentState } from "../../packages/sdk/src/index";
 
 type ChatMessage = {
   id?: string;
@@ -7,10 +7,7 @@ type ChatMessage = {
   content: string;
 };
 
-type Client = Pick<
-  AgentState,
-  "upsertState" | "getState" | "deleteState"
->;
+type Client = Pick<AgentState, "upsertState" | "getState" | "deleteState">;
 
 export type AiSDKUIExampleResult = {
   chatId: string;
@@ -66,7 +63,7 @@ async function main(): Promise<void> {
   console.log(JSON.stringify(result, null, 2));
 }
 
-if (process.argv[1]?.endsWith("examples/ai-sdk-ui/main.ts")) {
+if (process.argv[1]?.replaceAll("\\", "/").endsWith("examples/ai-sdk-ui/main.ts")) {
   main().catch((error) => {
     console.error(error);
     process.exitCode = 1;

--- a/examples/langgraph-js/main.ts
+++ b/examples/langgraph-js/main.ts
@@ -1,0 +1,98 @@
+import { AgentState } from "../../packages/sdk/src/index";
+import { AgentStateCheckpointSaver } from "../../packages/sdk/src/langgraph";
+
+type Client = Pick<
+  AgentState,
+  "upsertState" | "getState" | "queryStates" | "deleteState"
+>;
+
+export type LangGraphJsExampleResult = {
+  threadId: string;
+  checkpointId: string;
+  listLength: number;
+  pendingWriteTask: string;
+  pendingWrites: Array<[string, string, unknown]>;
+};
+
+export async function runLangGraphJsExample(
+  client: Client,
+  options?: {
+    threadId?: string;
+    checkpointId?: string;
+    cleanup?: boolean;
+  },
+): Promise<LangGraphJsExampleResult> {
+  const threadId = options?.threadId ?? "langgraph-thread-1";
+  const checkpointId = options?.checkpointId ?? "checkpoint-start";
+
+  const saver = new AgentStateCheckpointSaver(client, {
+    stateKeyPrefix: "agentstate/examples/langgraph/js",
+  });
+
+  const nextConfig = await saver.put(
+    {
+      configurable: { thread_id: threadId, checkpoint_ns: "" },
+    },
+    {
+      id: checkpointId,
+      values: { phase: "start" },
+    },
+    { note: "sdk example checkpoint" },
+    {},
+  );
+
+  const taskId = "task-ui-example";
+  await saver.putWrites(
+    nextConfig,
+    [["messages", { role: "assistant", content: "hello" }]],
+    taskId,
+  );
+
+  const row = await saver.getTuple(nextConfig);
+
+  const rows: Array<{
+    config: { configurable: { thread_id: string; checkpoint_id?: string }};
+    checkpoint: Record<string, unknown>;
+    pendingWrites?: Array<[string, string, unknown]>;
+  }> = [];
+
+  for await (const tuple of saver.list({ configurable: { thread_id: threadId } })) {
+    rows.push(tuple as unknown as {
+      config: { configurable: { thread_id: string; checkpoint_id?: string }};
+      checkpoint: Record<string, unknown>;
+      pendingWrites?: Array<[string, string, unknown]>;
+    });
+  }
+
+  const pendingWrites = row?.pendingWrites ?? [];
+
+  if (options?.cleanup) {
+    await saver.deleteThread(threadId);
+  }
+
+  return {
+    threadId,
+    checkpointId: nextConfig.configurable.checkpoint_id,
+    listLength: rows.length,
+    pendingWriteTask: taskId,
+    pendingWrites,
+  };
+}
+
+async function main(): Promise<void> {
+  const apiKey = process.env.AGENTSTATE_API_KEY;
+  if (!apiKey) {
+    throw new Error("AGENTSTATE_API_KEY is required");
+  }
+
+  const client = new AgentState({ apiKey });
+  const result = await runLangGraphJsExample(client);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+if (process.argv[1]?.endsWith("examples/langgraph-js/main.ts")) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/examples/langgraph-js/main.ts
+++ b/examples/langgraph-js/main.ts
@@ -1,10 +1,7 @@
 import { AgentState } from "../../packages/sdk/src/index";
 import { AgentStateCheckpointSaver } from "../../packages/sdk/src/langgraph";
 
-type Client = Pick<
-  AgentState,
-  "upsertState" | "getState" | "queryStates" | "deleteState"
->;
+type Client = Pick<AgentState, "upsertState" | "getState" | "queryStates" | "deleteState">;
 
 export type LangGraphJsExampleResult = {
   threadId: string;
@@ -51,17 +48,19 @@ export async function runLangGraphJsExample(
   const row = await saver.getTuple(nextConfig);
 
   const rows: Array<{
-    config: { configurable: { thread_id: string; checkpoint_id?: string }};
+    config: { configurable: { thread_id: string; checkpoint_id?: string } };
     checkpoint: Record<string, unknown>;
     pendingWrites?: Array<[string, string, unknown]>;
   }> = [];
 
   for await (const tuple of saver.list({ configurable: { thread_id: threadId } })) {
-    rows.push(tuple as unknown as {
-      config: { configurable: { thread_id: string; checkpoint_id?: string }};
-      checkpoint: Record<string, unknown>;
-      pendingWrites?: Array<[string, string, unknown]>;
-    });
+    rows.push(
+      tuple as unknown as {
+        config: { configurable: { thread_id: string; checkpoint_id?: string } };
+        checkpoint: Record<string, unknown>;
+        pendingWrites?: Array<[string, string, unknown]>;
+      },
+    );
   }
 
   const pendingWrites = row?.pendingWrites ?? [];
@@ -90,7 +89,7 @@ async function main(): Promise<void> {
   console.log(JSON.stringify(result, null, 2));
 }
 
-if (process.argv[1]?.endsWith("examples/langgraph-js/main.ts")) {
+if (process.argv[1]?.replaceAll("\\", "/").endsWith("examples/langgraph-js/main.ts")) {
   main().catch((error) => {
     console.error(error);
     process.exitCode = 1;

--- a/examples/langgraph-python/main.py
+++ b/examples/langgraph-python/main.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sys
-from typing import Dict
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -21,7 +20,7 @@ def run_langgraph_example(
     thread_id: str = "langgraph-python-thread-1",
     checkpoint_id: str = "checkpoint-start",
     cleanup: bool = False,
-) -> Dict[str, object]:
+) -> dict[str, object]:
     """Run a complete LangGraph checkpoint flow using a mockable AgentState client."""
 
     saver = AgentStateCheckpointSaver(client)
@@ -44,7 +43,7 @@ def run_langgraph_example(
         raise RuntimeError("Unable to load saved checkpoint tuple")
 
     config, checkpoint, _metadata, _parent, pending_writes = row
-    result: Dict[str, object] = {
+    result: dict[str, object] = {
         "thread_id": thread_id,
         "checkpoint_id": config["configurable"]["checkpoint_id"],
         "checkpoint_values": checkpoint,

--- a/examples/langgraph-python/main.py
+++ b/examples/langgraph-python/main.py
@@ -1,0 +1,75 @@
+"""LangGraph example for AgentState Python SDK."""
+
+from __future__ import annotations
+
+import sys
+from typing import Dict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SDK_PATH = ROOT / "packages" / "python-sdk"
+if str(SDK_PATH) not in sys.path:
+    sys.path.insert(0, str(SDK_PATH))
+
+from agentstate import AgentStateClient
+from agentstate.langgraph import AgentStateCheckpointSaver
+
+
+def run_langgraph_example(
+    client: AgentStateClient,
+    *,
+    thread_id: str = "langgraph-python-thread-1",
+    checkpoint_id: str = "checkpoint-start",
+    cleanup: bool = False,
+) -> Dict[str, object]:
+    """Run a complete LangGraph checkpoint flow using a mockable AgentState client."""
+
+    saver = AgentStateCheckpointSaver(client)
+
+    next_config = saver.put(
+        {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}},
+        {"id": checkpoint_id, "values": {"phase": "start"}},
+        {"note": "sdk example checkpoint"},
+        {},
+    )
+
+    saver.put_writes(
+        next_config,
+        [("messages", {"role": "assistant", "content": "Hello from LangGraph example"})],
+        "task-ui-example",
+    )
+
+    row = saver.get_tuple(next_config)
+    if row is None:
+        raise RuntimeError("Unable to load saved checkpoint tuple")
+
+    config, checkpoint, _metadata, _parent, pending_writes = row
+    result: Dict[str, object] = {
+        "thread_id": thread_id,
+        "checkpoint_id": config["configurable"]["checkpoint_id"],
+        "checkpoint_values": checkpoint,
+        "pending_writes": pending_writes or [],
+    }
+
+    if cleanup:
+        saver.delete_thread(thread_id)
+
+    return result
+
+
+def main() -> None:
+    """Run the example from CLI with a live API key."""
+
+    import os
+
+    api_key = os.environ.get("AGENTSTATE_API_KEY")
+    if not api_key:
+        raise RuntimeError("AGENTSTATE_API_KEY is required")
+
+    client = AgentStateClient(api_key=api_key)
+    result = run_langgraph_example(client)
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/sdk/tests/state-platform.test.ts
+++ b/packages/sdk/tests/state-platform.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AgentState } from "../src/index";
+import { createAISDKChatStore } from "../src/ai-sdk";
+import { AgentStateCheckpointSaver } from "../src/langgraph";
+
+type StateRecord = {
+  state_key: string;
+  agent_id: string;
+  data: Record<string, unknown>;
+  metadata: Record<string, unknown> | null;
+  tags: string[];
+  latest_sequence: number;
+  created_at: number;
+  updated_at: number;
+  deleted_at: null;
+};
+
+type MockRequest = {
+  method: string;
+  url: string;
+  body?: unknown;
+};
+
+function createStateApiMock() {
+  const stateStore = new Map<string, StateRecord>();
+  const requests: MockRequest[] = [];
+  let latestSequence = 1;
+  let timestamp = Date.now();
+
+  const now = () => {
+    timestamp += 1;
+    return timestamp;
+  };
+
+  function parseStateKey(pathname: string): string | null {
+    if (!pathname.startsWith("/v2/states/")) {
+      return null;
+    }
+    const remainder = pathname.replace("/v2/states/", "");
+    const [encoded] = remainder.split("/");
+    return encoded ? decodeURIComponent(encoded) : null;
+  }
+
+  function readPredicateValue(record: StateRecord, path: string): unknown {
+    if (!path.startsWith("$.") || !record.data) {
+      return undefined;
+    }
+    return record.data[path.slice(2)];
+  }
+
+  const query = (payload: Record<string, unknown>) => {
+    const requestedTags = (payload.tags as string[] | undefined) ?? [];
+    const predicates = (payload.predicates as Array<{ path: string; equals: unknown }> | undefined) ?? [];
+
+    return Array.from(stateStore.values())
+      .filter((record) =>
+        requestedTags.every((tag) => record.tags.includes(tag))
+      )
+      .filter((record) =>
+        predicates.every((predicate) => readPredicateValue(record, predicate.path) === predicate.equals),
+      )
+      .sort((left, right) => right.latest_sequence - left.latest_sequence)
+      .map((record) => record);
+  };
+
+  const buildRecord = (stateKey: string, payload: Record<string, unknown>): StateRecord => ({
+    state_key: stateKey,
+    agent_id: String((payload.agent_id as string) ?? ""),
+    data: (payload.data as Record<string, unknown>) ?? {},
+    metadata: payload.metadata === undefined ? null : (payload.metadata as Record<string, unknown>),
+    tags: (payload.tags as string[]) ?? [],
+    latest_sequence: latestSequence++,
+    created_at: now(),
+    updated_at: now(),
+    deleted_at: null,
+  });
+
+  const fetch = vi.fn(async (input: RequestInfo | URL, init: RequestInit = {}) => {
+    const request = input instanceof Request ? input : new Request(String(input), init);
+    const url = new URL(request.url);
+    const method = (request.method || "GET").toUpperCase();
+    const rawBody = request.body ? await request.text() : "";
+    const body = rawBody ? (JSON.parse(rawBody) as Record<string, unknown>) : undefined;
+
+    requests.push({
+      method,
+      url: `${url.pathname}${url.search}`,
+      body,
+    });
+
+    if (url.pathname === "/v2/states/query" && method === "POST") {
+      return new Response(
+        JSON.stringify({
+          data: query((body ?? {}) as Record<string, unknown>),
+          pagination: { next_cursor: null },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    const stateKey = parseStateKey(url.pathname);
+    if (!stateKey) {
+      return new Response(JSON.stringify({ error: "not_found" }), {
+        status: 404,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    if (method === "PUT" && !url.pathname.endsWith("/events")) {
+      const payload = body as Record<string, unknown>;
+      const record = buildRecord(stateKey, payload);
+      stateStore.set(stateKey, record);
+      return new Response(JSON.stringify(record), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    if (method === "GET" && url.pathname.endsWith("/events")) {
+      return new Response(
+        JSON.stringify({ data: [], pagination: { next_cursor: null } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    if (method === "GET") {
+      const existing = stateStore.get(stateKey);
+      if (!existing) {
+        return new Response(JSON.stringify({ error: "not_found" }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify(existing), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    if (method === "DELETE") {
+      const existing = stateStore.get(stateKey);
+      stateStore.delete(stateKey);
+      return new Response(JSON.stringify({ deleted: true, event: existing }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({ error: "unsupported" }), {
+      status: 404,
+      headers: { "content-type": "application/json" },
+    });
+  });
+
+  return { fetch, requests, stateStore };
+}
+
+describe("State SDK examples should run with mocked transport", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let stateMock: ReturnType<typeof createStateApiMock>;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    stateMock = createStateApiMock();
+    globalThis.fetch = stateMock.fetch as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  it("persists and loads AI SDK chat state using AgentState v2 endpoints", async () => {
+    const client = new AgentState({ apiKey: "as_live_test123" });
+    const store = createAISDKChatStore(client, {
+      stateKeyPrefix: "agentstate/ai-sdk/chat",
+      generateChatId: () => "chat-1",
+    });
+
+    const stateKey = "agentstate/ai-sdk/chat/chat-1";
+    await store.createChat();
+    await store.saveChat({
+      chatId: "chat-1",
+      messages: [{ id: "m1", role: "user", content: "hello" }],
+    });
+    const loaded = await store.loadChat("chat-1");
+
+    expect(loaded).toEqual([{ id: "m1", role: "user", content: "hello" }]);
+    expect(stateMock.stateStore.get(stateKey)?.data).toMatchObject({
+      kind: "ai-sdk-chat",
+      runtime: "ai-sdk",
+      messages: [{ id: "m1", role: "user", content: "hello" }],
+    });
+
+    await store.deleteChat("chat-1");
+    expect(stateMock.stateStore.has(stateKey)).toBe(false);
+    expect(stateMock.requests.some((request) => request.url.startsWith("/v2/states/"))).toBe(true);
+  });
+
+  it("persists LangGraph checkpoints and pending writes through query-backed list filtering", async () => {
+    const client = new AgentState({ apiKey: "as_live_test123" });
+    const saver = new AgentStateCheckpointSaver(client, {
+      stateKeyPrefix: "agentstate/langgraph",
+    });
+
+    const nextConfig = await saver.put(
+      { configurable: { thread_id: "thread-1", checkpoint_ns: "" } },
+      { id: "cp-1", values: { status: "running" } },
+      { note: "checkpoint created" },
+      {},
+    );
+    await saver.putWrites(
+      nextConfig,
+      [["messages", { role: "assistant", content: "ok" }]],
+      "task-id-1",
+    );
+
+    const rows = [];
+    for await (const row of saver.list(
+      { configurable: { thread_id: "thread-1" } },
+      { filter: { runtime: "langgraph" } },
+    )) {
+      rows.push(row);
+    }
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.config.configurable.checkpoint_id).toBe("cp-1");
+    expect(rows[0]!.checkpoint).toMatchObject({ id: "cp-1", values: { status: "running" } });
+    expect(rows[0]!.pendingWrites).toEqual([
+      ["task-id-1", "messages", { role: "assistant", content: "ok" }],
+    ]);
+    expect(stateMock.requests.some((request) => request.body && "predicates" in (request.body as any))).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add SDK example updates
- apply dashboard lint/style fixes in project and analytics components
- keep latest upstream SDK adapter logic after rebase conflict resolution

## Verification
- rebased branch cleanly
- pushed branch to origin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI SDK chat store and RSC state store adapters for persisting AI state and messages.
  * Added LangGraph checkpoint saver support for JavaScript and Python SDKs.
  * Extended state management API with upsert, get, query, delete, and list state event operations.
  * Updated capability token creation with configurable expiration timestamps.

* **Documentation**
  * Added integration guides for AI SDK and LangGraph framework adapters.
  * Published new code examples for chat and RSC state persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/agentstate/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->