### PR TITLE
ci: expand test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,17 +22,37 @@ jobs:
         with:
           node-version: "22"
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
       - name: Install dependencies
         run: bun install
 
-      - name: Lint
+      - name: API lint
         run: bunx biome check packages/api/src/
 
-      - name: Type check
+      - name: API typecheck
         run: bunx tsc --noEmit -p packages/api/tsconfig.json
 
-      - name: Test
+      - name: API unit and integration tests
         run: cd packages/api && bunx vitest run
+
+      - name: API E2E smoke test
+        run: cd packages/api && bunx vitest run test/e2e.test.ts
+
+      - name: TypeScript SDK typecheck, build, and tests
+        run: cd packages/sdk && bun run typecheck && bun run build && bun run test
+
+      - name: Install Python SDK test dependencies
+        run: python -m pip install -e "packages/python-sdk[dev]"
+
+      - name: Python SDK tests
+        run: python -m pytest -q
+        working-directory: packages/python-sdk
+
+      - name: SDK example tests
+        run: bun run test:sdk-examples
 
       - name: Build Dashboard
         run: cd packages/dashboard && bun install && bun run build

--- a/bun.lock
+++ b/bun.lock
@@ -66,7 +66,14 @@
       "devDependencies": {
         "tsup": "^8.0.0",
         "typescript": "^5.7.0",
+        "vitest": "^3.1.0",
       },
+      "peerDependencies": {
+        "@langchain/langgraph-checkpoint": "^1.0.0",
+      },
+      "optionalPeers": [
+        "@langchain/langgraph-checkpoint",
+      ],
     },
     "packages/shared": {
       "name": "@agentstate/shared",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev:dashboard": "cd packages/dashboard && bun run dev",
     "build": "cd packages/api && bunx tsc --noEmit && cd ../../packages/dashboard && bun run build",
     "test": "cd packages/api && bunx vitest run",
+    "test:sdk-examples": "node scripts/validate-sdk-examples.mjs",
     "fmt": "bunx biome check --write packages/*/src/",
     "lint": "bunx biome check packages/*/src/",
     "typecheck": "bunx tsc --noEmit -p packages/api/tsconfig.json",

--- a/packages/api/test/e2e.test.ts
+++ b/packages/api/test/e2e.test.ts
@@ -1,0 +1,86 @@
+import { SELF } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+import { applyMigrations, authHeaders, seedProject } from "./setup";
+
+describe("API E2E smoke", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await seedProject();
+  });
+
+  it("creates, updates, reads, tags, and deletes a conversation through Worker routes", async () => {
+    const headers = authHeaders();
+
+    const healthRes = await SELF.fetch("http://localhost/api");
+    expect(healthRes.status).toBe(200);
+    await expect(healthRes.json()).resolves.toMatchObject({ name: "agentstate", status: "ok" });
+
+    const createRes = await SELF.fetch("http://localhost/api/v1/conversations", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        external_id: `e2e-${Date.now()}`,
+        messages: [{ role: "user", content: "Start the smoke test" }],
+        metadata: { source: "ci-e2e" },
+      }),
+    });
+    expect(createRes.status).toBe(201);
+
+    const created = await createRes.json<{
+      id: string;
+      messages: Array<{ role: string; content: string }>;
+    }>();
+    expect(created.id).toBeTruthy();
+    expect(created.messages).toHaveLength(1);
+
+    const appendRes = await SELF.fetch(
+      `http://localhost/api/v1/conversations/${created.id}/messages`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          messages: [{ role: "assistant", content: "Smoke test reply" }],
+        }),
+      },
+    );
+    expect(appendRes.status).toBe(201);
+
+    const conversationRes = await SELF.fetch(
+      `http://localhost/api/v1/conversations/${created.id}`,
+      { headers },
+    );
+    expect(conversationRes.status).toBe(200);
+
+    const conversation = await conversationRes.json<{
+      id: string;
+      message_count: number;
+      messages: Array<{ role: string; content: string }>;
+    }>();
+    expect(conversation.id).toBe(created.id);
+    expect(conversation.message_count).toBe(2);
+    expect(conversation.messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+
+    const tagRes = await SELF.fetch(`http://localhost/api/v1/conversations/${created.id}/tags`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ tags: ["e2e-smoke"] }),
+    });
+    expect(tagRes.status).toBe(201);
+
+    const tagsRes = await SELF.fetch("http://localhost/api/v1/tags", { headers });
+    expect(tagsRes.status).toBe(200);
+    const tagsBody = await tagsRes.json<{ data: { tags: string[] } }>();
+    expect(tagsBody.data.tags).toContain("e2e-smoke");
+
+    const deleteRes = await SELF.fetch(`http://localhost/api/v1/conversations/${created.id}`, {
+      method: "DELETE",
+      headers,
+    });
+    expect(deleteRes.status).toBe(204);
+
+    const missingRes = await SELF.fetch(`http://localhost/api/v1/conversations/${created.id}`, {
+      headers,
+    });
+    expect(missingRes.status).toBe(404);
+  });
+});

--- a/packages/api/test/e2e.test.ts
+++ b/packages/api/test/e2e.test.ts
@@ -2,6 +2,24 @@ import { SELF } from "cloudflare:test";
 import { beforeAll, describe, expect, it } from "vitest";
 import { applyMigrations, authHeaders, seedProject } from "./setup";
 
+interface E2EMessage {
+  role: string;
+  content: string;
+}
+
+interface CreatedConversation {
+  id: string;
+  messages: E2EMessage[];
+}
+
+interface ConversationWithMessages extends CreatedConversation {
+  message_count: number;
+}
+
+interface TagsResponse {
+  data: { tags: string[] };
+}
+
 describe("API E2E smoke", () => {
   beforeAll(async () => {
     await applyMigrations();
@@ -26,10 +44,7 @@ describe("API E2E smoke", () => {
     });
     expect(createRes.status).toBe(201);
 
-    const created = await createRes.json<{
-      id: string;
-      messages: Array<{ role: string; content: string }>;
-    }>();
+    const created = await createRes.json<CreatedConversation>();
     expect(created.id).toBeTruthy();
     expect(created.messages).toHaveLength(1);
 
@@ -51,11 +66,7 @@ describe("API E2E smoke", () => {
     );
     expect(conversationRes.status).toBe(200);
 
-    const conversation = await conversationRes.json<{
-      id: string;
-      message_count: number;
-      messages: Array<{ role: string; content: string }>;
-    }>();
+    const conversation = await conversationRes.json<ConversationWithMessages>();
     expect(conversation.id).toBe(created.id);
     expect(conversation.message_count).toBe(2);
     expect(conversation.messages.map((message) => message.role)).toEqual(["user", "assistant"]);
@@ -69,7 +80,7 @@ describe("API E2E smoke", () => {
 
     const tagsRes = await SELF.fetch("http://localhost/api/v1/tags", { headers });
     expect(tagsRes.status).toBe(200);
-    const tagsBody = await tagsRes.json<{ data: { tags: string[] } }>();
+    const tagsBody = await tagsRes.json<TagsResponse>();
     expect(tagsBody.data.tags).toContain("e2e-smoke");
 
     const deleteRes = await SELF.fetch(`http://localhost/api/v1/conversations/${created.id}`, {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -24,6 +24,7 @@
   },
   "scripts": {
     "build": "tsup src/index.ts src/ai-sdk.ts src/langgraph.ts --format cjs,esm --dts",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
@@ -40,6 +41,7 @@
   "license": "MIT",
   "devDependencies": {
     "tsup": "^8.0.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^3.1.0"
   }
 }

--- a/packages/sdk/tests/state-platform.test.ts
+++ b/packages/sdk/tests/state-platform.test.ts
@@ -79,17 +79,20 @@ function createStateApiMock() {
   const fetch = vi.fn(async (input: RequestInfo | URL, init: RequestInit = {}) => {
     const request = input instanceof Request ? input : new Request(String(input), init);
     const url = new URL(request.url);
+    const routePath = url.pathname.startsWith("/api/")
+      ? url.pathname.slice("/api".length)
+      : url.pathname;
     const method = (request.method || "GET").toUpperCase();
     const rawBody = request.body ? await request.text() : "";
     const body = rawBody ? (JSON.parse(rawBody) as Record<string, unknown>) : undefined;
 
     requests.push({
       method,
-      url: `${url.pathname}${url.search}`,
+      url: `${routePath}${url.search}`,
       body,
     });
 
-    if (url.pathname === "/v2/states/query" && method === "POST") {
+    if (routePath === "/v2/states/query" && method === "POST") {
       return new Response(
         JSON.stringify({
           data: query((body ?? {}) as Record<string, unknown>),
@@ -99,7 +102,7 @@ function createStateApiMock() {
       );
     }
 
-    const stateKey = parseStateKey(url.pathname);
+    const stateKey = parseStateKey(routePath);
     if (!stateKey) {
       return new Response(JSON.stringify({ error: "not_found" }), {
         status: 404,
@@ -107,7 +110,7 @@ function createStateApiMock() {
       });
     }
 
-    if (method === "PUT" && !url.pathname.endsWith("/events")) {
+    if (method === "PUT" && !routePath.endsWith("/events")) {
       const payload = body as Record<string, unknown>;
       const record = buildRecord(stateKey, payload);
       stateStore.set(stateKey, record);
@@ -117,7 +120,7 @@ function createStateApiMock() {
       });
     }
 
-    if (method === "GET" && url.pathname.endsWith("/events")) {
+    if (method === "GET" && routePath.endsWith("/events")) {
       return new Response(
         JSON.stringify({ data: [], pagination: { next_cursor: null } }),
         { status: 200, headers: { "content-type": "application/json" } },

--- a/scripts/validate-sdk-examples.mjs
+++ b/scripts/validate-sdk-examples.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const tempDir = mkdtempSync(join(tmpdir(), "agentstate-sdk-examples-"));
+
+const tsExamples = [
+  "examples/ai-sdk-ui/README.md",
+  "examples/ai-sdk-rsc/README.md",
+  "examples/langgraph-js/README.md",
+];
+const pythonExample = "examples/langgraph-python/README.md";
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: root,
+    encoding: "utf8",
+    stdio: "pipe",
+    ...options,
+  });
+
+  if (result.status !== 0) {
+    const output = [result.stdout, result.stderr].filter(Boolean).join("\n");
+    throw new Error(`Command failed: ${command} ${args.join(" ")}\n${output}`);
+  }
+
+  return result;
+}
+
+function extractCodeBlocks(filePath, languages) {
+  const markdown = readFileSync(join(root, filePath), "utf8");
+  const blocks = [];
+  const pattern = /```([a-zA-Z0-9_-]*)\n([\s\S]*?)```/g;
+  let match;
+
+  while ((match = pattern.exec(markdown)) !== null) {
+    const language = match[1].toLowerCase();
+    if (languages.includes(language)) {
+      blocks.push(match[2].trim());
+    }
+  }
+
+  if (blocks.length === 0) {
+    throw new Error(`No ${languages.join("/")} code blocks found in ${filePath}`);
+  }
+
+  return blocks;
+}
+
+function importPath(fromFile, target) {
+  const withoutExtension = target.replace(/\.ts$/, "");
+  const specifier = relative(dirname(fromFile), withoutExtension).replaceAll("\\", "/");
+  return specifier.startsWith(".") ? specifier : `./${specifier}`;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function rewriteSdkImports(block, targetFile) {
+  const replacements = {
+    "@agentstate/sdk": join(root, "packages", "sdk", "src", "index.ts"),
+    "@agentstate/sdk/ai-sdk": join(root, "packages", "sdk", "src", "ai-sdk.ts"),
+    "@agentstate/sdk/langgraph": join(root, "packages", "sdk", "src", "langgraph.ts"),
+  };
+
+  let rewritten = block;
+  for (const [source, target] of Object.entries(replacements)) {
+    const pattern = new RegExp(`from\\s+(['"])${escapeRegExp(source)}\\1`, "g");
+    rewritten = rewritten.replace(pattern, `from "${importPath(targetFile, target)}"`);
+  }
+
+  return rewritten;
+}
+
+function validateTypeScriptExamples() {
+  const files = [];
+  for (const examplePath of tsExamples) {
+    const blocks = extractCodeBlocks(examplePath, ["ts", "tsx", "typescript"]);
+    blocks.forEach((block, index) => {
+      const fileName = `${examplePath.replaceAll("/", "__")}__${index + 1}.ts`;
+      const fullPath = join(tempDir, fileName);
+      const rewrittenBlock = rewriteSdkImports(block, fullPath);
+      writeFileSync(
+        fullPath,
+        [
+          "declare const process: { env: Record<string, string | undefined> };",
+          rewrittenBlock,
+          "",
+        ].join("\n"),
+      );
+      files.push(fileName);
+    });
+  }
+
+  writeFileSync(
+    join(tempDir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "ES2022",
+          moduleResolution: "bundler",
+          strict: true,
+          skipLibCheck: true,
+          noEmit: true,
+          lib: ["ES2022", "DOM"],
+          types: [],
+        },
+        include: files,
+      },
+      null,
+      2,
+    ),
+  );
+
+  run("bunx", ["tsc", "--project", join(tempDir, "tsconfig.json")]);
+}
+
+function pythonCommand() {
+  const preferred = process.env.PYTHON || "python";
+  const result = spawnSync(preferred, ["--version"], { encoding: "utf8", stdio: "pipe" });
+  if (result.status === 0) return preferred;
+  return "python3";
+}
+
+function validatePythonExample() {
+  const blocks = extractCodeBlocks(pythonExample, ["python", "py"]);
+
+  blocks.forEach((block, index) => {
+    const fullPath = join(tempDir, `langgraph-python-${index + 1}.py`);
+    writeFileSync(fullPath, `${block}\n`);
+    run(pythonCommand(), ["-m", "py_compile", fullPath], {
+      env: {
+        ...process.env,
+        PYTHONPATH: [join(root, "packages", "python-sdk"), process.env.PYTHONPATH]
+          .filter(Boolean)
+          .join(delimiter),
+      },
+    });
+  });
+
+  run(
+    pythonCommand(),
+    [
+      "-c",
+      [
+        "import agentstate",
+        "from agentstate.langgraph import AgentStateCheckpointSaver, AsyncAgentStateCheckpointSaver",
+      ].join("; "),
+    ],
+    {
+      env: {
+        ...process.env,
+        PYTHONPATH: [join(root, "packages", "python-sdk"), process.env.PYTHONPATH]
+          .filter(Boolean)
+          .join(delimiter),
+      },
+    },
+  );
+}
+
+try {
+  validateTypeScriptExamples();
+  validatePythonExample();
+  console.log("SDK examples validated");
+} finally {
+  rmSync(tempDir, { recursive: true, force: true });
+}

--- a/scripts/validate-sdk-examples.mjs
+++ b/scripts/validate-sdk-examples.mjs
@@ -36,13 +36,14 @@ function extractCodeBlocks(filePath, languages) {
   const markdown = readFileSync(join(root, filePath), "utf8");
   const blocks = [];
   const pattern = /```([a-zA-Z0-9_-]*)\n([\s\S]*?)```/g;
-  let match;
+  let match = pattern.exec(markdown);
 
-  while ((match = pattern.exec(markdown)) !== null) {
+  while (match !== null) {
     const language = match[1].toLowerCase();
     if (languages.includes(language)) {
-      blocks.push(match[2].trim());
+      blocks.push({ code: match[2].trim(), language });
     }
+    match = pattern.exec(markdown);
   }
 
   if (blocks.length === 0) {
@@ -78,14 +79,20 @@ function rewriteSdkImports(block, targetFile) {
   return rewritten;
 }
 
+function shouldUseTsxExtension(block) {
+  if (block.language === "tsx") return true;
+  return block.language === "typescript" && /<[A-Za-z][\s\S]*>/.test(block.code);
+}
+
 function validateTypeScriptExamples() {
   const files = [];
   for (const examplePath of tsExamples) {
     const blocks = extractCodeBlocks(examplePath, ["ts", "tsx", "typescript"]);
     blocks.forEach((block, index) => {
-      const fileName = `${examplePath.replaceAll("/", "__")}__${index + 1}.ts`;
+      const extension = shouldUseTsxExtension(block) ? "tsx" : "ts";
+      const fileName = `${examplePath.replaceAll("/", "__")}__${index + 1}.${extension}`;
       const fullPath = join(tempDir, fileName);
-      const rewrittenBlock = rewriteSdkImports(block, fullPath);
+      const rewrittenBlock = rewriteSdkImports(block.code, fullPath);
       writeFileSync(
         fullPath,
         [
@@ -109,6 +116,7 @@ function validateTypeScriptExamples() {
           strict: true,
           skipLibCheck: true,
           noEmit: true,
+          jsx: "react-jsx",
           lib: ["ES2022", "DOM"],
           types: [],
         },
@@ -123,10 +131,13 @@ function validateTypeScriptExamples() {
 }
 
 function pythonCommand() {
-  const preferred = process.env.PYTHON || "python";
-  const result = spawnSync(preferred, ["--version"], { encoding: "utf8", stdio: "pipe" });
-  if (result.status === 0) return preferred;
-  return "python3";
+  const candidates = [process.env.PYTHON, "python", "python3"].filter(Boolean);
+  for (const candidate of new Set(candidates)) {
+    const result = spawnSync(candidate, ["--version"], { encoding: "utf8", stdio: "pipe" });
+    if (result.status === 0) return candidate;
+  }
+
+  throw new Error("Could not find a Python interpreter. Set PYTHON or install python/python3.");
 }
 
 function validatePythonExample() {
@@ -134,7 +145,7 @@ function validatePythonExample() {
 
   blocks.forEach((block, index) => {
     const fullPath = join(tempDir, `langgraph-python-${index + 1}.py`);
-    writeFileSync(fullPath, `${block}\n`);
+    writeFileSync(fullPath, `${block.code}\n`);
     run(pythonCommand(), ["-m", "py_compile", fullPath], {
       env: {
         ...process.env,


### PR DESCRIPTION
## Summary
- add named CI steps for API E2E, TypeScript SDK, Python SDK, and SDK example validation
- add a Worker-level E2E smoke test for conversation create/read/update/tag/delete flow
- add SDK example validation that compiles TypeScript examples against local SDK source and checks Python example syntax/imports

## Verification
- bunx biome check packages/api/src/
- bunx tsc --noEmit -p packages/api/tsconfig.json
- cd packages/api && bunx vitest run test/e2e.test.ts
- cd packages/sdk && bun run typecheck && bun run build && bun run test
- cd packages/python-sdk && python -m pip install -e ".[dev]" && python -m pytest -q
- bun run test:sdk-examples
- cd packages/api && bunx vitest run
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive API end-to-end smoke tests to validate core functionality workflows.
  * Expanded test coverage for SDKs including Python SDK testing.
  * Added validation for SDK code examples in documentation to ensure accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/agentstate/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->