### PR TITLE
feat(dashboard): refine project workspace

### DIFF
--- a/packages/dashboard/src/app/dashboard/layout.tsx
+++ b/packages/dashboard/src/app/dashboard/layout.tsx
@@ -30,11 +30,11 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   }
 
   return (
-    <SidebarProvider>
-      <AppSidebar />
-      <SidebarInset className="bg-background">
-        <header className="flex h-14 shrink-0 items-center gap-3 border-b border-border/70 bg-background/95 px-4">
-          <SidebarTrigger />
+    <SidebarProvider className="bg-muted/35">
+      <AppSidebar variant="inset" />
+      <SidebarInset className="bg-background/95">
+        <header className="sticky top-0 z-30 flex h-14 shrink-0 items-center gap-3 border-b border-border/70 bg-background/85 px-4 backdrop-blur supports-[backdrop-filter]:bg-background/70">
+          <SidebarTrigger className="border border-border bg-card shadow-sm" />
           <Separator orientation="vertical" className="h-5" />
           <div className="flex min-w-0 flex-1 items-center gap-3">
             <div className="min-w-0">

--- a/packages/dashboard/src/app/dashboard/project/_conversations-empty-state.tsx
+++ b/packages/dashboard/src/app/dashboard/project/_conversations-empty-state.tsx
@@ -4,16 +4,18 @@ import { Card } from "@/components/ui/card";
 
 export function _ConversationsEmptyState() {
   return (
-    <Card className="border-dashed">
-      <EmptyState
-        icon={<MessageSquareIcon aria-hidden="true" />}
-        title="No conversations yet"
-        description="Use your API key to start storing conversations."
-      />
-      <div className="flex justify-center pb-8">
-        <span className="text-xs font-mono bg-muted px-2 py-1 rounded text-muted-foreground">
-          POST /api/v1/conversations
-        </span>
+    <Card className="border-dashed bg-card/80">
+      <div className="grid min-h-72 place-items-center px-4">
+        <div className="flex flex-col items-center gap-4 text-center">
+          <EmptyState
+            icon={<MessageSquareIcon aria-hidden="true" />}
+            title="No conversations yet"
+            description="Use your API key to start storing conversations."
+          />
+          <span className="rounded-md bg-muted px-2 py-1 font-mono text-xs text-muted-foreground">
+            POST /api/v1/conversations
+          </span>
+        </div>
       </div>
     </Card>
   );

--- a/packages/dashboard/src/app/dashboard/project/_data-tab.tsx
+++ b/packages/dashboard/src/app/dashboard/project/_data-tab.tsx
@@ -45,7 +45,7 @@ export function _DataTab({
   ];
 
   return (
-    <>
+    <div className="flex flex-col gap-3">
       <ConversationsHeader
         totalConvs={totalConvs}
         showColPicker={showColPicker}
@@ -65,6 +65,6 @@ export function _DataTab({
         allColumns={allColumns}
         onToggleConversation={onToggleConversation}
       />
-    </>
+    </div>
   );
 }

--- a/packages/dashboard/src/app/dashboard/project/_page-header.tsx
+++ b/packages/dashboard/src/app/dashboard/project/_page-header.tsx
@@ -1,5 +1,6 @@
-import { ArrowLeftIcon } from "lucide-react";
+import { ArrowLeftIcon, DatabaseIcon, Globe2Icon } from "lucide-react";
 import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
 interface PageHeaderProps {
@@ -9,19 +10,37 @@ interface PageHeaderProps {
 
 export function _PageHeader({ name, slug }: PageHeaderProps) {
   return (
-    <header className="mb-6 flex items-center gap-3 border-b border-border/70 pb-5">
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        nativeButton={false}
-        render={<Link href="/dashboard" />}
-      >
-        <ArrowLeftIcon aria-hidden="true" />
-        <span className="sr-only">Back to projects</span>
-      </Button>
-      <div className="min-w-0">
-        <h1 className="text-2xl font-semibold tracking-tight">{name}</h1>
-        <p className="truncate font-mono text-sm text-muted-foreground">{slug}</p>
+    <header className="mb-5 overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+      <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-start sm:justify-between sm:p-5">
+        <div className="flex min-w-0 gap-3">
+          <Button
+            variant="outline"
+            size="icon-sm"
+            className="mt-0.5 bg-background"
+            nativeButton={false}
+            render={<Link href="/dashboard" />}
+          >
+            <ArrowLeftIcon aria-hidden="true" />
+            <span className="sr-only">Back to projects</span>
+          </Button>
+          <div className="min-w-0 space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant="outline">Project</Badge>
+              <span className="font-mono text-xs text-muted-foreground">{slug}</span>
+            </div>
+            <h1 className="truncate text-2xl font-semibold tracking-tight sm:text-3xl">{name}</h1>
+          </div>
+        </div>
+        <div className="grid gap-2 text-xs text-muted-foreground sm:min-w-64">
+          <div className="flex items-center gap-2 rounded-lg border bg-muted/35 px-2.5 py-2">
+            <DatabaseIcon className="size-3.5" aria-hidden="true" />
+            <span className="font-mono">durable conversation history</span>
+          </div>
+          <div className="flex items-center gap-2 rounded-lg border bg-muted/35 px-2.5 py-2">
+            <Globe2Icon className="size-3.5" aria-hidden="true" />
+            <span className="truncate font-mono">https://agentstate.app/api</span>
+          </div>
+        </div>
       </div>
     </header>
   );

--- a/packages/dashboard/src/app/dashboard/project/_stats-grid.tsx
+++ b/packages/dashboard/src/app/dashboard/project/_stats-grid.tsx
@@ -15,11 +15,31 @@ export function _StatsGrid({
   activeKeyCount,
 }: StatsGridProps) {
   return (
-    <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
-      <StatCard icon={MessageSquareIcon} label="Conversations" value={totalConversations} />
-      <StatCard icon={HashIcon} label="Messages" value={totalMessages} />
-      <StatCard icon={CoinsIcon} label="Tokens" value={totalTokens} />
-      <StatCard icon={KeyIcon} label="API Keys" value={activeKeyCount} />
+    <div className="mb-5 grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <StatCard
+        className="bg-card/90 shadow-sm"
+        icon={MessageSquareIcon}
+        label="Conversations"
+        value={totalConversations}
+      />
+      <StatCard
+        className="bg-card/90 shadow-sm"
+        icon={HashIcon}
+        label="Messages"
+        value={totalMessages}
+      />
+      <StatCard
+        className="bg-card/90 shadow-sm"
+        icon={CoinsIcon}
+        label="Tokens"
+        value={totalTokens}
+      />
+      <StatCard
+        className="bg-card/90 shadow-sm"
+        icon={KeyIcon}
+        label="API Keys"
+        value={activeKeyCount}
+      />
     </div>
   );
 }

--- a/packages/dashboard/src/app/dashboard/project/_tab-trigger.tsx
+++ b/packages/dashboard/src/app/dashboard/project/_tab-trigger.tsx
@@ -11,10 +11,17 @@ interface TabTriggerProps {
 
 export function _TabTrigger({ value, icon: Icon, label, count }: TabTriggerProps) {
   return (
-    <TabsTrigger value={value} className="px-4">
+    <TabsTrigger
+      value={value}
+      className="h-10 justify-start rounded-lg px-3 data-active:bg-card data-active:shadow-sm data-active:ring-1 data-active:ring-border"
+    >
       <Icon aria-hidden="true" />
       {label}
-      {count !== undefined && <Badge variant="secondary">{count}</Badge>}
+      {count !== undefined && (
+        <Badge className="ml-auto rounded-md px-1.5 tabular-nums" variant="secondary">
+          {count}
+        </Badge>
+      )}
     </TabsTrigger>
   );
 }

--- a/packages/dashboard/src/app/dashboard/project/data-tab/conversations-header.tsx
+++ b/packages/dashboard/src/app/dashboard/project/data-tab/conversations-header.tsx
@@ -1,3 +1,4 @@
+import { SlidersHorizontalIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface ConversationsHeaderProps {
@@ -17,8 +18,11 @@ export function ConversationsHeader({
   onToggleColPicker,
 }: ConversationsHeaderProps) {
   return (
-    <div className="flex items-center justify-between mb-4">
-      <ConversationsCount count={totalConvs} />
+    <div className="mb-3 flex items-center justify-between rounded-xl border border-border bg-card px-3 py-2 shadow-sm">
+      <div>
+        <p className="text-sm font-medium">Conversation data</p>
+        <ConversationsCount count={totalConvs} />
+      </div>
       <ColumnPickerTrigger show={showColPicker} onToggle={onToggleColPicker} />
     </div>
   );
@@ -26,7 +30,7 @@ export function ConversationsHeader({
 
 function ConversationsCount({ count }: { count: number }) {
   return (
-    <p className="text-sm text-muted-foreground">
+    <p className="text-xs text-muted-foreground">
       {count} conversation{count !== 1 ? "s" : ""}
     </p>
   );
@@ -38,11 +42,13 @@ function ColumnPickerTrigger({ show, onToggle }: ColumnPickerTriggerProps) {
       <Button
         size="sm"
         variant="outline"
+        className="bg-background"
         type="button"
         onClick={onToggle}
         aria-expanded={show}
         aria-haspopup="menu"
       >
+        <SlidersHorizontalIcon data-icon="inline-start" aria-hidden="true" />
         Columns
       </Button>
     </div>

--- a/packages/dashboard/src/app/dashboard/project/page.tsx
+++ b/packages/dashboard/src/app/dashboard/project/page.tsx
@@ -76,8 +76,11 @@ function ProjectContent() {
         activeKeyCount={activeKeys.length}
       />
 
-      <Tabs defaultValue={createdKey ? "keys" : "data"}>
-        <TabsList variant="line" className="mb-6 border-b border-border/70 pb-px">
+      <Tabs defaultValue={createdKey ? "keys" : "data"} className="gap-4">
+        <TabsList
+          variant="default"
+          className="mb-1 grid h-auto w-full grid-cols-3 rounded-xl border border-border bg-muted/60 p-1"
+        >
           <_TabTrigger value="data" icon={MessageSquareIcon} label="Data" count={totalConvs} />
           <_TabTrigger value="keys" icon={KeyIcon} label="API Keys" count={activeKeys.length} />
           <_TabTrigger value="settings" icon={Settings2Icon} label="Settings" />

--- a/packages/dashboard/src/components/app-sidebar.tsx
+++ b/packages/dashboard/src/components/app-sidebar.tsx
@@ -20,16 +20,16 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
   const { isSignedIn } = useAuth();
 
   return (
-    <Sidebar collapsible="icon" {...props}>
-      <SidebarHeader>
+    <Sidebar collapsible="icon" className="p-2" {...props}>
+      <SidebarHeader className="pb-1">
         <OrganizationSwitcher />
       </SidebarHeader>
 
-      <SidebarContent>
+      <SidebarContent className="gap-1">
         <SidebarNav isSignedIn={isSignedIn ?? false} />
       </SidebarContent>
 
-      <SidebarFooter>
+      <SidebarFooter className="pt-1">
         <SidebarFooterLinks />
         <SidebarSeparator />
         <SidebarMenu>

--- a/packages/dashboard/src/components/dashboard/stat-card.tsx
+++ b/packages/dashboard/src/components/dashboard/stat-card.tsx
@@ -12,17 +12,17 @@ interface StatCardProps {
 
 export function StatCard({ icon: Icon, label, value, description, className }: StatCardProps) {
   return (
-    <Card size="sm" className={cn("min-h-[7rem]", className)}>
-      <CardHeader>
-        <CardDescription className="flex items-center gap-2">
-          <span className="flex size-7 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+    <Card size="sm" className={cn("min-h-[6.25rem] justify-between", className)}>
+      <CardHeader className="pb-0">
+        <CardDescription className="flex items-center gap-2 text-xs">
+          <span className="flex size-8 items-center justify-center rounded-lg bg-muted text-muted-foreground ring-1 ring-border">
             <Icon aria-hidden="true" />
           </span>
           {label}
         </CardDescription>
       </CardHeader>
-      <CardContent className="flex flex-col gap-1">
-        <CardTitle className="text-2xl tabular-nums">
+      <CardContent className="flex flex-col gap-1 pt-0">
+        <CardTitle className="text-2xl font-semibold tabular-nums">
           {typeof value === "number" ? value.toLocaleString() : value}
         </CardTitle>
         {description && <p className="text-xs text-muted-foreground">{description}</p>}

--- a/packages/dashboard/src/components/organization/_org-switcher-trigger.tsx
+++ b/packages/dashboard/src/components/organization/_org-switcher-trigger.tsx
@@ -14,7 +14,7 @@ export function OrgSwitcherTrigger({ orgName, hasOrg }: OrgSwitcherTriggerProps)
       render={
         <SidebarMenuButton
           size="lg"
-          className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+          className="h-12 rounded-xl bg-sidebar-accent/65 px-2.5 shadow-sm ring-1 ring-sidebar-border data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
           aria-label="Switch organization"
         />
       }

--- a/packages/dashboard/src/components/sidebar/_sidebar-footer-links.tsx
+++ b/packages/dashboard/src/components/sidebar/_sidebar-footer-links.tsx
@@ -10,7 +10,11 @@ export function SidebarFooterLinks() {
     <SidebarMenu>
       <SidebarMenuItem>
         <Link href="/docs">
-          <SidebarMenuButton isActive={pathname.startsWith("/docs")} tooltip="Docs">
+          <SidebarMenuButton
+            className="h-9 rounded-lg px-2.5 data-active:bg-sidebar-accent data-active:shadow-sm data-active:ring-1 data-active:ring-sidebar-border"
+            isActive={pathname.startsWith("/docs")}
+            tooltip="Docs"
+          >
             <BookOpenIcon />
             <span>Docs</span>
           </SidebarMenuButton>
@@ -18,7 +22,11 @@ export function SidebarFooterLinks() {
       </SidebarMenuItem>
       <SidebarMenuItem>
         <Link href="/">
-          <SidebarMenuButton isActive={pathname === "/"} tooltip="Home">
+          <SidebarMenuButton
+            className="h-9 rounded-lg px-2.5 data-active:bg-sidebar-accent data-active:shadow-sm data-active:ring-1 data-active:ring-sidebar-border"
+            isActive={pathname === "/"}
+            tooltip="Home"
+          >
             <HomeIcon />
             <span>Home</span>
           </SidebarMenuButton>

--- a/packages/dashboard/src/components/sidebar/_sidebar-nav.tsx
+++ b/packages/dashboard/src/components/sidebar/_sidebar-nav.tsx
@@ -32,7 +32,9 @@ export function SidebarNav({ isSignedIn }: SidebarNavProps) {
   return (
     <>
       <SidebarGroup>
-        <SidebarGroupLabel>Platform</SidebarGroupLabel>
+        <SidebarGroupLabel className="px-2 text-[0.68rem] font-semibold uppercase tracking-wide text-sidebar-foreground/50">
+          Platform
+        </SidebarGroupLabel>
         <SidebarMenu>
           {navItems.map((item) => {
             const isActive =
@@ -42,7 +44,11 @@ export function SidebarNav({ isSignedIn }: SidebarNavProps) {
             return (
               <SidebarMenuItem key={item.href}>
                 <Link href={item.href}>
-                  <SidebarMenuButton isActive={isActive} tooltip={item.label}>
+                  <SidebarMenuButton
+                    className="h-9 rounded-lg px-2.5 data-active:bg-sidebar-accent data-active:shadow-sm data-active:ring-1 data-active:ring-sidebar-border"
+                    isActive={isActive}
+                    tooltip={item.label}
+                  >
                     <item.icon />
                     <span>{item.label}</span>
                   </SidebarMenuButton>
@@ -55,11 +61,14 @@ export function SidebarNav({ isSignedIn }: SidebarNavProps) {
 
       {isSignedIn && (
         <SidebarGroup>
-          <SidebarGroupLabel>Settings</SidebarGroupLabel>
+          <SidebarGroupLabel className="px-2 text-[0.68rem] font-semibold uppercase tracking-wide text-sidebar-foreground/50">
+            Settings
+          </SidebarGroupLabel>
           <SidebarMenu>
             <SidebarMenuItem>
               <Link href="/dashboard/settings/organizations">
                 <SidebarMenuButton
+                  className="h-9 rounded-lg px-2.5 data-active:bg-sidebar-accent data-active:shadow-sm data-active:ring-1 data-active:ring-sidebar-border"
                   isActive={pathname.startsWith("/dashboard/settings/organizations")}
                   tooltip="Organizations"
                 >


### PR DESCRIPTION
## Summary\n- Restyle the dashboard shell with an inset sidebar, stronger active navigation states, and a sticky top bar.\n- Redesign the project detail header, stat cards, segmented tabs, and conversation empty state for a denser workspace feel.\n- Keep project data, auth, routes, and API behavior unchanged.\n\n## Verification\n- bunx biome check packages/dashboard/src/\n- cd packages/dashboard && bunx tsc --noEmit\n- bun run build\n\n## Notes\n- Local signed-in browser QA is blocked by the production Clerk key domain restriction on localhost; the unauthenticated production route still shows the expected sign-in screen.\n