### PR TITLE
fix(deploy): sync prepared deploy scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ cd packages/api && bunx vitest run
 cd packages/api
 WRANGLER_DEPLOY_CONFIG=wrangler.deploy.jsonc bash scripts/prepare-wrangler-deploy-config.sh
 npx wrangler deploy -c wrangler.deploy.jsonc
+# Shortcut: `bun run deploy` from the repo root runs the same deploy-config prep.
 ```
 
 ## Architecture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ cd packages/api && bunx vitest run
 cd packages/api
 WRANGLER_DEPLOY_CONFIG=wrangler.deploy.jsonc bash scripts/prepare-wrangler-deploy-config.sh
 npx wrangler deploy -c wrangler.deploy.jsonc
-# Shortcut: `bun run deploy` from the repo root runs the same deploy-config prep.
+# Shortcut: `bun run deploy` from the repo root delegates to the API deploy script above.
 ```
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ cd packages/api && bunx vitest run
 cd packages/api
 WRANGLER_DEPLOY_CONFIG=wrangler.deploy.jsonc bash scripts/prepare-wrangler-deploy-config.sh
 npx wrangler deploy -c wrangler.deploy.jsonc
+# Shortcut: `bun run deploy` from the repo root runs the same deploy-config prep.
 ```
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ cd packages/api && bunx vitest run
 cd packages/api
 WRANGLER_DEPLOY_CONFIG=wrangler.deploy.jsonc bash scripts/prepare-wrangler-deploy-config.sh
 npx wrangler deploy -c wrangler.deploy.jsonc
-# Shortcut: `bun run deploy` from the repo root runs the same deploy-config prep.
+# Shortcut: `bun run deploy` from the repo root delegates to the API deploy script above.
 ```
 
 ## Architecture

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -10,6 +10,7 @@ Durable notes for recurring maintenance. Keep this file small and update it inst
 - For code-smell automation, read `$CODEX_HOME/automations/code-smell-detector/memory.md` first, scan commits since that timestamp, then fall back to the last 24 hours or 7 days only when needed.
 - When refreshing `/agents.md`, edit `packages/api/src/content/agents.md` and regenerate `packages/api/src/content/static.ts`.
 - In sandboxed maintenance runs, set Bun and Wrangler writable paths when needed: `BUN_TMPDIR=/private/tmp/codex-bun-tmp`, `BUN_INSTALL_CACHE_DIR=/private/tmp/codex-bun-cache`, and `XDG_CONFIG_HOME=/private/tmp/codex-wrangler-config`.
+- Root `bun run deploy` and `cd packages/api && bun run deploy` must prepare `wrangler.deploy.jsonc` first so deploys can omit unavailable Vectorize or cron bindings without editing `wrangler.jsonc`.
 - Validate dashboard changes with `cd packages/dashboard && bun run build`; raw `bunx tsc --noEmit` can fail in fresh checkouts before Next generates route type files.
 
 ## Review Memory

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -10,7 +10,7 @@ Durable notes for recurring maintenance. Keep this file small and update it inst
 - For code-smell automation, read `$CODEX_HOME/automations/code-smell-detector/memory.md` first, scan commits since that timestamp, then fall back to the last 24 hours or 7 days only when needed.
 - When refreshing `/agents.md`, edit `packages/api/src/content/agents.md` and regenerate `packages/api/src/content/static.ts`.
 - In sandboxed maintenance runs, set Bun and Wrangler writable paths when needed: `BUN_TMPDIR=/private/tmp/codex-bun-tmp`, `BUN_INSTALL_CACHE_DIR=/private/tmp/codex-bun-cache`, and `XDG_CONFIG_HOME=/private/tmp/codex-wrangler-config`.
-- Root `bun run deploy` and `cd packages/api && bun run deploy` must prepare `wrangler.deploy.jsonc` first so deploys can omit unavailable Vectorize or cron bindings without editing `wrangler.jsonc`.
+- Root `bun run deploy` should delegate to `cd packages/api && bun run deploy`, and the API deploy script must prepare `wrangler.deploy.jsonc` first so deploys can omit unavailable Vectorize or cron bindings without editing `wrangler.jsonc`.
 - Validate dashboard changes with `cd packages/dashboard && bun run build`; raw `bunx tsc --noEmit` can fail in fresh checkouts before Next generates route type files.
 
 ## Review Memory

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "bunx biome check packages/*/src/",
     "typecheck": "bunx tsc --noEmit -p packages/api/tsconfig.json",
     "db:generate": "cd packages/api && bunx drizzle-kit generate",
-    "deploy": "cd packages/api && bunx wrangler deploy"
+    "deploy": "cd packages/api && WRANGLER_DEPLOY_CONFIG=wrangler.deploy.jsonc bash scripts/prepare-wrangler-deploy-config.sh && npx wrangler deploy -c wrangler.deploy.jsonc"
   },
   "overrides": {
     "@hono/node-server": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "bunx biome check packages/*/src/",
     "typecheck": "bunx tsc --noEmit -p packages/api/tsconfig.json",
     "db:generate": "cd packages/api && bunx drizzle-kit generate",
-    "deploy": "cd packages/api && WRANGLER_DEPLOY_CONFIG=wrangler.deploy.jsonc bash scripts/prepare-wrangler-deploy-config.sh && npx wrangler deploy -c wrangler.deploy.jsonc"
+    "deploy": "cd packages/api && bun run deploy"
   },
   "overrides": {
     "@hono/node-server": "^2.0.3",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
+    "deploy": "WRANGLER_DEPLOY_CONFIG=wrangler.deploy.jsonc bash scripts/prepare-wrangler-deploy-config.sh && wrangler deploy -c wrangler.deploy.jsonc",
     "db:generate": "drizzle-kit generate",
     "db:migrate:local": "wrangler d1 migrations apply agentstate-db --local",
     "db:migrate:remote": "wrangler d1 migrations apply agentstate-db --remote",


### PR DESCRIPTION
## Summary
- route root and API deploy scripts through `prepare-wrangler-deploy-config.sh` before deploy
- mirror the deploy shortcut in `AGENTS.md` and `CLAUDE.md`
- record the deploy-script rule in core memory

## Why
Recent maintenance docs require deploys to use `wrangler.deploy.jsonc` so unavailable Vectorize or cron bindings do not block production deploys. The package scripts still called raw `wrangler deploy`, which left the command surface out of sync with the documented workflow.

## Verification
- `bunx biome check packages/api/src/`
- `bunx tsc --noEmit -p packages/api/tsconfig.json`
- `cd packages/api && bunx vitest run`

## Automation
- code-smell-detector maintenance pass
- no recent commits after the last run timestamp; audited the last 7 days instead