### PR TITLE
docs(agent): note sandbox envs for verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,10 @@ bunx wrangler dev
 cd packages/dashboard
 bun run dev
 
+# Sandboxed runs
+export BUN_TMPDIR=/private/tmp/codex-bun-tmp BUN_INSTALL_CACHE_DIR=/private/tmp/codex-bun-cache XDG_CONFIG_HOME=/private/tmp/codex-wrangler-config
+# Prefix `bunx tsc`, `bunx vitest`, and Wrangler commands with the env block above when the sandbox blocks default temp or config paths.
+
 # Database
 bunx drizzle-kit generate                                      # Generate migrations
 bunx wrangler d1 migrations apply agentstate-db --local        # Apply locally

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,10 @@ bunx wrangler dev
 cd packages/dashboard
 bun run dev
 
+# Sandboxed runs
+export BUN_TMPDIR=/private/tmp/codex-bun-tmp BUN_INSTALL_CACHE_DIR=/private/tmp/codex-bun-cache XDG_CONFIG_HOME=/private/tmp/codex-wrangler-config
+# Prefix `bunx tsc`, `bunx vitest`, and Wrangler commands with the env block above when the sandbox blocks default temp or config paths.
+
 # Database
 bunx drizzle-kit generate                                      # Generate migrations
 bunx wrangler d1 migrations apply agentstate-db --local        # Apply locally


### PR DESCRIPTION
## Summary
- document the writable Bun and Wrangler env vars for sandboxed verification runs
- keep `CLAUDE.md` and `AGENTS.md` in sync with the existing core-memory guidance

## Why
The current `main` verification pass reproduced two sandbox-specific failures on June 5, 2026: Bun tempdir writes during `bunx tsc`, and Wrangler log writes during `bunx vitest`. The repo already records the workaround in `docs/knowledge/core-memory.md`; this PR surfaces it in the root agent guides that automation runs read first.

## Verification
- `bunx biome check packages/api/src/`
- `BUN_TMPDIR=/private/tmp/codex-bun-tmp BUN_INSTALL_CACHE_DIR=/private/tmp/codex-bun-cache bunx tsc --noEmit -p packages/api/tsconfig.json`
- `cd packages/api && BUN_TMPDIR=/private/tmp/codex-bun-tmp BUN_INSTALL_CACHE_DIR=/private/tmp/codex-bun-cache XDG_CONFIG_HOME=/private/tmp/codex-wrangler-config bunx vitest run`
- `cd packages/api && BUN_TMPDIR=/private/tmp/codex-bun-tmp BUN_INSTALL_CACHE_DIR=/private/tmp/codex-bun-cache XDG_CONFIG_HOME=/private/tmp/codex-wrangler-config WRANGLER_DEPLOY_CONFIG=/private/tmp/agentstate-audit.deploy.jsonc bash scripts/prepare-wrangler-deploy-config.sh`

## Automation
- code-smell-detector maintenance pass
- findings scoped to commits after `2026-06-02T21:01:00Z`

## Summary by Sourcery

Document environment variables required for running Bun and Wrangler commands in sandboxed verification environments and keep agent documentation aligned with existing core-memory guidance.

Documentation:
- Add guidance for configuring Bun and Wrangler environment variables when running TypeScript and Vitest commands in sandboxed environments in AGENTS.md.
- Mirror the sandbox environment variable guidance for Bun and Wrangler in CLAUDE.md to keep agent docs in sync.