### PR TITLE
fix(ci): repair dashboard workflow syntax

### DIFF
--- a/.github/workflows/dashboard-deploy.yml
+++ b/.github/workflows/dashboard-deploy.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   deploy-production:
     runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
     steps:
       - name: Checkout code
@@ -47,8 +49,6 @@ jobs:
 
       - name: Notify deployment
         uses: 8398a7/action-slack@v3
-        if: always() && secrets.SLACK_WEBHOOK_URL != ''
+        if: always() && env.SLACK_WEBHOOK_URL != ''
         with:
           status: ${{ job.status }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -76,8 +76,8 @@ jobs:
 
               > This preview URL will be available for all reviewers. Let us know if you encounter any issues!`
             })
-          env:
-            PREVIEW_URL: ${{ steps.preview.outputs.preview_url }}
+        env:
+          PREVIEW_URL: ${{ steps.preview.outputs.preview_url }}
 
       - name: Delete previous preview deployments
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
- move the Slack webhook secret into job env so the deploy workflow stops using `secrets.*` inside a step `if:` conditional
- fix the preview workflow indentation so the `github-script` step uses a real step-level `env` block

## Evidence
- main workflow run `27040331369` was rejected as a workflow file issue after `#109`; GitHub Docs say secrets cannot be referenced directly in `if:` conditionals
- main workflow run `27040331702` was rejected as a workflow file issue after `#109`; `.github/workflows/preview-deploy.yml` had `env:` nested under `with:` on the comment step

## Verification
- inspected the failing main runs with `gh run view`
- verified the corrected YAML structure in both workflow files

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>
