### PR TITLE
fix(ci): repair dashboard pages config

### DIFF
--- a/.github/workflows/dashboard-deploy.yml
+++ b/.github/workflows/dashboard-deploy.yml
@@ -41,8 +41,8 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDir: packages/dashboard
-          command: pages deploy out --project-name=agentstate-production
+          workingDirectory: packages/dashboard
+          command: pages deploy out --project-name=agentstate-dashboard
         env:
           NODE_ENV: production
           NEXT_PUBLIC_API_ENDPOINT: https://agentstate.app/api

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDir: packages/dashboard
+          workingDirectory: packages/dashboard
           command: pages deploy out --project-name=agentstate-dashboard --branch=${{ github.head_ref || github.ref_name }}
         env:
           NODE_ENV: production


### PR DESCRIPTION
## Summary
- use the supported `workingDirectory` input for `cloudflare/wrangler-action`
- point the production Pages deploy at the known existing `agentstate-dashboard` project instead of the missing `agentstate-production` project

## Evidence
- main deploy run `27040547821` warned that `workingDir` is not a valid `wrangler-action` input
- the same run failed with `Project not found` for `agentstate-production [code: 8000007]`
- the preview workflow and cleanup step already use `agentstate-dashboard`, which is the only Pages project name referenced elsewhere in the repo

## Verification
- inspected the failed deploy log with `gh run view 27040547821 --log-failed`
- verified both workflow files now use `workingDirectory`

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>
