### PR TITLE
fix(ci): use bun for dashboard wrangler deploys

### DIFF
--- a/.github/workflows/dashboard-deploy.yml
+++ b/.github/workflows/dashboard-deploy.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          packageManager: bun
           workingDirectory: packages/dashboard
           command: pages deploy out --project-name=agentstate-dashboard
         env:

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          packageManager: bun
           workingDirectory: packages/dashboard
           command: pages deploy out --project-name=agentstate-dashboard --branch=${{ github.head_ref || github.ref_name }}
         env:


### PR DESCRIPTION
## Summary
- force `cloudflare/wrangler-action` to use `bun` when it installs Wrangler in the dashboard Pages workflows

## Evidence
- main deploy run `27040726109` failed in `Deploy to Cloudflare Pages`
- the action tried `npm i wrangler@3.90.0` and failed with `Unsupported URL Type "workspace:": workspace:*`
- the action exposes a `packageManager` input, and this repo uses Bun workspaces

## Verification
- inspected the failed deploy log with `gh run view 27040726109 --log-failed`
- verified both workflow files now pass `packageManager: bun`

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>
