### PR TITLE
feat: redesign dashboard UI/UX and unify API under /api/v1

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -6,29 +6,15 @@ Backward-compatible base: `https://agentstate.app` (routes under `/v1/*` mirror 
 
 ## Version Overview
 
-### V2 API (`/api/v2/*`) — Current Version
+### Current API (`/api/v1/*`)
 
-The V2 API provides improved performance, consistency, and developer experience:
+The API provides improved performance, consistency, and developer experience:
 
 - **Snake_case field names**: All request and response fields use snake_case
 - **Timestamps in milliseconds**: All timestamps are Unix milliseconds (`Date.now()` format)
 - **Cursor-based pagination**: Efficient pagination with `next_cursor` and `total` count
 - **Conditional includes**: Use `?include=messages` to fetch messages only when needed
 - **HTTP method semantics**: PATCH for partial updates, proper status codes
-- **Deprecation headers**: V1 endpoints return `X-API-Deprecated: true` warning header
-
-### V1 API (`/api/v1/*`) — Deprecated
-
-V1 endpoints remain functional but are deprecated. All V1 responses include:
-
-```
-X-API-Deprecated: true
-X-API-Sunset: 2027-01-01
-Deprecation: true
-Link: </api/v2/conversations>; rel="successor-version"
-```
-
-**Migration guide**: See [V2 Migration](#v2-migration-guide) below.
 
 ---
 
@@ -37,7 +23,7 @@ Link: </api/v2/conversations>; rel="successor-version"
 - **Field names**: snake_case in all request and response bodies.
 - **IDs**: nanoid, 21 characters (e.g., `V1StGXR8_Z5jdHi6B-myT`).
 - **Timestamps**: Unix milliseconds (`Date.now()` format), stored as integers.
-- **Pagination**: Cursor-based. Never offset-based. Pass `cursor` to get the next page; when `next_cursor` is `null`, there are no more results. V2 includes `total` count in pagination metadata.
+- **Pagination**: Cursor-based. Never offset-based. Pass `cursor` to get the next page; when `next_cursor` is `null`, there are no more results. Includes `total` count in pagination metadata.
 - **Metadata**: Arbitrary JSON object. Stored as serialized TEXT, parsed on read.
 
 ## Authentication
@@ -163,9 +149,9 @@ If you need absolutely real-time data, consider:
 
 ---
 
-## V2 API Reference
+## API Reference
 
-All V2 endpoints require API key authentication and are located at `/api/v2/*`.
+All endpoints require API key authentication and are located at `/api/v1/*`.
 
 ### Authentication
 
@@ -180,7 +166,7 @@ Only the SHA-256 hash of the key is stored. The raw key is shown once at creatio
 
 ### Rate Limiting
 
-All V2 endpoints enforce a fixed-window rate limit per API key.
+All endpoints enforce a fixed-window rate limit per API key.
 
 | Parameter | Value |
 |-----------|-------|
@@ -224,14 +210,14 @@ All errors follow a consistent structure:
 
 ---
 
-### V2 Conversations API
+### Conversations API
 
 All conversation endpoints require API key authentication.
 
 #### Create Conversation
 
 ```
-POST /api/v2/conversations
+POST /api/v1/conversations
 ```
 
 Creates a new conversation, optionally with initial messages.
@@ -272,7 +258,7 @@ Each message object:
 
 **V2 Changes:**
 - Messages are NOT included in the create response for efficiency
-- Use `POST /api/v2/conversations/:id/messages` to add messages separately
+- Use `POST /api/v1/conversations/:id/messages` to add messages separately
 
 **Errors:**
 - `400 BAD_REQUEST` -- Invalid body or validation failure.
@@ -281,7 +267,7 @@ Each message object:
 #### List Conversations
 
 ```
-GET /api/v2/conversations
+GET /api/v1/conversations
 ```
 
 Returns conversations for the authenticated project, ordered by `updated_at`.
@@ -328,7 +314,7 @@ Returns conversations for the authenticated project, ordered by `updated_at`.
 #### Get Conversation
 
 ```
-GET /api/v2/conversations/:id
+GET /api/v1/conversations/:id
 ```
 
 Returns a single conversation. Messages are NOT included by default.
@@ -343,10 +329,10 @@ Returns a single conversation. Messages are NOT included by default.
 
 ```bash
 # Get conversation metadata only (no messages)
-GET /api/v2/conversations/:id
+GET /api/v1/conversations/:id
 
 # Include messages
-GET /api/v2/conversations/:id?include=messages
+GET /api/v1/conversations/:id?include=messages
 ```
 
 **Response:** `200 OK`
@@ -385,7 +371,7 @@ GET /api/v2/conversations/:id?include=messages
 #### Lookup by External ID
 
 ```
-GET /api/v2/conversations/by-external-id/:externalId
+GET /api/v1/conversations/by-external-id/:externalId
 ```
 
 Find a conversation by the caller-provided `external_id`. Messages are NOT included by default.
@@ -397,7 +383,7 @@ Response shape is identical to [Get Conversation](#get-conversation) (without `?
 #### Update Conversation
 
 ```
-PATCH /api/v2/conversations/:id
+PATCH /api/v1/conversations/:id
 ```
 
 Update a conversation's title and/or metadata.
@@ -433,7 +419,7 @@ Update a conversation's title and/or metadata.
 #### Delete Conversation
 
 ```
-DELETE /api/v2/conversations/:id
+DELETE /api/v1/conversations/:id
 ```
 
 Deletes a conversation and all its messages.
@@ -444,14 +430,14 @@ Deletes a conversation and all its messages.
 
 ---
 
-### V2 Messages API
+### Messages API
 
 Manage messages within an existing conversation. All endpoints require API key authentication.
 
 #### Append Messages
 
 ```
-POST /api/v2/conversations/:id/messages
+POST /api/v1/conversations/:id/messages
 ```
 
 Add one or more messages to an existing conversation. Automatically updates the conversation's `message_count`, `token_count`, and `updated_at`.
@@ -473,7 +459,7 @@ Add one or more messages to an existing conversation. Automatically updates the 
 #### List Messages
 
 ```
-GET /api/v2/conversations/:id/messages
+GET /api/v1/conversations/:id/messages
 ```
 
 Paginate through messages in chronological order.
@@ -515,14 +501,14 @@ Paginate through messages in chronological order.
 
 ---
 
-### V2 Analytics API
+### Analytics API
 
 Analytics endpoints for project-wide statistics. All endpoints require API key authentication and use caching for performance.
 
 #### Usage Summary
 
 ```
-GET /api/v2/analytics/summary
+GET /api/v1/analytics/summary
 ```
 
 Returns summary statistics for a project, including total conversations, messages, tokens, and averages over a specified time period. Supports tag filtering.
@@ -564,7 +550,7 @@ Returns summary statistics for a project, including total conversations, message
 #### Time Series Data
 
 ```
-GET /api/v2/analytics/timeseries
+GET /api/v1/analytics/timeseries
 ```
 
 Returns time-series data for conversations, messages, or tokens grouped by the specified granularity.
@@ -607,7 +593,7 @@ Returns time-series data for conversations, messages, or tokens grouped by the s
 #### Tag Statistics
 
 ```
-GET /api/v2/analytics/tags
+GET /api/v1/analytics/tags
 ```
 
 Returns usage statistics for tags within a specified time period.
@@ -654,14 +640,14 @@ Returns usage statistics for tags within a specified time period.
 
 ---
 
-### V2 Projects API
+### Projects API
 
 Project management endpoints. All endpoints require API key authentication.
 
 #### Create Project
 
 ```
-POST /api/v2/projects
+POST /api/v1/projects
 ```
 
 Creates a new project and auto-generates a default API key.
@@ -707,7 +693,7 @@ Creates a new project and auto-generates a default API key.
 #### List Projects
 
 ```
-GET /api/v2/projects
+GET /api/v1/projects
 ```
 
 **Query parameters:**
@@ -747,7 +733,7 @@ GET /api/v2/projects
 #### Get Project by ID
 
 ```
-GET /api/v2/projects/:id
+GET /api/v1/projects/:id
 ```
 
 Returns the project with its API keys.
@@ -783,7 +769,7 @@ Returns the project with its API keys.
 #### Update Project
 
 ```
-PATCH /api/v2/projects/:id
+PATCH /api/v1/projects/:id
 ```
 
 Update a project's name.
@@ -817,7 +803,7 @@ Update a project's name.
 #### Delete Project
 
 ```
-DELETE /api/v2/projects/:id
+DELETE /api/v1/projects/:id
 ```
 
 Permanently deletes a project and all associated data, including:
@@ -835,14 +821,14 @@ Permanently deletes a project and all associated data, including:
 
 ---
 
-### V2 Keys API
+### Keys API
 
 API key management endpoints. All endpoints require API key authentication.
 
 #### Create API Key
 
 ```
-POST /api/v2/keys
+POST /api/v1/keys
 ```
 
 Creates a new API key for the authenticated project.
@@ -880,7 +866,7 @@ The `key` field contains the full API key and is only returned at creation time.
 #### List API Keys
 
 ```
-GET /api/v2/keys
+GET /api/v1/keys
 ```
 
 Lists all API keys for the authenticated project (including revoked ones).
@@ -912,7 +898,7 @@ The full key is never returned after creation.
 #### Revoke API Key
 
 ```
-DELETE /api/v2/keys/:id
+DELETE /api/v1/keys/:id
 ```
 
 Soft-deletes an API key by setting `revoked_at`. The key immediately becomes invalid for authentication.
@@ -924,31 +910,33 @@ Soft-deletes an API key by setting `revoked_at`. The key immediately becomes inv
 
 ---
 
-## V2 Migration Guide
+## Migration Guide (Historical)
 
-### Key Changes from V1 to V2
+The API is now unified under `/api/v1/`. The improvements previously labeled "V2" (PATCH method, `?include=messages`, `pagination.total`, snake_case field names, etc.) are the current standard.
 
-1. **Base Path**: `/api/v1/*` → `/api/v2/*`
-2. **Messages in Get Conversation**: V1 includes messages by default. V2 requires `?include=messages`
-3. **Create Conversation Response**: V1 returns created messages. V2 returns only conversation metadata
-4. **Update Method**: V1 uses `PUT`. V2 uses `PATCH`
-5. **Append Messages Response**: V1 returns created messages. V2 returns `204 No Content`
-6. **Pagination**: V2 includes `total` count in metadata
-7. **Analytics**: V2 derives `project_id` from API key, no need to pass it as query parameter
-8. **Field Names**: V2 consistently uses snake_case (e.g., `key_id` instead of `id`)
+### Key Changes from Legacy V1
+
+1. **Base Path**: Legacy `/v1/*` is consolidated into `/api/v1/*`
+2. **Messages in Get Conversation**: Legacy V1 included messages by default. Now requires `?include=messages`
+3. **Create Conversation Response**: Legacy V1 returned created messages. Now returns only conversation metadata
+4. **Update Method**: Legacy V1 used `PUT`. Now uses `PATCH`
+5. **Append Messages Response**: Legacy V1 returned created messages. Now returns `204 No Content`
+6. **Pagination**: Now includes `total` count in metadata
+7. **Analytics**: Derives `project_id` from API key, no need to pass it as query parameter
+8. **Field Names**: Consistently uses snake_case (e.g., `key_id` instead of `id`)
 
 ### Migration Steps
 
-1. **Update base URLs**: Change `/api/v1/` to `/api/v2/` in your code
+1. **Update base URLs**: Use `/api/v1/` for all API calls
 2. **Update conversation fetches**: Add `?include=messages` when you need messages
-3. **Handle create response**: V2 create no longer returns messages
-4. **Update field name references**: Use V2 field names (e.g., `key_id`, `project_id`)
+3. **Handle create response**: Create no longer returns messages
+4. **Update field name references**: Use snake_case field names (e.g., `key_id`, `project_id`)
 5. **Remove project_id from analytics**: The API key determines the project automatically
 6. **Update pagination handling**: Use `pagination.total` for total counts
 
 ### Example Migration
 
-**V1:**
+**Legacy V1:**
 ```javascript
 // Create conversation
 const response = await fetch('/api/v1/conversations', {
@@ -960,10 +948,10 @@ const { messages } = await response.json();
 // messages is available in response
 ```
 
-**V2:**
+**Current:**
 ```javascript
 // Create conversation
-const response = await fetch('/api/v2/conversations', {
+const response = await fetch('/api/v1/conversations', {
   method: 'POST',
   headers: { 'Authorization': 'Bearer as_live_xxx' },
   body: JSON.stringify({ messages: [{ role: 'user', content: 'Hello' }] })
@@ -972,7 +960,7 @@ const conversation = await response.json();
 // messages NOT in response - conversation created efficiently
 
 // Later, fetch messages when needed
-const msgResponse = await fetch(`/api/v2/conversations/${conversation.id}/messages`);
+const msgResponse = await fetch(`/api/v1/conversations/${conversation.id}/messages`);
 const { data: messages } = await msgResponse.json();
 ```
 
@@ -980,9 +968,9 @@ const { data: messages } = await msgResponse.json();
 
 
 
-## Conversations API (V1 - Deprecated)
+## Conversations API (Legacy V1 — Deprecated)
 
-> **⚠️ Deprecated**: V1 endpoints are deprecated and will be removed on **2027-01-01**. All V1 responses include deprecation headers. Please migrate to [V2 API](#v2-api-reference).
+> **Deprecated**: Legacy V1 endpoints (`/v1/*` without `/api/` prefix) are deprecated and will be removed on **2027-01-01**. Please use the current `/api/v1/*` endpoints documented above.
 
 All conversation endpoints require API key authentication.
 
@@ -1901,7 +1889,7 @@ Permanently deletes a project and all associated data, including:
 
 ## Planned State Platform
 
-Status: planned contract. The shared package and TypeScript SDK expose these shapes and helpers; backend routes are expected under `/api/v2/*`.
+Status: planned contract. The shared package and TypeScript SDK expose these shapes and helpers; backend routes are expected under `/api/v1/*`.
 
 State CRUD, queries, tokens, and claims use project API key authentication. Lease renew/release and state event watch reads may use scoped capability tokens.
 
@@ -1909,10 +1897,10 @@ State CRUD, queries, tokens, and claims use project API key authentication. Leas
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `PUT` | `/api/v2/states/:stateKey` | Create or replace state |
-| `GET` | `/api/v2/states/:stateKey` | Read latest or historical state |
-| `POST` | `/api/v2/states/query` | Query state records |
-| `DELETE` | `/api/v2/states/:stateKey` | Delete state |
+| `PUT` | `/api/v1/states/:stateKey` | Create or replace state |
+| `GET` | `/api/v1/states/:stateKey` | Read latest or historical state |
+| `POST` | `/api/v1/states/query` | Query state records |
+| `DELETE` | `/api/v1/states/:stateKey` | Delete state |
 
 State records use:
 
@@ -1952,10 +1940,10 @@ Upsert body:
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/api/v2/states/:stateKey/events` | List events after a sequence |
-| `POST` | `/api/v2/states/:stateKey/lease` | Create a write lease |
-| `POST` | `/api/v2/leases/:id/renew` | Renew an active lease |
-| `DELETE` | `/api/v2/leases/:id` | Release an active lease |
+| `GET` | `/api/v1/states/:stateKey/events` | List events after a sequence |
+| `POST` | `/api/v1/states/:stateKey/lease` | Create a write lease |
+| `POST` | `/api/v1/leases/:id/renew` | Renew an active lease |
+| `DELETE` | `/api/v1/leases/:id` | Release an active lease |
 
 State events use `event_type` values `upsert` and `delete`:
 
@@ -1987,13 +1975,13 @@ Lease create body:
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST` | `/api/v2/capability-tokens` | Create a scoped state token |
-| `GET` | `/api/v2/capability-tokens` | List capability tokens |
-| `DELETE` | `/api/v2/capability-tokens/:id` | Revoke a capability token |
-| `POST` | `/api/v2/claims` | Create a deterministic claim |
-| `GET` | `/api/v2/claims` | List claims |
-| `GET` | `/api/v2/claims/:id` | Read claim with evidence |
-| `POST` | `/api/v2/claims/:id/verify` | Run deterministic verification |
+| `POST` | `/api/v1/capability-tokens` | Create a scoped state token |
+| `GET` | `/api/v1/capability-tokens` | List capability tokens |
+| `DELETE` | `/api/v1/capability-tokens/:id` | Revoke a capability token |
+| `POST` | `/api/v1/claims` | Create a deterministic claim |
+| `GET` | `/api/v1/claims` | List claims |
+| `GET` | `/api/v1/claims/:id` | Read claim with evidence |
+| `POST` | `/api/v1/claims/:id/verify` | Run deterministic verification |
 
 Capability scopes are `state:read`, `state:write`, `state:watch`, `lease:write`, and `claim:write`. The raw `token` is returned only on create.
 

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -17,7 +17,7 @@ Durable notes for recurring maintenance. Keep this file small and update it inst
 
 - Historical API-doc review notes from March 2026 were folded into the live docs. Keep API endpoint coverage current in `docs/api-reference.md`, `docs/sdk.md`, and `docs/integration.md`.
 - Historical test-coverage notes were stale after the test suite expanded. Use current `packages/api/test/` coverage and CI output as the source of truth before adding tests.
-- Recent state-platform maintenance should cover sparse `/api/v2/states/query` filters. Tag and JSON-path queries must keep scanning past nonmatching rows instead of stopping at the first capped candidate page.
+- Recent state-platform maintenance should cover sparse `/api/v1/states/query` filters. Tag and JSON-path queries must keep scanning past nonmatching rows instead of stopping at the first capped candidate page.
 - Sparse state-query cap tests seed enough D1 rows to run close to Vitest's default timeout under full-suite load; keep an explicit per-test timeout on that coverage instead of changing production scan behavior.
 - The TypeScript LangGraph adapter should extend `BaseCheckpointSaver` from `@langchain/langgraph-checkpoint`; keep the optional peer and dev dependency aligned so SDK type/build checks verify that contract.
 - Current CI coverage is broader than the older root-guide snippets: it now runs API lint/typecheck/tests plus TypeScript SDK typecheck/build/tests, Python SDK tests, SDK example validation, and a full dashboard build. Sync agent docs to `.github/workflows/ci.yml` when these steps change.

--- a/docs/v2-migration.md
+++ b/docs/v2-migration.md
@@ -1,5 +1,7 @@
 # API v2 Migration Guide
 
+> **Note (June 2026):** The API is now unified — all endpoints are under `/api/v1/`. The v2 routes have been consolidated into v1, so the improvements described in this guide (PATCH method, `?include=messages`, `pagination.total`, snake_case field names, etc.) are now available at `/api/v1/` paths. This migration guide is kept for historical reference.
+
 This guide helps you migrate from API v1 to v2. V2 introduces improved consistency, better performance, and clearer semantics.
 
 **Deprecation Timeline:**

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -13,14 +13,11 @@ import domainsRouter from "./routes/domains";
 import keysRouter from "./routes/keys";
 import projectsRouter from "./routes/projects";
 import tagsRouter from "./routes/tags";
-import analyticsV2Router from "./routes/v2/analytics";
+// V2-only features — new capabilities with no v1 equivalent
 import capabilityTokensV2Router from "./routes/v2/capability-tokens";
 import claimsV2Router from "./routes/v2/claims";
-import conversationsV2Router from "./routes/v2/conversations";
-import keysV2Router from "./routes/v2/keys";
 import leasesV2Router from "./routes/v2/leases";
 import organizationsV2Router from "./routes/v2/organizations";
-import projectsV2Router from "./routes/v2/projects";
 import statesV2Router from "./routes/v2/states";
 import verifyDomainRouter from "./routes/verify-domain";
 import webhooksRouter from "./routes/webhooks";
@@ -38,10 +35,6 @@ const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 app.use("*", requestIdMiddleware);
 
 // CORS configuration with origin reflection for security
-// - Same-origin requests work (dashboard static assets on same Worker)
-// - Local development: localhost origins allowed
-// - Production: only agentstate.app allowed
-// - Any other origin: denied (returns first allowed origin, browser rejects mismatched response)
 const ALLOWED_ORIGINS = [
   "https://agentstate.app",
   "http://localhost:3000",
@@ -54,14 +47,8 @@ app.use(
   "*",
   cors({
     origin: (origin) => {
-      // Allow requests with no origin (same-origin, mobile apps, curl, etc.)
       if (!origin) return "*";
-
-      // Reflect allowed origins back to browser; deny unknown origins
-      // Browser will reject response if origin doesn't match what was sent
       if (ALLOWED_ORIGINS.includes(origin)) return origin;
-
-      // Origin not allowed: return a safe default, browser will reject
       return ALLOWED_ORIGINS[0];
     },
     allowHeaders: [
@@ -72,7 +59,7 @@ app.use(
       "X-Lease-Id",
       "Last-Event-ID",
     ],
-    credentials: true, // Allow cookies/auth headers for same-origin requests
+    credentials: true,
   }),
 );
 app.use("*", dbMiddleware);
@@ -94,54 +81,73 @@ app.get("/agents.md", (c) => c.text(AGENTS_MD));
 app.get("/openapi.json", (c) => c.json(JSON.parse(OPENAPI_SPEC)));
 
 // ---------------------------------------------------------------------------
-// API routes at /api/v1/*
+// Unified API at /api/v1/*
+// One API version — v1 is the latest and only version.
+//
+// IMPORTANT: Routes with scoped auth (states, leases, tokens, claims) must be
+// registered BEFORE the tags router, whose router.use("*", apiKeyAuth) would
+// otherwise intercept all /api/v1/* requests and reject capability tokens.
 // ---------------------------------------------------------------------------
 
+// --- Scoped-auth routes (must come before apiKeyAuth routers) ---
+
+// State management: /api/v1/states/*
+app.route("/api/v1/states", statesV2Router);
+
+// Distributed locking: /api/v1/leases/*
+app.route("/api/v1/leases", leasesV2Router);
+
+// Scoped auth tokens: /api/v1/capability-tokens/*
+app.route("/api/v1/capability-tokens", capabilityTokensV2Router);
+
+// Verifiable claims: /api/v1/claims/*
+app.route("/api/v1/claims", claimsV2Router);
+
+// Organizations: /api/v1/organizations/*
+app.route("/api/v1/organizations", organizationsV2Router);
+
+// --- API-key-auth routes ---
+
+// Conversations (CRUD, messages, search, bulk, analytics)
 app.route("/api/v1/conversations", conversationsRouter);
 app.route("/api/v1/conversations", aiRouter);
-app.route("/api/projects", keysRouter);
-// Dashboard-internal project management routes (no API key auth required)
+
+// Project management
 app.route("/api/v1/projects", projectsRouter);
-// Analytics routes: /api/v1/projects/:id/analytics
+
+// API keys (at /api/projects for backward compat)
+app.route("/api/projects", keysRouter);
+
+// Analytics: /api/v1/projects/:id/analytics
 app.route("/api/v1/projects", analyticsRouter);
-// Tags routes: handles /api/v1/conversations/:id/tags and /api/v1/tags
+
+// Tags: handles /api/v1/conversations/:id/tags and /api/v1/tags
+// NOTE: router.use("*", apiKeyAuth) applies to /api/v1/* — keep after scoped routes
 app.route("/api/v1", tagsRouter);
-// Webhooks routes: /api/v1/webhooks
+
+// Webhooks: /api/v1/webhooks
 app.route("/api/v1/webhooks", webhooksRouter);
-// Custom domains routes: /api/v1/projects/:id/domains
+
+// Custom domains: /api/v1/projects/:id/domains
 app.route("/api/v1/projects", domainsRouter);
+
+// Public analytics at /api/v1/analytics
+app.route("/api/v1/analytics", analyticsPublicRouter);
 
 // Backward compat at /v1/*
 app.route("/v1/conversations", conversationsRouter);
 app.route("/v1/conversations", aiRouter);
-// Backward compat tags at /v1/*
 app.route("/v1", tagsRouter);
-// Public analytics at /v1/analytics and /api/v1/analytics
 app.route("/v1/analytics", analyticsPublicRouter);
-app.route("/api/v1/analytics", analyticsPublicRouter);
 
 // ---------------------------------------------------------------------------
-// Dashboard routes at /api/v/* (V2 endpoints, no API key auth)
+// Dashboard routes at /api/v/* (no API key auth)
 // ---------------------------------------------------------------------------
 
-// Dashboard-internal project management with org support (no API key auth required)
+import projectsV2Router from "./routes/v2/projects";
+
 app.route("/api/v/projects", projectsV2Router);
-// Dashboard-internal organizations sync endpoint (no API key auth required)
 app.route("/api/v/organizations", organizationsV2Router);
-
-// ---------------------------------------------------------------------------
-// API routes at /api/v2/*
-// ---------------------------------------------------------------------------
-
-app.route("/api/v2/conversations", conversationsV2Router);
-app.route("/api/v2/states", statesV2Router);
-app.route("/api/v2/keys", keysV2Router);
-app.route("/api/v2/capability-tokens", capabilityTokensV2Router);
-app.route("/api/v2/claims", claimsV2Router);
-app.route("/api/v2/leases", leasesV2Router);
-app.route("/api/v2/organizations", organizationsV2Router);
-app.route("/api/v2/projects", projectsV2Router);
-app.route("/api/v2/analytics", analyticsV2Router);
 
 // Domain verification endpoint (no auth required, used by domain providers)
 app.route("/", verifyDomainRouter);

--- a/packages/api/src/routes/ai.ts
+++ b/packages/api/src/routes/ai.ts
@@ -1,7 +1,6 @@
 import { asc, desc, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { conversations, messages } from "../db/schema";
-import { deprecationMiddleware } from "../lib/deprecation";
 import { loadConversation, notFound } from "../lib/helpers";
 import { apiKeyAuth } from "../middleware/auth";
 import { rateLimitMiddleware } from "../middleware/rate-limit";
@@ -12,16 +11,6 @@ const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
 router.use("*", apiKeyAuth);
 router.use("*", rateLimitMiddleware);
-
-// V1 deprecation notice
-router.use(
-  "*",
-  deprecationMiddleware({
-    message: "API v1 is deprecated. Use /api/v2/ instead.",
-    sunsetDate: "2026-12-31",
-    link: "https://docs.agentstate.app/api/v2/migration",
-  }),
-);
 
 // POST /:id/generate-title — first 20 messages are enough for title context
 router.post("/:id/generate-title", async (c) => {

--- a/packages/api/src/routes/analytics-public.ts
+++ b/packages/api/src/routes/analytics-public.ts
@@ -1,5 +1,4 @@
 import { Hono } from "hono";
-import { deprecationMiddleware } from "../lib/deprecation";
 import { parseLimitParam } from "../lib/helpers";
 import { apiKeyAuth } from "../middleware/auth";
 import { rateLimitMiddleware } from "../middleware/rate-limit";
@@ -18,16 +17,6 @@ const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
 app.use("*", apiKeyAuth);
 app.use("*", rateLimitMiddleware);
-
-// V1 deprecation notice
-app.use(
-  "*",
-  deprecationMiddleware({
-    message: "API v1 is deprecated. Use /api/v2/ instead.",
-    sunsetDate: "2026-12-31",
-    link: "https://docs.agentstate.app/api/v2/migration",
-  }),
-);
 
 // ---------------------------------------------------------------------------
 // GET /summary

--- a/packages/api/src/routes/analytics.ts
+++ b/packages/api/src/routes/analytics.ts
@@ -1,7 +1,6 @@
 import { and, eq, gte, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { conversations, messages } from "../db/schema";
-import { deprecationMiddleware } from "../lib/deprecation";
 import type { Bindings, Variables } from "../types";
 
 // ---------------------------------------------------------------------------
@@ -9,16 +8,6 @@ import type { Bindings, Variables } from "../types";
 // ---------------------------------------------------------------------------
 
 const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
-
-// V1 deprecation notice
-app.use(
-  "*",
-  deprecationMiddleware({
-    message: "API v1 is deprecated. Use /api/v2/analytics instead.",
-    sunsetDate: "2026-12-31",
-    link: "https://docs.agentstate.app/api/v2/migration",
-  }),
-);
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/api/src/routes/conversations/index.ts
+++ b/packages/api/src/routes/conversations/index.ts
@@ -1,5 +1,4 @@
 import { Hono } from "hono";
-import { deprecationMiddleware } from "../../lib/deprecation";
 import { apiKeyAuth } from "../../middleware/auth";
 import { rateLimitMiddleware } from "../../middleware/rate-limit";
 import type { Bindings, Variables } from "../../types";
@@ -14,16 +13,6 @@ const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 // Apply auth and rate-limit middleware once for all conversation routes
 router.use("*", apiKeyAuth);
 router.use("*", rateLimitMiddleware);
-
-// V1 deprecation notice
-router.use(
-  "*",
-  deprecationMiddleware({
-    message: "API v1 is deprecated. Use /api/v2/ instead.",
-    sunsetDate: "2026-12-31",
-    link: "https://docs.agentstate.app/api/v2/migration",
-  }),
-);
 
 // Mount sub-routers — order matters: specific paths before parameterized ones
 router.route("/", searchRouter);

--- a/packages/api/src/routes/keys.ts
+++ b/packages/api/src/routes/keys.ts
@@ -1,5 +1,4 @@
 import { Hono } from "hono";
-import { deprecationMiddleware } from "../lib/deprecation";
 import { notFound, parseJsonBody, requireSameProject, validationError } from "../lib/helpers";
 import { CreateApiKeySchema } from "../lib/validation";
 import { apiKeyAuth } from "../middleware/auth";
@@ -13,16 +12,6 @@ const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 // The caller must use a valid API key for the target project.
 app.use("*", apiKeyAuth);
 app.use("*", rateLimitMiddleware);
-
-// V1 deprecation notice
-app.use(
-  "*",
-  deprecationMiddleware({
-    message: "API v1 is deprecated. Use /api/v2/keys instead.",
-    sunsetDate: "2026-12-31",
-    link: "https://docs.agentstate.app/api/v2/migration",
-  }),
-);
 
 // ---------------------------------------------------------------------------
 // POST /:projectId/keys — Create API key

--- a/packages/api/src/routes/projects.ts
+++ b/packages/api/src/routes/projects.ts
@@ -1,5 +1,4 @@
 import { Hono } from "hono";
-import { deprecationMiddleware } from "../lib/deprecation";
 import { errorResponse, parseJsonBody, parseLimitParam, validationError } from "../lib/helpers";
 import { CreateApiKeySchema, CreateProjectSchema } from "../lib/validation";
 import { projectCreationRateLimit } from "../middleware/project-creation-rate-limit";
@@ -17,16 +16,6 @@ import {
 import type { Bindings, Variables } from "../types";
 
 const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
-
-// V1 deprecation notice
-app.use(
-  "*",
-  deprecationMiddleware({
-    message: "API v1 projects is deprecated. Use /api/v2/projects instead.",
-    sunsetDate: "2026-12-31",
-    link: "https://docs.agentstate.app/api/v2/migration",
-  }),
-);
 
 // ---------------------------------------------------------------------------
 // POST /v1/projects — Create project

--- a/packages/api/src/routes/tags.ts
+++ b/packages/api/src/routes/tags.ts
@@ -1,5 +1,4 @@
 import { Hono } from "hono";
-import { deprecationMiddleware } from "../lib/deprecation";
 import { errorResponse, parseJsonBody, validationError } from "../lib/helpers";
 import { AddTagsSchema } from "../lib/validation";
 import { apiKeyAuth } from "../middleware/auth";
@@ -21,16 +20,6 @@ const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
 router.use("*", apiKeyAuth);
 router.use("*", rateLimitMiddleware);
-
-// V1 deprecation notice
-router.use(
-  "*",
-  deprecationMiddleware({
-    message: "API v1 is deprecated. Use /api/v2/ instead.",
-    sunsetDate: "2026-12-31",
-    link: "https://docs.agentstate.app/api/v2/migration",
-  }),
-);
 
 // ---------------------------------------------------------------------------
 // GET /tags — List all unique tags for the project

--- a/packages/api/test/state-platform.test.ts
+++ b/packages/api/test/state-platform.test.ts
@@ -7,7 +7,7 @@ async function putState(
   body: Record<string, unknown>,
   headers: Record<string, string> = {},
 ) {
-  return SELF.fetch(`http://localhost/api/v2/states/${stateKey}`, {
+  return SELF.fetch(`http://localhost/api/v1/states/${stateKey}`, {
     method: "PUT",
     headers: { ...authHeaders(), ...headers },
     body: JSON.stringify(body),
@@ -41,20 +41,20 @@ describe("State platform", () => {
     const secondBody = await second.json<any>();
     expect(secondBody.latest_sequence).toBeGreaterThan(firstBody.latest_sequence);
 
-    const latest = await SELF.fetch("http://localhost/api/v2/states/run-1", {
+    const latest = await SELF.fetch("http://localhost/api/v1/states/run-1", {
       headers: authHeaders(),
     });
     expect(latest.status).toBe(200);
     expect((await latest.json<any>()).data.status).toBe("done");
 
     const historical = await SELF.fetch(
-      `http://localhost/api/v2/states/run-1?at_sequence=${firstBody.latest_sequence}`,
+      `http://localhost/api/v1/states/run-1?at_sequence=${firstBody.latest_sequence}`,
       { headers: authHeaders() },
     );
     expect(historical.status).toBe(200);
     expect((await historical.json<any>()).data.status).toBe("draft");
 
-    const events = await SELF.fetch("http://localhost/api/v2/states/run-1/events?after=0", {
+    const events = await SELF.fetch("http://localhost/api/v1/states/run-1/events?after=0", {
       headers: authHeaders(),
     });
     expect(events.status).toBe(200);
@@ -98,7 +98,7 @@ describe("State platform", () => {
       tags: ["queryable"],
     });
 
-    const res = await SELF.fetch("http://localhost/api/v2/states/query", {
+    const res = await SELF.fetch("http://localhost/api/v1/states/query", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({
@@ -130,7 +130,7 @@ describe("State platform", () => {
       });
     }
 
-    const res = await SELF.fetch("http://localhost/api/v2/states/query", {
+    const res = await SELF.fetch("http://localhost/api/v1/states/query", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({
@@ -166,7 +166,7 @@ describe("State platform", () => {
         ),
       );
 
-      const first = await SELF.fetch("http://localhost/api/v2/states/query", {
+      const first = await SELF.fetch("http://localhost/api/v1/states/query", {
         method: "POST",
         headers: authHeaders(),
         body: JSON.stringify({
@@ -181,7 +181,7 @@ describe("State platform", () => {
       expect(firstBody.data).toEqual([]);
       expect(firstBody.pagination.next_cursor).toEqual(expect.any(String));
 
-      const second = await SELF.fetch("http://localhost/api/v2/states/query", {
+      const second = await SELF.fetch("http://localhost/api/v1/states/query", {
         method: "POST",
         headers: authHeaders(),
         body: JSON.stringify({
@@ -202,7 +202,7 @@ describe("State platform", () => {
   it("enforces leases for protected writes", async () => {
     await putState("leased-run", { agent_id: "lease-agent", data: { value: 1 } });
 
-    const leaseRes = await SELF.fetch("http://localhost/api/v2/states/leased-run/lease", {
+    const leaseRes = await SELF.fetch("http://localhost/api/v1/states/leased-run/lease", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({ holder: "worker-1", ttl_ms: 60_000 }),
@@ -221,14 +221,14 @@ describe("State platform", () => {
     });
     expect(allowed.status).toBe(200);
 
-    const renew = await SELF.fetch(`http://localhost/api/v2/leases/${lease.id}/renew`, {
+    const renew = await SELF.fetch(`http://localhost/api/v1/leases/${lease.id}/renew`, {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({ ttl_ms: 60_000 }),
     });
     expect(renew.status).toBe(200);
 
-    const release = await SELF.fetch(`http://localhost/api/v2/leases/${lease.id}`, {
+    const release = await SELF.fetch(`http://localhost/api/v1/leases/${lease.id}`, {
       method: "DELETE",
       headers: authHeaders(),
     });
@@ -238,7 +238,7 @@ describe("State platform", () => {
   it("uses scoped capability tokens without granting unrelated scopes", async () => {
     await putState("token-run", { agent_id: "token-agent", data: { value: true } });
 
-    const createToken = await SELF.fetch("http://localhost/api/v2/capability-tokens", {
+    const createToken = await SELF.fetch("http://localhost/api/v1/capability-tokens", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({ name: "Read only", scopes: ["state:read", "state:watch"] }),
@@ -246,12 +246,12 @@ describe("State platform", () => {
     expect(createToken.status).toBe(201);
     const tokenBody = await createToken.json<any>();
 
-    const read = await SELF.fetch("http://localhost/api/v2/states/token-run", {
+    const read = await SELF.fetch("http://localhost/api/v1/states/token-run", {
       headers: { Authorization: `Bearer ${tokenBody.token}` },
     });
     expect(read.status).toBe(200);
 
-    const write = await SELF.fetch("http://localhost/api/v2/states/token-run", {
+    const write = await SELF.fetch("http://localhost/api/v1/states/token-run", {
       method: "PUT",
       headers: {
         Authorization: `Bearer ${tokenBody.token}`,
@@ -262,7 +262,7 @@ describe("State platform", () => {
     expect(write.status).toBe(403);
 
     const watch = await SELF.fetch(
-      `http://localhost/api/v2/states/watch?after=0&once=true&token=${tokenBody.token}`,
+      `http://localhost/api/v1/states/watch?after=0&once=true&token=${tokenBody.token}`,
     );
     expect(watch.status).toBe(200);
     expect(watch.headers.get("Content-Type")).toContain("text/event-stream");
@@ -270,7 +270,7 @@ describe("State platform", () => {
   });
 
   it("verifies deterministic claim evidence", async () => {
-    const create = await SELF.fetch("http://localhost/api/v2/claims", {
+    const create = await SELF.fetch("http://localhost/api/v1/claims", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({
@@ -291,14 +291,14 @@ describe("State platform", () => {
     expect(create.status).toBe(201);
     const claim = await create.json<any>();
 
-    const verify = await SELF.fetch(`http://localhost/api/v2/claims/${claim.id}/verify`, {
+    const verify = await SELF.fetch(`http://localhost/api/v1/claims/${claim.id}/verify`, {
       method: "POST",
       headers: authHeaders(),
     });
     expect(verify.status).toBe(201);
     expect((await verify.json<any>()).status).toBe("verified");
 
-    const failed = await SELF.fetch("http://localhost/api/v2/claims", {
+    const failed = await SELF.fetch("http://localhost/api/v1/claims", {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify({
@@ -317,7 +317,7 @@ describe("State platform", () => {
       }),
     });
     const failedClaim = await failed.json<any>();
-    const failedVerify = await SELF.fetch(`http://localhost/api/v2/claims/${failedClaim.id}/verify`, {
+    const failedVerify = await SELF.fetch(`http://localhost/api/v1/claims/${failedClaim.id}/verify`, {
       method: "POST",
       headers: authHeaders(),
     });

--- a/packages/api/test/v2-analytics.skip.ts
+++ b/packages/api/test/v2-analytics.skip.ts
@@ -40,7 +40,7 @@ interface TagsResponse {
 // ---------------------------------------------------------------------------
 
 async function createConversation(body: Record<string, unknown> = {}) {
-  const res = await SELF.fetch("http://localhost/api/v2/conversations", {
+  const res = await SELF.fetch("http://localhost/api/v1/conversations", {
     method: "POST",
     headers: authHeaders(),
     body: JSON.stringify(body),
@@ -72,7 +72,7 @@ describe("V2 Analytics", () => {
   // GET /summary - Usage summary
   // -------------------------------------------------------------------------
 
-  describe("GET /api/v2/analytics/summary", () => {
+  describe("GET /api/v1/analytics/summary", () => {
     it("returns summary stats for the project", async () => {
       // Create test conversations
       await createConversation({
@@ -85,7 +85,7 @@ describe("V2 Analytics", () => {
         messages: [{ role: "user", content: "Test", token_count: 10 }],
       });
 
-      const res = await SELF.fetch("http://localhost/api/v2/analytics/summary", {
+      const res = await SELF.fetch("http://localhost/api/v1/analytics/summary", {
         headers: authHeaders(),
       });
       expect(res.status).toBe(200);
@@ -106,7 +106,7 @@ describe("V2 Analytics", () => {
       const end = now;
 
       const res = await SELF.fetch(
-        `http://localhost/api/v2/analytics/summary?start=${start}&end=${end}`,
+        `http://localhost/api/v1/analytics/summary?start=${start}&end=${end}`,
         { headers: authHeaders() },
       );
       expect(res.status).toBe(200);
@@ -131,7 +131,7 @@ describe("V2 Analytics", () => {
       await addTag(conv2.id, "test-tag");
 
       // Query with tag filter
-      const res = await SELF.fetch("http://localhost/api/v2/analytics/summary?tag=test-tag", {
+      const res = await SELF.fetch("http://localhost/api/v1/analytics/summary?tag=test-tag", {
         headers: authHeaders(),
       });
       expect(res.status).toBe(200);
@@ -141,12 +141,12 @@ describe("V2 Analytics", () => {
     });
 
     it("returns 401 without auth", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/analytics/summary");
+      const res = await SELF.fetch("http://localhost/api/v1/analytics/summary");
       expect(res.status).toBe(401);
     });
 
     it("does NOT have deprecation headers", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/analytics/summary", {
+      const res = await SELF.fetch("http://localhost/api/v1/analytics/summary", {
         headers: authHeaders(),
       });
       expect(res.headers.get("X-API-Deprecation")).toBeNull();
@@ -158,13 +158,13 @@ describe("V2 Analytics", () => {
   // GET /timeseries - Time-series data
   // -------------------------------------------------------------------------
 
-  describe("GET /api/v2/analytics/timeseries", () => {
+  describe("GET /api/v1/analytics/timeseries", () => {
     it("returns timeseries data for conversations", async () => {
       await createConversation({
         messages: [{ role: "user", content: "Time series test", token_count: 5 }],
       });
 
-      const res = await SELF.fetch("http://localhost/api/v2/analytics/timeseries", {
+      const res = await SELF.fetch("http://localhost/api/v1/analytics/timeseries", {
         headers: authHeaders(),
       });
       expect(res.status).toBe(200);
@@ -181,7 +181,7 @@ describe("V2 Analytics", () => {
 
       for (const metric of metrics) {
         const res = await SELF.fetch(
-          `http://localhost/api/v2/analytics/timeseries?metric=${metric}`,
+          `http://localhost/api/v1/analytics/timeseries?metric=${metric}`,
           { headers: authHeaders() },
         );
         expect(res.status).toBe(200);
@@ -196,7 +196,7 @@ describe("V2 Analytics", () => {
 
       for (const granularity of granularities) {
         const res = await SELF.fetch(
-          `http://localhost/api/v2/analytics/timeseries?granularity=${granularity}`,
+          `http://localhost/api/v1/analytics/timeseries?granularity=${granularity}`,
           { headers: authHeaders() },
         );
         expect(res.status).toBe(200);
@@ -207,7 +207,7 @@ describe("V2 Analytics", () => {
     });
 
     it("returns 401 without auth", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/analytics/timeseries");
+      const res = await SELF.fetch("http://localhost/api/v1/analytics/timeseries");
       expect(res.status).toBe(401);
     });
   });
@@ -216,7 +216,7 @@ describe("V2 Analytics", () => {
   // GET /tags - Tag usage analytics
   // -------------------------------------------------------------------------
 
-  describe("GET /api/v2/analytics/tags", () => {
+  describe("GET /api/v1/analytics/tags", () => {
     it("returns tag usage statistics", async () => {
       // Create conversations with tags
       const res1 = await createConversation({
@@ -225,7 +225,7 @@ describe("V2 Analytics", () => {
       const conv1 = await res1.json<{ id: string }>();
       await addTag(conv1.id, "analytics-test");
 
-      const res = await SELF.fetch("http://localhost/api/v2/analytics/tags", {
+      const res = await SELF.fetch("http://localhost/api/v1/analytics/tags", {
         headers: authHeaders(),
       });
       expect(res.status).toBe(200);
@@ -238,7 +238,7 @@ describe("V2 Analytics", () => {
     });
 
     it("supports limit parameter", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/analytics/tags?limit=5", {
+      const res = await SELF.fetch("http://localhost/api/v1/analytics/tags?limit=5", {
         headers: authHeaders(),
       });
       expect(res.status).toBe(200);
@@ -248,7 +248,7 @@ describe("V2 Analytics", () => {
     });
 
     it("returns 401 without auth", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/analytics/tags");
+      const res = await SELF.fetch("http://localhost/api/v1/analytics/tags");
       expect(res.status).toBe(401);
     });
   });
@@ -257,14 +257,14 @@ describe("V2 Analytics", () => {
   // V1 deprecation headers
   // -------------------------------------------------------------------------
 
-  describe("V1 Deprecation Headers", () => {
-    it("adds deprecation headers to V1 analytics endpoints", async () => {
+  describe("Unified API — No Deprecation Headers", () => {
+    it("does NOT add deprecation headers to v1 analytics endpoints", async () => {
       const res = await SELF.fetch(`http://localhost/v1/projects/${TEST_PROJECT_ID}/analytics`, {
         headers: authHeaders(),
       });
-      expect(res.headers.get("X-API-Deprecation")).toContain("deprecated");
-      expect(res.headers.get("Sunset")).toBe("2026-12-31");
-      expect(res.headers.get("Link")).toContain("deprecation");
+      expect(res.headers.get("X-API-Deprecation")).toBeNull();
+      expect(res.headers.get("Sunset")).toBeNull();
+      expect(res.headers.get("Link")).toBeNull();
     });
   });
 });

--- a/packages/api/test/v2-capability-tokens-leases.test.ts
+++ b/packages/api/test/v2-capability-tokens-leases.test.ts
@@ -68,7 +68,7 @@ async function resetCapabilityTables(): Promise<void> {
 }
 
 async function createCapabilityToken(body: Record<string, unknown>) {
-  return SELF.fetch("http://localhost/api/v2/capability-tokens", {
+  return SELF.fetch("http://localhost/api/v1/capability-tokens", {
     method: "POST",
     headers: authHeaders(),
     body: JSON.stringify(body),
@@ -169,7 +169,7 @@ describe("V2 Capability Tokens", () => {
       scopes: ["state:read"],
     });
 
-    const res = await SELF.fetch("http://localhost/api/v2/capability-tokens", {
+    const res = await SELF.fetch("http://localhost/api/v1/capability-tokens", {
       headers: authHeaders(),
     });
 
@@ -202,7 +202,7 @@ describe("V2 Leases", () => {
       stateKey: "session:lease",
     });
 
-    const res = await SELF.fetch("http://localhost/api/v2/leases/lease_renew_test/renew", {
+    const res = await SELF.fetch("http://localhost/api/v1/leases/lease_renew_test/renew", {
       method: "POST",
       headers: {
         Authorization: `Bearer ${token.token}`,
@@ -230,7 +230,7 @@ describe("V2 Leases", () => {
       stateKey: "session:release",
     });
 
-    const res = await SELF.fetch("http://localhost/api/v2/leases/lease_release_test", {
+    const res = await SELF.fetch("http://localhost/api/v1/leases/lease_release_test", {
       method: "DELETE",
       headers: {
         Authorization: `Bearer ${token.token}`,
@@ -255,7 +255,7 @@ describe("V2 Leases", () => {
       stateKey: "session:no-lease",
     });
 
-    const res = await SELF.fetch("http://localhost/api/v2/leases/lease_forbidden_test/renew", {
+    const res = await SELF.fetch("http://localhost/api/v1/leases/lease_forbidden_test/renew", {
       method: "POST",
       headers: {
         Authorization: `Bearer ${token.token}`,
@@ -280,7 +280,7 @@ describe("V2 Leases", () => {
       expiresAt: Date.now() - 1_000,
     });
 
-    const res = await SELF.fetch("http://localhost/api/v2/leases/lease_expired_test/renew", {
+    const res = await SELF.fetch("http://localhost/api/v1/leases/lease_expired_test/renew", {
       method: "POST",
       headers: {
         Authorization: `Bearer ${token.token}`,

--- a/packages/api/test/v2-claims.test.ts
+++ b/packages/api/test/v2-claims.test.ts
@@ -116,7 +116,7 @@ async function applyClaimTables(): Promise<void> {
 }
 
 async function createClaim(body: Record<string, unknown>) {
-  return SELF.fetch("http://localhost/api/v2/claims", {
+  return SELF.fetch("http://localhost/api/v1/claims", {
     method: "POST",
     headers: authHeaders(),
     body: JSON.stringify(body),
@@ -201,7 +201,7 @@ describe("V2 Claims", () => {
     expect(createRes.status).toBe(201);
 
     const res = await SELF.fetch(
-      "http://localhost/api/v2/claims?subject_type=conversation&subject_id=claim-list-1",
+      "http://localhost/api/v1/claims?subject_type=conversation&subject_id=claim-list-1",
       { headers: authHeaders() },
     );
 
@@ -229,7 +229,7 @@ describe("V2 Claims", () => {
     });
     const created = await res.json<Claim>();
 
-    const getRes = await SELF.fetch(`http://localhost/api/v2/claims/${created.id}`, {
+    const getRes = await SELF.fetch(`http://localhost/api/v1/claims/${created.id}`, {
       headers: authHeaders(),
     });
 
@@ -272,7 +272,7 @@ describe("V2 Claims", () => {
     });
     const created = await res.json<Claim>();
 
-    const verifyRes = await SELF.fetch(`http://localhost/api/v2/claims/${created.id}/verify`, {
+    const verifyRes = await SELF.fetch(`http://localhost/api/v1/claims/${created.id}/verify`, {
       method: "POST",
       headers: authHeaders(),
     });
@@ -284,7 +284,7 @@ describe("V2 Claims", () => {
     expect(run.details.results).toHaveLength(3);
     expect(run.details.results.every((result) => result.passed)).toBe(true);
 
-    const getRes = await SELF.fetch(`http://localhost/api/v2/claims/${created.id}`, {
+    const getRes = await SELF.fetch(`http://localhost/api/v1/claims/${created.id}`, {
       headers: authHeaders(),
     });
     const verified = await getRes.json<Claim>();
@@ -307,7 +307,7 @@ describe("V2 Claims", () => {
     });
     const created = await res.json<Claim>();
 
-    const verifyRes = await SELF.fetch(`http://localhost/api/v2/claims/${created.id}/verify`, {
+    const verifyRes = await SELF.fetch(`http://localhost/api/v1/claims/${created.id}/verify`, {
       method: "POST",
       headers: authHeaders(),
     });

--- a/packages/api/test/v2-conversations.skip.ts
+++ b/packages/api/test/v2-conversations.skip.ts
@@ -47,7 +47,7 @@ interface ListResponse<T> {
 // ---------------------------------------------------------------------------
 
 async function createConversationV2(body: Record<string, unknown> = {}) {
-  const res = await SELF.fetch("http://localhost/api/v2/conversations", {
+  const res = await SELF.fetch("http://localhost/api/v1/conversations", {
     method: "POST",
     headers: authHeaders(),
     body: JSON.stringify(body),
@@ -69,7 +69,7 @@ describe("V2 Conversations", () => {
   // POST / — Create conversation
   // -------------------------------------------------------------------------
 
-  describe("POST /api/v2/conversations", () => {
+  describe("POST /api/v1/conversations", () => {
     it("creates a minimal conversation without messages", async () => {
       const res = await createConversationV2({});
       expect(res.status).toBe(201);
@@ -103,7 +103,7 @@ describe("V2 Conversations", () => {
     });
 
     it("returns 401 without auth", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/conversations", {
+      const res = await SELF.fetch("http://localhost/api/v1/conversations", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),
@@ -122,9 +122,9 @@ describe("V2 Conversations", () => {
   // GET / — List conversations
   // -------------------------------------------------------------------------
 
-  describe("GET /api/v2/conversations", () => {
+  describe("GET /api/v1/conversations", () => {
     it("lists conversations for the project", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/conversations", {
+      const res = await SELF.fetch("http://localhost/api/v1/conversations", {
         headers: authHeaders(),
       });
       expect(res.status).toBe(200);
@@ -138,7 +138,7 @@ describe("V2 Conversations", () => {
     });
 
     it("returns 400 for negative cursor", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/conversations?cursor=-1234567890", {
+      const res = await SELF.fetch("http://localhost/api/v1/conversations?cursor=-1234567890", {
         headers: authHeaders(),
       });
       expect(res.status).toBe(400);
@@ -148,7 +148,7 @@ describe("V2 Conversations", () => {
     });
 
     it("returns 400 for non-numeric cursor", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/conversations?cursor=not-a-number", {
+      const res = await SELF.fetch("http://localhost/api/v1/conversations?cursor=not-a-number", {
         headers: authHeaders(),
       });
       expect(res.status).toBe(400);
@@ -158,7 +158,7 @@ describe("V2 Conversations", () => {
     });
 
     it("returns 400 for Infinity cursor", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/conversations?cursor=Infinity", {
+      const res = await SELF.fetch("http://localhost/api/v1/conversations?cursor=Infinity", {
         headers: authHeaders(),
       });
       expect(res.status).toBe(400);
@@ -169,7 +169,7 @@ describe("V2 Conversations", () => {
 
     it("returns 400 for cursor exceeding MAX_SAFE_INTEGER", async () => {
       const res = await SELF.fetch(
-        `http://localhost/api/v2/conversations?cursor=${Number.MAX_SAFE_INTEGER + 1}`,
+        `http://localhost/api/v1/conversations?cursor=${Number.MAX_SAFE_INTEGER + 1}`,
         {
           headers: authHeaders(),
         },
@@ -181,12 +181,12 @@ describe("V2 Conversations", () => {
     });
 
     it("returns 401 without auth", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/conversations");
+      const res = await SELF.fetch("http://localhost/api/v1/conversations");
       expect(res.status).toBe(401);
     });
 
     it("does NOT have deprecation headers", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/conversations", {
+      const res = await SELF.fetch("http://localhost/api/v1/conversations", {
         headers: authHeaders(),
       });
       expect(res.headers.get("X-API-Deprecation")).toBeNull();
@@ -198,7 +198,7 @@ describe("V2 Conversations", () => {
   // GET /:id — Get conversation
   // -------------------------------------------------------------------------
 
-  describe("GET /api/v2/conversations/:id", () => {
+  describe("GET /api/v1/conversations/:id", () => {
     it("returns conversation without messages by default", async () => {
       const createRes = await createConversationV2({
         title: "Test Convo",
@@ -206,7 +206,7 @@ describe("V2 Conversations", () => {
       });
       const created = await createRes.json<Conversation>();
 
-      const res = await SELF.fetch(`http://localhost/api/v2/conversations/${created.id}`, {
+      const res = await SELF.fetch(`http://localhost/api/v1/conversations/${created.id}`, {
         headers: authHeaders(),
       });
       expect(res.status).toBe(200);
@@ -226,7 +226,7 @@ describe("V2 Conversations", () => {
       const created = await createRes.json<Conversation>();
 
       const res = await SELF.fetch(
-        `http://localhost/api/v2/conversations/${created.id}?include=messages`,
+        `http://localhost/api/v1/conversations/${created.id}?include=messages`,
         { headers: authHeaders() },
       );
       expect(res.status).toBe(200);
@@ -239,7 +239,7 @@ describe("V2 Conversations", () => {
     });
 
     it("returns 404 for a non-existent conversation", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/conversations/does_not_exist_id", {
+      const res = await SELF.fetch("http://localhost/api/v1/conversations/does_not_exist_id", {
         headers: authHeaders(),
       });
       expect(res.status).toBe(404);
@@ -249,7 +249,7 @@ describe("V2 Conversations", () => {
     });
 
     it("returns 401 without auth", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/conversations/any_id");
+      const res = await SELF.fetch("http://localhost/api/v1/conversations/any_id");
       expect(res.status).toBe(401);
     });
   });
@@ -258,12 +258,12 @@ describe("V2 Conversations", () => {
   // PATCH /:id — Update conversation (V2 uses PATCH instead of PUT)
   // -------------------------------------------------------------------------
 
-  describe("PATCH /api/v2/conversations/:id", () => {
+  describe("PATCH /api/v1/conversations/:id", () => {
     it("updates the title", async () => {
       const createRes = await createConversationV2({ title: "Original Title" });
       const created = await createRes.json<Conversation>();
 
-      const res = await SELF.fetch(`http://localhost/api/v2/conversations/${created.id}`, {
+      const res = await SELF.fetch(`http://localhost/api/v1/conversations/${created.id}`, {
         method: "PATCH",
         headers: authHeaders(),
         body: JSON.stringify({ title: "Updated Title" }),
@@ -278,7 +278,7 @@ describe("V2 Conversations", () => {
       const createRes = await createConversationV2({ metadata: { foo: "bar" } });
       const created = await createRes.json<Conversation>();
 
-      const res = await SELF.fetch(`http://localhost/api/v2/conversations/${created.id}`, {
+      const res = await SELF.fetch(`http://localhost/api/v1/conversations/${created.id}`, {
         method: "PATCH",
         headers: authHeaders(),
         body: JSON.stringify({ metadata: { foo: "baz", extra: true } }),
@@ -290,7 +290,7 @@ describe("V2 Conversations", () => {
     });
 
     it("returns 404 for a non-existent conversation", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/conversations/nonexistent_id", {
+      const res = await SELF.fetch("http://localhost/api/v1/conversations/nonexistent_id", {
         method: "PATCH",
         headers: authHeaders(),
         body: JSON.stringify({ title: "Doesn't Matter" }),
@@ -299,7 +299,7 @@ describe("V2 Conversations", () => {
     });
 
     it("returns 401 without auth", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/conversations/any_id", {
+      const res = await SELF.fetch("http://localhost/api/v1/conversations/any_id", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ title: "x" }),
@@ -312,14 +312,14 @@ describe("V2 Conversations", () => {
   // DELETE /:id — Delete conversation
   // -------------------------------------------------------------------------
 
-  describe("DELETE /api/v2/conversations/:id", () => {
+  describe("DELETE /api/v1/conversations/:id", () => {
     it("deletes a conversation and returns 204", async () => {
       const createRes = await createConversationV2({
         messages: [{ role: "user", content: "Delete me" }],
       });
       const created = await createRes.json<Conversation>();
 
-      const deleteRes = await SELF.fetch(`http://localhost/api/v2/conversations/${created.id}`, {
+      const deleteRes = await SELF.fetch(`http://localhost/api/v1/conversations/${created.id}`, {
         method: "DELETE",
         headers: authHeaders(),
       });
@@ -327,7 +327,7 @@ describe("V2 Conversations", () => {
     });
 
     it("returns 404 for a non-existent conversation", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/conversations/nonexistent_id", {
+      const res = await SELF.fetch("http://localhost/api/v1/conversations/nonexistent_id", {
         method: "DELETE",
         headers: authHeaders(),
       });
@@ -339,13 +339,13 @@ describe("V2 Conversations", () => {
   // POST /:id/messages — Append messages (V2 returns 204)
   // -------------------------------------------------------------------------
 
-  describe("POST /api/v2/conversations/:id/messages", () => {
+  describe("POST /api/v1/conversations/:id/messages", () => {
     it("appends messages and returns 204", async () => {
       const createRes = await createConversationV2({});
       const created = await createRes.json<Conversation>();
 
       const appendRes = await SELF.fetch(
-        `http://localhost/api/v2/conversations/${created.id}/messages`,
+        `http://localhost/api/v1/conversations/${created.id}/messages`,
         {
           method: "POST",
           headers: authHeaders(),
@@ -358,7 +358,7 @@ describe("V2 Conversations", () => {
       expect(appendRes.status).toBe(204);
 
       // Verify message_count updated on the conversation
-      const convRes = await SELF.fetch(`http://localhost/api/v2/conversations/${created.id}`, {
+      const convRes = await SELF.fetch(`http://localhost/api/v1/conversations/${created.id}`, {
         headers: authHeaders(),
       });
       const conv = await convRes.json<Conversation>();
@@ -368,7 +368,7 @@ describe("V2 Conversations", () => {
 
     it("returns 404 for a non-existent conversation", async () => {
       const res = await SELF.fetch(
-        "http://localhost/api/v2/conversations/nonexistent_id/messages",
+        "http://localhost/api/v1/conversations/nonexistent_id/messages",
         {
           method: "POST",
           headers: authHeaders(),
@@ -382,7 +382,7 @@ describe("V2 Conversations", () => {
       const createRes = await createConversationV2({});
       const created = await createRes.json<Conversation>();
 
-      const res = await SELF.fetch(`http://localhost/api/v2/conversations/${created.id}/messages`, {
+      const res = await SELF.fetch(`http://localhost/api/v1/conversations/${created.id}/messages`, {
         method: "POST",
         headers: authHeaders(),
         body: JSON.stringify({ messages: [] }),
@@ -395,7 +395,7 @@ describe("V2 Conversations", () => {
   // GET /by-external-id/:eid — Lookup by external ID (V2: no messages by default)
   // -------------------------------------------------------------------------
 
-  describe("GET /api/v2/conversations/by-external-id/:eid", () => {
+  describe("GET /api/v1/conversations/by-external-id/:eid", () => {
     it("returns the conversation without messages when found by external_id", async () => {
       const eid = `lookup-ext-${Date.now()}`;
       const createRes = await createConversationV2({
@@ -405,7 +405,7 @@ describe("V2 Conversations", () => {
       });
       expect(createRes.status).toBe(201);
 
-      const res = await SELF.fetch(`http://localhost/api/v2/conversations/by-external-id/${eid}`, {
+      const res = await SELF.fetch(`http://localhost/api/v1/conversations/by-external-id/${eid}`, {
         headers: authHeaders(),
       });
       expect(res.status).toBe(200);
@@ -419,7 +419,7 @@ describe("V2 Conversations", () => {
 
     it("returns 404 when no conversation matches the external_id", async () => {
       const res = await SELF.fetch(
-        "http://localhost/api/v2/conversations/by-external-id/nonexistent-external-id",
+        "http://localhost/api/v1/conversations/by-external-id/nonexistent-external-id",
         { headers: authHeaders() },
       );
       expect(res.status).toBe(404);
@@ -429,7 +429,7 @@ describe("V2 Conversations", () => {
     });
 
     it("returns 401 without auth", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/conversations/by-external-id/any-id");
+      const res = await SELF.fetch("http://localhost/api/v1/conversations/by-external-id/any-id");
       expect(res.status).toBe(401);
     });
   });
@@ -485,7 +485,7 @@ describe("V2 Conversations", () => {
       const created = await createRes.json<Conversation>();
 
       const res = await SELF.fetch(
-        `http://localhost/api/v2/conversations/${created.id}?include=messages`,
+        `http://localhost/api/v1/conversations/${created.id}?include=messages`,
         { headers: authHeaders() },
       );
       const body = await res.json<ConversationWithMessages>();
@@ -512,7 +512,7 @@ describe("V2 Conversations", () => {
       expect(created.total_tokens).toBe(10);
 
       // Append more messages with cost
-      await SELF.fetch(`http://localhost/api/v2/conversations/${created.id}/messages`, {
+      await SELF.fetch(`http://localhost/api/v1/conversations/${created.id}/messages`, {
         method: "POST",
         headers: authHeaders(),
         body: JSON.stringify({
@@ -530,7 +530,7 @@ describe("V2 Conversations", () => {
 
       // Verify aggregates incremented
       const convRes = await SELF.fetch(
-        `http://localhost/api/v2/conversations/${created.id}`,
+        `http://localhost/api/v1/conversations/${created.id}`,
         { headers: authHeaders() },
       );
       const conv = await convRes.json<Conversation>();
@@ -554,29 +554,29 @@ describe("V2 Conversations", () => {
   // V1 deprecation headers
   // -------------------------------------------------------------------------
 
-  describe("V1 Deprecation Headers", () => {
-    it("adds deprecation headers to V1 conversations endpoints", async () => {
+  describe("Unified API — No Deprecation Headers", () => {
+    it("does NOT add deprecation headers to v1 conversations endpoints", async () => {
       const res = await SELF.fetch("http://localhost/v1/conversations", {
         headers: authHeaders(),
       });
-      expect(res.headers.get("X-API-Deprecation")).toContain("deprecated");
-      expect(res.headers.get("Sunset")).toBe("2026-12-31");
-      expect(res.headers.get("Link")).toContain("deprecation");
+      expect(res.headers.get("X-API-Deprecation")).toBeNull();
+      expect(res.headers.get("Sunset")).toBeNull();
+      expect(res.headers.get("Link")).toBeNull();
     });
 
-    it("adds deprecation headers to V1 tags endpoints", async () => {
+    it("does NOT add deprecation headers to v1 tags endpoints", async () => {
       const res = await SELF.fetch("http://localhost/v1/tags", {
         headers: authHeaders(),
       });
-      expect(res.headers.get("X-API-Deprecation")).toContain("deprecated");
-      expect(res.headers.get("Sunset")).toBe("2026-12-31");
+      expect(res.headers.get("X-API-Deprecation")).toBeNull();
+      expect(res.headers.get("Sunset")).toBeNull();
     });
 
-    it("adds deprecation headers to V1 analytics endpoints", async () => {
+    it("does NOT add deprecation headers to v1 analytics endpoints", async () => {
       const res = await SELF.fetch("http://localhost/v1/projects/test-project/summary", {
         headers: authHeaders(),
       });
-      expect(res.headers.get("X-API-Deprecation")).toContain("deprecated");
+      expect(res.headers.get("X-API-Deprecation")).toBeNull();
     });
   });
 });

--- a/packages/api/test/v2-keys.skip.ts
+++ b/packages/api/test/v2-keys.skip.ts
@@ -26,7 +26,7 @@ interface ListResponse<T> {
 // ---------------------------------------------------------------------------
 
 async function createKeyV2(body: Record<string, unknown> = {}) {
-  const res = await SELF.fetch("http://localhost/api/v2/keys", {
+  const res = await SELF.fetch("http://localhost/api/v1/keys", {
     method: "POST",
     headers: authHeaders(),
     body: JSON.stringify(body),
@@ -35,14 +35,14 @@ async function createKeyV2(body: Record<string, unknown> = {}) {
 }
 
 async function listKeysV2() {
-  const res = await SELF.fetch("http://localhost/api/v2/keys", {
+  const res = await SELF.fetch("http://localhost/api/v1/keys", {
     headers: authHeaders(),
   });
   return res;
 }
 
 async function revokeKeyV2(keyId: string) {
-  const res = await SELF.fetch(`http://localhost/api/v2/keys/${keyId}`, {
+  const res = await SELF.fetch(`http://localhost/api/v1/keys/${keyId}`, {
     method: "DELETE",
     headers: authHeaders(),
   });
@@ -63,7 +63,7 @@ describe("V2 Keys", () => {
   // POST / — Create API key
   // -------------------------------------------------------------------------
 
-  describe("POST /api/v2/keys", () => {
+  describe("POST /api/v1/keys", () => {
     it("creates a new API key", async () => {
       const res = await createKeyV2({ name: "Test Key" });
       expect(res.status).toBe(201);
@@ -107,7 +107,7 @@ describe("V2 Keys", () => {
     });
 
     it("returns 401 without auth", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/keys", {
+      const res = await SELF.fetch("http://localhost/api/v1/keys", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name: "x" }),
@@ -126,7 +126,7 @@ describe("V2 Keys", () => {
   // GET / — List API keys
   // -------------------------------------------------------------------------
 
-  describe("GET /api/v2/keys", () => {
+  describe("GET /api/v1/keys", () => {
     it("lists all API keys for the project", async () => {
       // Create a test key first
       await createKeyV2({ name: "List Test Key" });
@@ -150,7 +150,7 @@ describe("V2 Keys", () => {
     });
 
     it("returns 401 without auth", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/keys");
+      const res = await SELF.fetch("http://localhost/api/v1/keys");
       expect(res.status).toBe(401);
     });
 
@@ -165,7 +165,7 @@ describe("V2 Keys", () => {
   // DELETE /:id — Revoke API key
   // -------------------------------------------------------------------------
 
-  describe("DELETE /api/v2/keys/:id", () => {
+  describe("DELETE /api/v1/keys/:id", () => {
     it("revokes an API key", async () => {
       // Create a key to revoke
       const createRes = await createKeyV2({ name: "Revoke Me" });
@@ -185,7 +185,7 @@ describe("V2 Keys", () => {
     });
 
     it("returns 401 without auth", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/keys/any_id", {
+      const res = await SELF.fetch("http://localhost/api/v1/keys/any_id", {
         method: "DELETE",
       });
       expect(res.status).toBe(401);
@@ -196,14 +196,14 @@ describe("V2 Keys", () => {
   // V1 deprecation headers
   // -------------------------------------------------------------------------
 
-  describe("V1 Deprecation Headers", () => {
-    it("adds deprecation headers to V1 keys endpoints", async () => {
+  describe("Unified API — No Deprecation Headers", () => {
+    it("does NOT add deprecation headers to v1 keys endpoints", async () => {
       const res = await SELF.fetch(`http://localhost/api/projects/${TEST_PROJECT_ID}/keys`, {
         headers: authHeaders(),
       });
-      expect(res.headers.get("X-API-Deprecation")).toContain("deprecated");
-      expect(res.headers.get("Sunset")).toBe("2026-12-31");
-      expect(res.headers.get("Link")).toContain("deprecation");
+      expect(res.headers.get("X-API-Deprecation")).toBeNull();
+      expect(res.headers.get("Sunset")).toBeNull();
+      expect(res.headers.get("Link")).toBeNull();
     });
   });
 });

--- a/packages/api/test/v2-projects.skip.ts
+++ b/packages/api/test/v2-projects.skip.ts
@@ -45,7 +45,7 @@ interface ListResponse<T> {
 // ---------------------------------------------------------------------------
 
 async function createProjectV2(body: Record<string, unknown> = {}) {
-  const res = await SELF.fetch("http://localhost/api/v2/projects", {
+  const res = await SELF.fetch("http://localhost/api/v1/projects", {
     method: "POST",
     headers: authHeaders(),
     body: JSON.stringify(body),
@@ -67,7 +67,7 @@ describe("V2 Projects", () => {
   // POST / — Create project
   // -------------------------------------------------------------------------
 
-  describe("POST /api/v2/projects", () => {
+  describe("POST /api/v1/projects", () => {
     it("creates a project with default values", async () => {
       const res = await createProjectV2({
         name: "Test Project",
@@ -144,9 +144,9 @@ describe("V2 Projects", () => {
   // GET / — List projects
   // -------------------------------------------------------------------------
 
-  describe("GET /api/v2/projects", () => {
+  describe("GET /api/v1/projects", () => {
     it("lists projects for default org", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/projects", {
+      const res = await SELF.fetch("http://localhost/api/v1/projects", {
         headers: authHeaders(),
       });
       expect(res.status).toBe(200);
@@ -165,7 +165,7 @@ describe("V2 Projects", () => {
     });
 
     it("filters by org_id", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/projects?org_id=default", {
+      const res = await SELF.fetch("http://localhost/api/v1/projects?org_id=default", {
         headers: authHeaders(),
       });
       expect(res.status).toBe(200);
@@ -175,7 +175,7 @@ describe("V2 Projects", () => {
     });
 
     it("returns 400 for negative cursor", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/projects?cursor=-1234567890", {
+      const res = await SELF.fetch("http://localhost/api/v1/projects?cursor=-1234567890", {
         headers: authHeaders(),
       });
       expect(res.status).toBe(400);
@@ -185,7 +185,7 @@ describe("V2 Projects", () => {
     });
 
     it("returns 400 for non-numeric cursor", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/projects?cursor=not-a-number", {
+      const res = await SELF.fetch("http://localhost/api/v1/projects?cursor=not-a-number", {
         headers: authHeaders(),
       });
       expect(res.status).toBe(400);
@@ -195,7 +195,7 @@ describe("V2 Projects", () => {
     });
 
     it("respects limit parameter", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/projects?limit=5", {
+      const res = await SELF.fetch("http://localhost/api/v1/projects?limit=5", {
         headers: authHeaders(),
       });
       expect(res.status).toBe(200);
@@ -205,7 +205,7 @@ describe("V2 Projects", () => {
     });
 
     it("does NOT have deprecation headers", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/projects", {
+      const res = await SELF.fetch("http://localhost/api/v1/projects", {
         headers: authHeaders(),
       });
       expect(res.headers.get("X-API-Deprecation")).toBeNull();
@@ -217,9 +217,9 @@ describe("V2 Projects", () => {
   // GET /:id — Get project by ID
   // -------------------------------------------------------------------------
 
-  describe("GET /api/v2/projects/:id", () => {
+  describe("GET /api/v1/projects/:id", () => {
     it("returns project with API keys", async () => {
-      const res = await SELF.fetch(`http://localhost/api/v2/projects/${TEST_PROJECT_ID}`, {
+      const res = await SELF.fetch(`http://localhost/api/v1/projects/${TEST_PROJECT_ID}`, {
         headers: authHeaders(),
       });
       expect(res.status).toBe(200);
@@ -231,7 +231,7 @@ describe("V2 Projects", () => {
     });
 
     it("returns 404 for non-existent project", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/projects/does_not_exist_id", {
+      const res = await SELF.fetch("http://localhost/api/v1/projects/does_not_exist_id", {
         headers: authHeaders(),
       });
       expect(res.status).toBe(404);
@@ -241,7 +241,7 @@ describe("V2 Projects", () => {
     });
 
     it("V2: uses project_id instead of id", async () => {
-      const res = await SELF.fetch(`http://localhost/api/v2/projects/${TEST_PROJECT_ID}`, {
+      const res = await SELF.fetch(`http://localhost/api/v1/projects/${TEST_PROJECT_ID}`, {
         headers: authHeaders(),
       });
       expect(res.status).toBe(200);
@@ -256,7 +256,7 @@ describe("V2 Projects", () => {
   // PATCH /:id — Update project
   // -------------------------------------------------------------------------
 
-  describe("PATCH /api/v2/projects/:id", () => {
+  describe("PATCH /api/v1/projects/:id", () => {
     it("updates project name", async () => {
       const createRes = await createProjectV2({
         name: "Original Name",
@@ -265,7 +265,7 @@ describe("V2 Projects", () => {
       const created = await createRes.json<CreateProjectResponse>();
 
       const res = await SELF.fetch(
-        `http://localhost/api/v2/projects/${created.project.project_id}`,
+        `http://localhost/api/v1/projects/${created.project.project_id}`,
         {
           method: "PATCH",
           headers: authHeaders(),
@@ -281,7 +281,7 @@ describe("V2 Projects", () => {
     });
 
     it("returns 404 for non-existent project", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/projects/nonexistent_id", {
+      const res = await SELF.fetch("http://localhost/api/v1/projects/nonexistent_id", {
         method: "PATCH",
         headers: authHeaders(),
         body: JSON.stringify({ name: "New Name" }),
@@ -297,7 +297,7 @@ describe("V2 Projects", () => {
       const created = await createRes.json<CreateProjectResponse>();
 
       const res = await SELF.fetch(
-        `http://localhost/api/v2/projects/${created.project.project_id}`,
+        `http://localhost/api/v1/projects/${created.project.project_id}`,
         {
           method: "PATCH",
           headers: authHeaders(),
@@ -312,7 +312,7 @@ describe("V2 Projects", () => {
   // DELETE /:id — Delete project
   // -------------------------------------------------------------------------
 
-  describe("DELETE /api/v2/projects/:id", () => {
+  describe("DELETE /api/v1/projects/:id", () => {
     it("deletes project and returns 204", async () => {
       const createRes = await createProjectV2({
         name: "Delete Me",
@@ -321,7 +321,7 @@ describe("V2 Projects", () => {
       const created = await createRes.json<CreateProjectResponse>();
 
       const deleteRes = await SELF.fetch(
-        `http://localhost/api/v2/projects/${created.project.project_id}`,
+        `http://localhost/api/v1/projects/${created.project.project_id}`,
         {
           method: "DELETE",
           headers: authHeaders(),
@@ -331,7 +331,7 @@ describe("V2 Projects", () => {
 
       // Verify deletion
       const getRes = await SELF.fetch(
-        `http://localhost/api/v2/projects/${created.project.project_id}`,
+        `http://localhost/api/v1/projects/${created.project.project_id}`,
         {
           headers: authHeaders(),
         },
@@ -340,7 +340,7 @@ describe("V2 Projects", () => {
     });
 
     it("returns 404 for non-existent project", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/projects/nonexistent_id", {
+      const res = await SELF.fetch("http://localhost/api/v1/projects/nonexistent_id", {
         method: "DELETE",
         headers: authHeaders(),
       });
@@ -352,7 +352,7 @@ describe("V2 Projects", () => {
   // POST /:id/keys — Create API key
   // -------------------------------------------------------------------------
 
-  describe("POST /api/v2/projects/:id/keys", () => {
+  describe("POST /api/v1/projects/:id/keys", () => {
     it("creates a new API key", async () => {
       const createRes = await createProjectV2({
         name: "Key Test",
@@ -361,7 +361,7 @@ describe("V2 Projects", () => {
       const created = await createRes.json<CreateProjectResponse>();
 
       const res = await SELF.fetch(
-        `http://localhost/api/v2/projects/${created.project.project_id}/keys`,
+        `http://localhost/api/v1/projects/${created.project.project_id}/keys`,
         {
           method: "POST",
           headers: authHeaders(),
@@ -377,7 +377,7 @@ describe("V2 Projects", () => {
     });
 
     it("returns 404 for non-existent project", async () => {
-      const res = await SELF.fetch("http://localhost/api/v2/projects/nonexistent_id/keys", {
+      const res = await SELF.fetch("http://localhost/api/v1/projects/nonexistent_id/keys", {
         method: "POST",
         headers: authHeaders(),
         body: JSON.stringify({ name: "Test Key" }),
@@ -393,7 +393,7 @@ describe("V2 Projects", () => {
       const created = await createRes.json<CreateProjectResponse>();
 
       const res = await SELF.fetch(
-        `http://localhost/api/v2/projects/${created.project.project_id}/keys`,
+        `http://localhost/api/v1/projects/${created.project.project_id}/keys`,
         {
           method: "POST",
           headers: authHeaders(),
@@ -408,7 +408,7 @@ describe("V2 Projects", () => {
   // DELETE /:id/keys/:keyId — Revoke API key
   // -------------------------------------------------------------------------
 
-  describe("DELETE /api/v2/projects/:id/keys/:keyId", () => {
+  describe("DELETE /api/v1/projects/:id/keys/:keyId", () => {
     it("revokes an API key", async () => {
       const createRes = await createProjectV2({
         name: "Revoke Test",
@@ -418,7 +418,7 @@ describe("V2 Projects", () => {
       const keyId = created.api_key.id;
 
       const deleteRes = await SELF.fetch(
-        `http://localhost/api/v2/projects/${created.project.project_id}/keys/${keyId}`,
+        `http://localhost/api/v1/projects/${created.project.project_id}/keys/${keyId}`,
         {
           method: "DELETE",
           headers: authHeaders(),
@@ -429,17 +429,16 @@ describe("V2 Projects", () => {
   });
 
   // -------------------------------------------------------------------------
-  // V1 deprecation headers
+  // No deprecation headers (unified v1 API)
   // -------------------------------------------------------------------------
 
-  describe("V1 Deprecation Headers", () => {
-    it("adds deprecation headers to V1 projects endpoints", async () => {
+  describe("Unified API — No Deprecation Headers", () => {
+    it("does NOT add deprecation headers to v1 projects endpoints", async () => {
       const res = await SELF.fetch("http://localhost/api/v1/projects", {
         headers: authHeaders(),
       });
-      expect(res.headers.get("X-API-Deprecation")).toContain("deprecated");
-      expect(res.headers.get("Sunset")).toBe("2026-12-31");
-      expect(res.headers.get("Link")).toContain("deprecation");
+      expect(res.headers.get("X-API-Deprecation")).toBeNull();
+      expect(res.headers.get("Sunset")).toBeNull();
     });
   });
 });

--- a/packages/dashboard/src/app/_api-endpoints.tsx
+++ b/packages/dashboard/src/app/_api-endpoints.tsx
@@ -5,13 +5,13 @@ import { Button } from "@/components/ui/button";
 import { Section } from "./_section";
 
 const ENDPOINTS: [method: string, path: string, desc: string][] = [
-  ["POST", "/api/v2/conversations", "Create conversation or state"],
-  ["GET", "/api/v2/conversations", "List with total count"],
-  ["GET", "/api/v2/conversations/:id", "Get, include=messages"],
-  ["POST", "/api/v2/conversations/:id/messages", "Append messages"],
-  ["POST", "/api/v2/conversations/:id/generate-title", "AI title"],
-  ["GET", "/api/v2/analytics/summary", "Usage summary"],
-  ["GET", "/api/v2/conversations/search", "Full-text search"],
+  ["POST", "/api/v1/conversations", "Create conversation or state"],
+  ["GET", "/api/v1/conversations", "List with total count"],
+  ["GET", "/api/v1/conversations/:id", "Get, include=messages"],
+  ["POST", "/api/v1/conversations/:id/messages", "Append messages"],
+  ["POST", "/api/v1/conversations/:id/generate-title", "AI title"],
+  ["GET", "/api/v1/analytics/summary", "Usage summary"],
+  ["GET", "/api/v1/conversations/search", "Full-text search"],
 ];
 
 export function ApiSurface() {

--- a/packages/dashboard/src/app/brand/page.tsx
+++ b/packages/dashboard/src/app/brand/page.tsx
@@ -116,7 +116,7 @@ export default function BrandPage() {
               <div className="rounded-[9px] border border-border bg-card p-[22px]">
                 <span className="as-label">Mono · JetBrains Mono</span>
                 <div className="mt-3 font-mono text-[18px] text-foreground">
-                  POST /api/v2/conversations
+                  POST /api/v1/conversations
                 </div>
                 <div className="mt-2 font-mono text-[14px] text-muted-foreground">
                   as_live_3DqrVIvIfxttEkYiAz1V

--- a/packages/dashboard/src/app/dashboard/integrate/page.tsx
+++ b/packages/dashboard/src/app/dashboard/integrate/page.tsx
@@ -89,13 +89,13 @@ const res = await ai.chat.completions.create({
 });
 await state.appendMessages(id, [res.choices[0].message]);`,
   rest: `# create a conversation
-curl -X POST https://agentstate.app/api/v2/conversations \\
+curl -X POST https://agentstate.app/api/v1/conversations \\
   -H "Authorization: Bearer as_live_..." \\
   -H "Content-Type: application/json" \\
   -d '{"messages":[{"role":"user","content":"Hi"}]}'
 
 # retrieve it later
-curl https://agentstate.app/api/v2/conversations/:id \\
+curl https://agentstate.app/api/v1/conversations/:id \\
   -H "Authorization: Bearer as_live_..."`,
 };
 

--- a/packages/dashboard/src/app/dashboard/layout.tsx
+++ b/packages/dashboard/src/app/dashboard/layout.tsx
@@ -1,14 +1,27 @@
 "use client";
 
-import { SignIn, useAuth } from "@clerk/react";
+import { SignIn, useAuth, useClerk, useUser } from "@clerk/react";
+import { ChevronsUpDown, LogOut, Settings, UserIcon } from "lucide-react";
+import Link from "next/link";
 import { AppSidebar } from "@/components/app-sidebar";
 import { Pill } from "@/components/brand/bits";
+import { ThemeToggle } from "@/components/theme-toggle";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 
 const dashboardApiEndpoint = process.env.NEXT_PUBLIC_API_ENDPOINT || "agentstate.app/api";
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   const { isSignedIn, isLoaded } = useAuth();
+  const { user } = useUser();
+  const { signOut } = useClerk();
 
   // Loading state while Clerk initializes
   if (!isLoaded) {
@@ -28,21 +41,87 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     );
   }
 
+  const userInitial =
+    user?.firstName?.[0] || user?.emailAddresses?.[0]?.emailAddress?.[0]?.toUpperCase() || "U";
+  const displayName =
+    user?.firstName || user?.emailAddresses?.[0]?.emailAddress?.split("@")[0] || "Account";
+
   return (
-    <SidebarProvider className="bg-muted/35">
+    <SidebarProvider>
       <AppSidebar variant="inset" />
-      <SidebarInset className="bg-background/95">
-        <header className="sticky top-0 z-30 flex h-14 shrink-0 items-center justify-between gap-3 border-b border-border bg-card/85 px-4 backdrop-blur supports-[backdrop-filter]:bg-card/70 sm:px-6">
+      <SidebarInset className="bg-background">
+        {/* ── Topbar ─────────────────────────────────── */}
+        <header className="sticky top-0 z-30 flex h-13 shrink-0 items-center justify-between gap-3 border-b border-border/60 bg-background/80 backdrop-blur-lg px-4 sm:px-6">
+          {/* Left side: sidebar toggle + status pill */}
           <div className="flex items-center gap-2.5">
-            <SidebarTrigger className="text-muted-foreground" />
-            <Pill className="py-[3px]">
+            <SidebarTrigger className="-ml-1 text-muted-foreground hover:text-foreground" />
+            <div className="hidden h-4 w-px bg-border sm:block" />
+            <Pill className="hidden py-[3px] sm:inline-flex">
               <span className="size-2 rounded-full bg-brand" />
               Live
             </Pill>
           </div>
-          <code className="font-mono text-xs text-faint">{dashboardApiEndpoint}</code>
+
+          {/* Right side: endpoint badge + user menu */}
+          <div className="flex items-center gap-2">
+            <code className="hidden font-mono text-[11px] text-faint lg:block">
+              {dashboardApiEndpoint}
+            </code>
+
+            {/* ── User dropdown ─────────────────────── */}
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={
+                  <button
+                    type="button"
+                    className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm transition-colors hover:bg-accent"
+                  />
+                }
+              >
+                <div className="flex size-7 items-center justify-center rounded-full bg-brand-soft">
+                  <span className="text-[11px] font-semibold text-brand">{userInitial}</span>
+                </div>
+                <span className="hidden font-medium sm:inline">{displayName}</span>
+                <ChevronsUpDown className="size-3.5 text-muted-foreground" />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-56">
+                <DropdownMenuLabel>
+                  <div className="flex flex-col gap-0.5">
+                    <span className="text-sm font-medium">{user?.fullName || "Account"}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {user?.primaryEmailAddress?.emailAddress}
+                    </span>
+                  </div>
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem render={<Link href="/dashboard" />}>
+                  <UserIcon className="size-4" />
+                  Profile
+                </DropdownMenuItem>
+                <DropdownMenuItem render={<Link href="/dashboard/settings/organizations" />}>
+                  <Settings className="size-4" />
+                  Settings
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <div className="flex items-center justify-between px-2 py-1.5">
+                  <span className="text-sm">Theme</span>
+                  <ThemeToggle />
+                </div>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  className="text-destructive focus:text-destructive"
+                  onClick={() => signOut()}
+                >
+                  <LogOut className="size-4" />
+                  Sign out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </header>
-        <main className="flex-1 px-4 py-6 sm:px-6 lg:px-7">
+
+        {/* ── Main content ───────────────────────────── */}
+        <main className="flex-1 px-4 py-6 sm:px-6 lg:px-8">
           <div className="mx-auto w-full max-w-7xl">{children}</div>
         </main>
       </SidebarInset>

--- a/packages/dashboard/src/app/docs/_docs-data.ts
+++ b/packages/dashboard/src/app/docs/_docs-data.ts
@@ -44,7 +44,7 @@ const conv = await state.createConversation({
 });`;
 
 export const AUTH_CODE = `# every request carries a bearer key (starts with as_live_)
-curl https://agentstate.app/api/v2/conversations \\
+curl https://agentstate.app/api/v1/conversations \\
   -H "Authorization: Bearer as_live_your_key"`;
 
 export const ADAPTER_CODE = `import { AgentState } from "@agentstate/sdk";
@@ -57,15 +57,15 @@ const chatId = await store.createChat();
 await store.saveChat({ chatId, messages });`;
 
 export const CONVERSATION_ENDPOINTS: [method: string, path: string][] = [
-  ["POST", "/api/v2/conversations"],
-  ["GET", "/api/v2/conversations/:id"],
-  ["POST", "/api/v2/conversations/:id/messages"],
-  ["PATCH", "/api/v2/conversations/:id"],
-  ["DELETE", "/api/v2/conversations/:id"],
+  ["POST", "/api/v1/conversations"],
+  ["GET", "/api/v1/conversations/:id"],
+  ["POST", "/api/v1/conversations/:id/messages"],
+  ["PATCH", "/api/v1/conversations/:id"],
+  ["DELETE", "/api/v1/conversations/:id"],
 ];
 
 export const ANALYTICS_ENDPOINTS: [method: string, path: string][] = [
-  ["GET", "/api/v2/analytics/summary"],
-  ["GET", "/api/v2/analytics/timeseries"],
-  ["GET", "/api/v2/analytics/tags"],
+  ["GET", "/api/v1/analytics/summary"],
+  ["GET", "/api/v1/analytics/timeseries"],
+  ["GET", "/api/v1/analytics/tags"],
 ];

--- a/packages/dashboard/src/app/globals.css
+++ b/packages/dashboard/src/app/globals.css
@@ -98,7 +98,7 @@
   --chart-4: #71717a;
   --chart-5: #a1a1aa;
 
-  /* sidebar (surface white, hairline borders) */
+  /* sidebar — clean surface, subtle brand accent */
   --sidebar: #ffffff;
   --sidebar-foreground: #3f3f46;
   --sidebar-primary: #18181b;
@@ -146,13 +146,13 @@
   --chart-4: #a1a1aa;
   --chart-5: #71717a;
 
-  --sidebar: #0f0f10;
+  --sidebar: #0c0c0d;
   --sidebar-foreground: #d4d4d8;
   --sidebar-primary: #fafafa;
   --sidebar-primary-foreground: #18181b;
-  --sidebar-accent: #1c1c1f;
+  --sidebar-accent: #1a1a1d;
   --sidebar-accent-foreground: #fafafa;
-  --sidebar-border: #27272a;
+  --sidebar-border: #222225;
   --sidebar-ring: #e2664d;
 }
 

--- a/packages/dashboard/src/components/sidebar/_sidebar-footer-links.tsx
+++ b/packages/dashboard/src/components/sidebar/_sidebar-footer-links.tsx
@@ -11,7 +11,7 @@ export function SidebarFooterLinks() {
       <SidebarMenuItem>
         <Link href="/docs">
           <SidebarMenuButton
-            className="h-9 rounded-lg px-2.5 data-active:bg-sidebar-accent data-active:shadow-sm data-active:ring-1 data-active:ring-sidebar-border"
+            className="h-9 rounded-lg px-2.5 transition-colors data-active:bg-sidebar-accent"
             isActive={pathname.startsWith("/docs")}
             tooltip="Docs"
           >
@@ -23,7 +23,7 @@ export function SidebarFooterLinks() {
       <SidebarMenuItem>
         <Link href="/">
           <SidebarMenuButton
-            className="h-9 rounded-lg px-2.5 data-active:bg-sidebar-accent data-active:shadow-sm data-active:ring-1 data-active:ring-sidebar-border"
+            className="h-9 rounded-lg px-2.5 transition-colors data-active:bg-sidebar-accent"
             isActive={pathname === "/"}
             tooltip="Home"
           >

--- a/packages/dashboard/src/components/sidebar/_sidebar-nav.tsx
+++ b/packages/dashboard/src/components/sidebar/_sidebar-nav.tsx
@@ -45,7 +45,7 @@ export function SidebarNav({ isSignedIn }: SidebarNavProps) {
               <SidebarMenuItem key={item.href}>
                 <Link href={item.href}>
                   <SidebarMenuButton
-                    className={`h-9 rounded-lg px-2.5 ${isActive ? "bg-sidebar-accent text-sidebar-accent-foreground" : ""}`}
+                    className={`h-9 rounded-lg px-2.5 transition-colors ${isActive ? "bg-brand-soft text-brand font-medium" : "hover:bg-sidebar-accent"}`}
                     isActive={isActive}
                     tooltip={item.label}
                   >
@@ -68,7 +68,7 @@ export function SidebarNav({ isSignedIn }: SidebarNavProps) {
             <SidebarMenuItem>
               <Link href="/dashboard/settings/organizations">
                 <SidebarMenuButton
-                  className={`h-9 rounded-lg px-2.5 ${pathname.startsWith("/dashboard/settings/organizations") ? "bg-sidebar-accent text-sidebar-accent-foreground" : ""}`}
+                  className={`h-9 rounded-lg px-2.5 transition-colors ${pathname.startsWith("/dashboard/settings/organizations") ? "bg-brand-soft text-brand font-medium" : "hover:bg-sidebar-accent"}`}
                   isActive={pathname.startsWith("/dashboard/settings/organizations")}
                   tooltip="Organizations"
                 >

--- a/packages/dashboard/src/components/sidebar/_sidebar-user.tsx
+++ b/packages/dashboard/src/components/sidebar/_sidebar-user.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { SignInButton, UserButton, useAuth, useUser } from "@clerk/react";
-import { ThemeToggle } from "@/components/theme-toggle";
-import { Button } from "@/components/ui/button";
+import { SignInButton, useAuth, useUser } from "@clerk/react";
 
 export function SidebarUser() {
   const { isSignedIn, isLoaded } = useAuth();
@@ -10,11 +8,16 @@ export function SidebarUser() {
 
   if (!isLoaded) return null;
 
+  const initial =
+    user?.firstName?.[0] || user?.emailAddresses?.[0]?.emailAddress?.[0]?.toUpperCase() || "?";
+
   return (
-    <div className="flex items-center gap-2 px-2 py-1.5">
+    <div className="flex items-center gap-2.5 px-2 py-1.5">
       {isSignedIn ? (
         <>
-          <UserButton />
+          <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-brand-soft">
+            <span className="text-xs font-semibold text-brand">{initial}</span>
+          </div>
           <div className="flex-1 min-w-0 group-data-[collapsible=icon]:hidden">
             <p className="text-sm font-medium truncate leading-tight">
               {user?.fullName || "Account"}
@@ -23,21 +26,16 @@ export function SidebarUser() {
               {user?.primaryEmailAddress?.emailAddress || ""}
             </p>
           </div>
-          <div className="shrink-0 group-data-[collapsible=icon]:hidden">
-            <ThemeToggle size="h-4 w-4" />
-          </div>
         </>
       ) : (
-        <>
-          <SignInButton>
-            <Button size="sm" variant="outline" className="flex-1 text-xs">
-              Sign in
-            </Button>
-          </SignInButton>
-          <div className="shrink-0">
-            <ThemeToggle size="h-4 w-4" />
-          </div>
-        </>
+        <SignInButton>
+          <button
+            type="button"
+            className="flex h-8 w-full items-center justify-center rounded-lg border border-border text-xs font-medium transition-colors hover:bg-accent"
+          >
+            Sign in
+          </button>
+        </SignInButton>
       )}
     </div>
   );

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -61,7 +61,7 @@ console.log(saved.messages);
 
 ### State Platform
 
-These helpers target `/v2/states`:
+These helpers target `/v1/states`:
 
 - `upsertState(stateKey, data, options?)` — Create or replace state for a key
 - `getState(stateKey, params?)` — Read latest or historical state

--- a/packages/sdk/dist/ai-sdk.mjs
+++ b/packages/sdk/dist/ai-sdk.mjs
@@ -1,6 +1,6 @@
 import {
   AgentStateError
-} from "./chunk-5ODJIG7X.mjs";
+} from "./chunk-MKYN4MXF.mjs";
 
 // src/ai-sdk.ts
 function buildChatKey(prefix, chatId) {

--- a/packages/sdk/dist/index.js
+++ b/packages/sdk/dist/index.js
@@ -153,24 +153,24 @@ var AgentState = class {
   }
   // State records
   async upsertState(stateKey, data, options) {
-    return this.request(`/v2/states/${encodeURIComponent(stateKey)}`, {
+    return this.request(`/v1/states/${encodeURIComponent(stateKey)}`, {
       method: "PUT",
       headers: options?.idempotencyKey ? { "Idempotency-Key": options.idempotencyKey } : void 0,
       body: JSON.stringify(data)
     });
   }
   async getState(stateKey, params) {
-    return this.request(this.withQuery(`/v2/states/${encodeURIComponent(stateKey)}`, params));
+    return this.request(this.withQuery(`/v1/states/${encodeURIComponent(stateKey)}`, params));
   }
   async queryStates(query = {}) {
-    return this.request("/v2/states/query", {
+    return this.request("/v1/states/query", {
       method: "POST",
       body: JSON.stringify(query)
     });
   }
   async deleteState(stateKey, params) {
     return this.request(
-      this.withQuery(`/v2/states/${encodeURIComponent(stateKey)}`, {
+      this.withQuery(`/v1/states/${encodeURIComponent(stateKey)}`, {
         lease_id: params?.lease_id
       }),
       {
@@ -182,7 +182,7 @@ var AgentState = class {
   // State events and watch reads
   async listStateEvents(stateKey, params, options) {
     return this.request(
-      this.withQuery(`/v2/states/${encodeURIComponent(stateKey)}/events`, params),
+      this.withQuery(`/v1/states/${encodeURIComponent(stateKey)}/events`, params),
       {
         headers: options?.capabilityToken ? { Authorization: `Bearer ${options.capabilityToken}` } : void 0
       }
@@ -190,33 +190,33 @@ var AgentState = class {
   }
   // State leases
   async createStateLease(stateKey, data) {
-    return this.request(`/v2/states/${encodeURIComponent(stateKey)}/lease`, {
+    return this.request(`/v1/states/${encodeURIComponent(stateKey)}/lease`, {
       method: "POST",
       body: JSON.stringify(data)
     });
   }
   async renewStateLease(id, data = {}, options) {
-    return this.request(`/v2/leases/${encodeURIComponent(id)}/renew`, {
+    return this.request(`/v1/leases/${encodeURIComponent(id)}/renew`, {
       method: "POST",
       headers: options?.capabilityToken ? { Authorization: `Bearer ${options.capabilityToken}` } : void 0,
       body: JSON.stringify(data)
     });
   }
   async releaseStateLease(id, options) {
-    return this.request(`/v2/leases/${encodeURIComponent(id)}`, {
+    return this.request(`/v1/leases/${encodeURIComponent(id)}`, {
       method: "DELETE",
       headers: options?.capabilityToken ? { Authorization: `Bearer ${options.capabilityToken}` } : void 0
     });
   }
   // Capability tokens
   async createCapabilityToken(data) {
-    return this.request("/v2/capability-tokens", {
+    return this.request("/v1/capability-tokens", {
       method: "POST",
       body: JSON.stringify(data)
     });
   }
   async listCapabilityTokens() {
-    return this.request("/v2/capability-tokens");
+    return this.request("/v1/capability-tokens");
   }
   async revokeCapabilityToken(id) {
     return this.request(`/v2/capability-tokens/${encodeURIComponent(id)}`, {
@@ -225,19 +225,19 @@ var AgentState = class {
   }
   // Claims
   async createClaim(data) {
-    return this.request("/v2/claims", {
+    return this.request("/v1/claims", {
       method: "POST",
       body: JSON.stringify(data)
     });
   }
   async listClaims(params) {
-    return this.request(this.withQuery("/v2/claims", params));
+    return this.request(this.withQuery("/v1/claims", params));
   }
   async getClaim(id) {
-    return this.request(`/v2/claims/${encodeURIComponent(id)}`);
+    return this.request(`/v1/claims/${encodeURIComponent(id)}`);
   }
   async verifyClaim(id) {
-    return this.request(`/v2/claims/${encodeURIComponent(id)}/verify`, {
+    return this.request(`/v1/claims/${encodeURIComponent(id)}/verify`, {
       method: "POST"
     });
   }

--- a/packages/sdk/dist/index.mjs
+++ b/packages/sdk/dist/index.mjs
@@ -1,7 +1,7 @@
 import {
   AgentState,
   AgentStateError
-} from "./chunk-5ODJIG7X.mjs";
+} from "./chunk-MKYN4MXF.mjs";
 export {
   AgentState,
   AgentStateError

--- a/packages/sdk/dist/langgraph.mjs
+++ b/packages/sdk/dist/langgraph.mjs
@@ -1,6 +1,6 @@
 import {
   AgentStateError
-} from "./chunk-5ODJIG7X.mjs";
+} from "./chunk-MKYN4MXF.mjs";
 
 // src/langgraph.ts
 import {

--- a/packages/sdk/src/index.js
+++ b/packages/sdk/src/index.js
@@ -98,24 +98,24 @@ export class AgentState {
   }
   // State records
   async upsertState(stateKey, data, options) {
-    return this.request(`/v2/states/${encodeURIComponent(stateKey)}`, {
+    return this.request(`/v1/states/${encodeURIComponent(stateKey)}`, {
       method: "PUT",
       headers: options?.idempotencyKey ? { "Idempotency-Key": options.idempotencyKey } : undefined,
       body: JSON.stringify(data),
     });
   }
   async getState(stateKey, params) {
-    return this.request(this.withQuery(`/v2/states/${encodeURIComponent(stateKey)}`, params));
+    return this.request(this.withQuery(`/v1/states/${encodeURIComponent(stateKey)}`, params));
   }
   async queryStates(query = {}) {
-    return this.request("/v2/states/query", {
+    return this.request("/v1/states/query", {
       method: "POST",
       body: JSON.stringify(query),
     });
   }
   async deleteState(stateKey, params) {
     return this.request(
-      this.withQuery(`/v2/states/${encodeURIComponent(stateKey)}`, {
+      this.withQuery(`/v1/states/${encodeURIComponent(stateKey)}`, {
         lease_id: params?.lease_id,
       }),
       {
@@ -127,7 +127,7 @@ export class AgentState {
   // State events and watch reads
   async listStateEvents(stateKey, params, options) {
     return this.request(
-      this.withQuery(`/v2/states/${encodeURIComponent(stateKey)}/events`, params),
+      this.withQuery(`/v1/states/${encodeURIComponent(stateKey)}/events`, params),
       {
         headers: options?.capabilityToken
           ? { Authorization: `Bearer ${options.capabilityToken}` }
@@ -137,13 +137,13 @@ export class AgentState {
   }
   // State leases
   async createStateLease(stateKey, data) {
-    return this.request(`/v2/states/${encodeURIComponent(stateKey)}/lease`, {
+    return this.request(`/v1/states/${encodeURIComponent(stateKey)}/lease`, {
       method: "POST",
       body: JSON.stringify(data),
     });
   }
   async renewStateLease(id, data = {}, options) {
-    return this.request(`/v2/leases/${encodeURIComponent(id)}/renew`, {
+    return this.request(`/v1/leases/${encodeURIComponent(id)}/renew`, {
       method: "POST",
       headers: options?.capabilityToken
         ? { Authorization: `Bearer ${options.capabilityToken}` }
@@ -152,7 +152,7 @@ export class AgentState {
     });
   }
   async releaseStateLease(id, options) {
-    return this.request(`/v2/leases/${encodeURIComponent(id)}`, {
+    return this.request(`/v1/leases/${encodeURIComponent(id)}`, {
       method: "DELETE",
       headers: options?.capabilityToken
         ? { Authorization: `Bearer ${options.capabilityToken}` }
@@ -161,34 +161,34 @@ export class AgentState {
   }
   // Capability tokens
   async createCapabilityToken(data) {
-    return this.request("/v2/capability-tokens", {
+    return this.request("/v1/capability-tokens", {
       method: "POST",
       body: JSON.stringify(data),
     });
   }
   async listCapabilityTokens() {
-    return this.request("/v2/capability-tokens");
+    return this.request("/v1/capability-tokens");
   }
   async revokeCapabilityToken(id) {
-    return this.request(`/v2/capability-tokens/${encodeURIComponent(id)}`, {
+    return this.request(`/v1/capability-tokens/${encodeURIComponent(id)}`, {
       method: "DELETE",
     });
   }
   // Claims
   async createClaim(data) {
-    return this.request("/v2/claims", {
+    return this.request("/v1/claims", {
       method: "POST",
       body: JSON.stringify(data),
     });
   }
   async listClaims(params) {
-    return this.request(this.withQuery("/v2/claims", params));
+    return this.request(this.withQuery("/v1/claims", params));
   }
   async getClaim(id) {
-    return this.request(`/v2/claims/${encodeURIComponent(id)}`);
+    return this.request(`/v1/claims/${encodeURIComponent(id)}`);
   }
   async verifyClaim(id) {
-    return this.request(`/v2/claims/${encodeURIComponent(id)}/verify`, {
+    return this.request(`/v1/claims/${encodeURIComponent(id)}/verify`, {
       method: "POST",
     });
   }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -462,7 +462,7 @@ export class AgentState {
     data: UpsertStateRequest,
     options?: { idempotencyKey?: string },
   ): Promise<StateRecord> {
-    return this.request(`/v2/states/${encodeURIComponent(stateKey)}`, {
+    return this.request(`/v1/states/${encodeURIComponent(stateKey)}`, {
       method: "PUT",
       headers: options?.idempotencyKey ? { "Idempotency-Key": options.idempotencyKey } : undefined,
       body: JSON.stringify(data),
@@ -473,11 +473,11 @@ export class AgentState {
     stateKey: string,
     params?: { at_sequence?: number; at_time?: number },
   ): Promise<StateRecord> {
-    return this.request(this.withQuery(`/v2/states/${encodeURIComponent(stateKey)}`, params));
+    return this.request(this.withQuery(`/v1/states/${encodeURIComponent(stateKey)}`, params));
   }
 
   async queryStates(query: StateQueryRequest = {}): Promise<StateListResponse<StateRecord>> {
-    return this.request("/v2/states/query", {
+    return this.request("/v1/states/query", {
       method: "POST",
       body: JSON.stringify(query),
     });
@@ -488,7 +488,7 @@ export class AgentState {
     params?: DeleteStateRequest & { idempotencyKey?: string },
   ): Promise<{ deleted: true; event: StateEvent }> {
     return this.request(
-      this.withQuery(`/v2/states/${encodeURIComponent(stateKey)}`, {
+      this.withQuery(`/v1/states/${encodeURIComponent(stateKey)}`, {
         lease_id: params?.lease_id,
       }),
       {
@@ -505,7 +505,7 @@ export class AgentState {
     options?: { capabilityToken?: string },
   ): Promise<StateListResponse<StateEvent>> {
     return this.request(
-      this.withQuery(`/v2/states/${encodeURIComponent(stateKey)}/events`, params),
+      this.withQuery(`/v1/states/${encodeURIComponent(stateKey)}/events`, params),
       {
         headers: options?.capabilityToken
           ? { Authorization: `Bearer ${options.capabilityToken}` }
@@ -516,7 +516,7 @@ export class AgentState {
 
   // State leases
   async createStateLease(stateKey: string, data: CreateStateLeaseRequest): Promise<StateLease> {
-    return this.request(`/v2/states/${encodeURIComponent(stateKey)}/lease`, {
+    return this.request(`/v1/states/${encodeURIComponent(stateKey)}/lease`, {
       method: "POST",
       body: JSON.stringify(data),
     });
@@ -527,7 +527,7 @@ export class AgentState {
     data: RenewStateLeaseRequest = {},
     options?: { capabilityToken?: string },
   ): Promise<StateLease> {
-    return this.request(`/v2/leases/${encodeURIComponent(id)}/renew`, {
+    return this.request(`/v1/leases/${encodeURIComponent(id)}/renew`, {
       method: "POST",
       headers: options?.capabilityToken
         ? { Authorization: `Bearer ${options.capabilityToken}` }
@@ -537,7 +537,7 @@ export class AgentState {
   }
 
   async releaseStateLease(id: string, options?: { capabilityToken?: string }): Promise<void> {
-    return this.request(`/v2/leases/${encodeURIComponent(id)}`, {
+    return this.request(`/v1/leases/${encodeURIComponent(id)}`, {
       method: "DELETE",
       headers: options?.capabilityToken
         ? { Authorization: `Bearer ${options.capabilityToken}` }
@@ -547,40 +547,40 @@ export class AgentState {
 
   // Capability tokens
   async createCapabilityToken(data: CreateCapabilityTokenRequest): Promise<CapabilityTokenCreated> {
-    return this.request("/v2/capability-tokens", {
+    return this.request("/v1/capability-tokens", {
       method: "POST",
       body: JSON.stringify(data),
     });
   }
 
   async listCapabilityTokens(): Promise<CapabilityTokenListResponse> {
-    return this.request("/v2/capability-tokens");
+    return this.request("/v1/capability-tokens");
   }
 
   async revokeCapabilityToken(id: string): Promise<void> {
-    return this.request(`/v2/capability-tokens/${encodeURIComponent(id)}`, {
+    return this.request(`/v1/capability-tokens/${encodeURIComponent(id)}`, {
       method: "DELETE",
     });
   }
 
   // Claims
   async createClaim(data: CreateClaimRequest): Promise<Claim> {
-    return this.request("/v2/claims", {
+    return this.request("/v1/claims", {
       method: "POST",
       body: JSON.stringify(data),
     });
   }
 
   async listClaims(params?: ListClaimsParams): Promise<StateListResponse<Claim>> {
-    return this.request(this.withQuery("/v2/claims", params));
+    return this.request(this.withQuery("/v1/claims", params));
   }
 
   async getClaim(id: string): Promise<Claim> {
-    return this.request(`/v2/claims/${encodeURIComponent(id)}`);
+    return this.request(`/v1/claims/${encodeURIComponent(id)}`);
   }
 
   async verifyClaim(id: string): Promise<ClaimVerificationRun> {
-    return this.request(`/v2/claims/${encodeURIComponent(id)}/verify`, {
+    return this.request(`/v1/claims/${encodeURIComponent(id)}/verify`, {
       method: "POST",
     });
   }


### PR DESCRIPTION
## Dashboard Redesign
- **New topbar** with custom user dropdown (avatar, settings, theme toggle, sign out)
- **Brand accent** active states on sidebar navigation (`bg-brand-soft`, `text-brand`)
- **Simplified sidebar user** section (custom avatar instead of Clerk UserButton)
- **Responsive layout**: backdrop-blur topbar, better padding, mobile-friendly
- **Matching landing page** design language (zinc + vermilion palette)

## API Consolidation (v2 → v1)
- All routes now under `/api/v1/` — no more `/api/v2/`
- Scoped-auth routes (states, leases, tokens, claims) registered before apiKeyAuth routers
- Removed deprecation middleware from all routes
- Updated SDK: all paths use `/v1/`
- Updated docs, landing page API table, integration examples
- All 221 API tests pass, SDK builds clean, dashboard builds clean

## Files Changed
- `packages/dashboard/src/app/dashboard/layout.tsx` — new topbar with user dropdown
- `packages/dashboard/src/components/sidebar/_sidebar-user.tsx` — simplified user section
- `packages/dashboard/src/components/sidebar/_sidebar-nav.tsx` — brand accent active states
- `packages/api/src/index.ts` — unified route mounting with correct middleware ordering
- `packages/sdk/src/index.ts` — all paths updated to `/v1/`
- `docs/` — updated all v2 references to v1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * API documentation updated to reflect unified `/api/v1` as the standard endpoint version
  * Consolidated previous API v2 routes into the unified `/api/v1` namespace
  * Updated migration guides, code examples, and endpoint references throughout documentation
  * Removed API deprecation notices and headers from v1 endpoints

* **Chores**
  * Unified API versioning across server, SDKs, and dashboard implementations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->