### PR TITLE
fix(dashboard): tighten padding and margin for compact sidebar layout

### DIFF
--- a/packages/dashboard/src/app/dashboard/layout.tsx
+++ b/packages/dashboard/src/app/dashboard/layout.tsx
@@ -25,11 +25,11 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   }
 
   return (
-    <SidebarProvider style={{ "--header-height": "52px" } as React.CSSProperties}>
+    <SidebarProvider style={{ "--header-height": "48px" } as React.CSSProperties}>
       <AppSidebar variant="inset" />
       <SidebarInset className="bg-background">
         <SiteHeader />
-        <main className="flex-1 px-4 py-6 sm:px-6 lg:px-8">
+        <main className="flex-1 px-4 py-4 sm:px-6 lg:px-8">
           <div className="mx-auto w-full max-w-7xl">{children}</div>
         </main>
       </SidebarInset>

--- a/packages/dashboard/src/components/app-sidebar.tsx
+++ b/packages/dashboard/src/components/app-sidebar.tsx
@@ -54,22 +54,22 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
   const { isSignedIn } = useAuth();
 
   return (
-    <Sidebar collapsible="icon" className="p-2" {...props}>
-      <SidebarHeader className="gap-2 pb-1">
+    <Sidebar collapsible="icon" {...props}>
+      <SidebarHeader className="gap-0 p-2 pb-0">
         <SidebarMenu>
           <SidebarMenuItem>
             <SidebarMenuButton
               size="lg"
               tooltip="AgentState"
-              className="p-1.5!"
+              className="p-1!"
               render={<Link href="/dashboard" className="flex items-center gap-2.5" />}
             >
-              <Logo size={24} className="shrink-0 text-foreground" />
+              <Logo size={22} className="shrink-0 text-foreground" />
               <span className="grid group-data-[collapsible=icon]:hidden">
-                <span className="font-display text-[15px] font-semibold leading-none text-foreground">
+                <span className="font-display text-sm font-semibold leading-none text-foreground">
                   AgentState
                 </span>
-                <span className="mt-[3px] font-mono text-[10px] text-faint">state operations</span>
+                <span className="mt-0.5 font-mono text-[9px] text-faint">state operations</span>
               </span>
             </SidebarMenuButton>
           </SidebarMenuItem>
@@ -77,12 +77,12 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
         <OrganizationSwitcher />
       </SidebarHeader>
 
-      <SidebarContent className="gap-1">
+      <SidebarContent>
         <NavMain groups={isSignedIn ? navGroups : [navGroups[0]]} />
         <NavSecondary items={secondaryItems} className="mt-auto" />
       </SidebarContent>
 
-      <SidebarFooter>
+      <SidebarFooter className="p-2 pt-0">
         <NavUser />
       </SidebarFooter>
 

--- a/packages/dashboard/src/components/sidebar/nav-main.tsx
+++ b/packages/dashboard/src/components/sidebar/nav-main.tsx
@@ -28,8 +28,8 @@ export function NavMain({ groups }: { groups: NavGroup[] }) {
   return (
     <>
       {groups.map((group) => (
-        <SidebarGroup key={group.label}>
-          <SidebarGroupLabel className="px-2 text-[0.68rem] font-semibold uppercase tracking-wide text-sidebar-foreground/50">
+        <SidebarGroup key={group.label} className="py-1 px-2">
+          <SidebarGroupLabel className="h-7 px-2 text-[0.62rem] font-semibold uppercase tracking-wider text-sidebar-foreground/40">
             {group.label}
           </SidebarGroupLabel>
           <SidebarMenu>
@@ -42,7 +42,7 @@ export function NavMain({ groups }: { groups: NavGroup[] }) {
                 <SidebarMenuItem key={item.url}>
                   <Link href={item.url}>
                     <SidebarMenuButton
-                      className={`h-9 rounded-lg px-2.5 transition-colors ${isActive ? "bg-brand-soft text-brand font-medium" : "hover:bg-sidebar-accent"}`}
+                      className={`rounded-md transition-colors ${isActive ? "bg-brand-soft text-brand font-medium" : "hover:bg-sidebar-accent"}`}
                       isActive={isActive}
                       tooltip={item.title}
                     >

--- a/packages/dashboard/src/components/sidebar/nav-secondary.tsx
+++ b/packages/dashboard/src/components/sidebar/nav-secondary.tsx
@@ -3,6 +3,7 @@
 import type { LucideIcon } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -21,7 +22,7 @@ export function NavSecondary({ items, className }: { items: NavItem[]; className
   const pathname = usePathname();
 
   return (
-    <SidebarGroup className={className}>
+    <SidebarGroup className={cn("py-1 px-2", className)}>
       <SidebarGroupContent>
         <SidebarMenu>
           {items.map((item) => {
@@ -30,7 +31,7 @@ export function NavSecondary({ items, className }: { items: NavItem[]; className
               <SidebarMenuItem key={item.url}>
                 <Link href={item.url}>
                   <SidebarMenuButton
-                    className={`h-9 rounded-lg px-2.5 transition-colors ${isActive ? "bg-brand-soft text-brand font-medium" : "hover:bg-sidebar-accent"}`}
+                    className={`rounded-md transition-colors ${isActive ? "bg-brand-soft text-brand font-medium" : "hover:bg-sidebar-accent"}`}
                     isActive={isActive}
                     tooltip={item.title}
                   >

--- a/packages/dashboard/src/components/sidebar/nav-user.tsx
+++ b/packages/dashboard/src/components/sidebar/nav-user.tsx
@@ -55,21 +55,21 @@ export function NavUser() {
             render={
               <SidebarMenuButton
                 size="lg"
-                className="flex items-center gap-2.5 rounded-lg px-2 data-[state=open]:bg-sidebar-accent"
+                className="flex items-center gap-2 rounded-md p-1.5 data-[state=open]:bg-sidebar-accent"
                 aria-label="User menu"
               />
             }
           >
-            <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-brand-soft">
-              <span className="text-xs font-semibold text-brand">{initial}</span>
+            <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-brand-soft">
+              <span className="text-[11px] font-semibold text-brand">{initial}</span>
             </div>
             <div className="grid flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden">
-              <span className="truncate font-medium">{user?.fullName || "Account"}</span>
-              <span className="truncate text-xs text-muted-foreground">
+              <span className="truncate text-sm font-medium">{user?.fullName || "Account"}</span>
+              <span className="truncate text-[11px] text-muted-foreground">
                 {user?.primaryEmailAddress?.emailAddress || ""}
               </span>
             </div>
-            <ChevronsUpDownIcon className="ml-auto size-4 shrink-0 group-data-[collapsible=icon]:hidden" />
+            <ChevronsUpDownIcon className="ml-auto size-3.5 shrink-0 text-muted-foreground group-data-[collapsible=icon]:hidden" />
           </DropdownMenuTrigger>
         </SidebarMenuItem>
       </SidebarMenu>

--- a/packages/dashboard/src/components/site-header.tsx
+++ b/packages/dashboard/src/components/site-header.tsx
@@ -56,10 +56,10 @@ export function SiteHeader() {
   const route = routeMap[pathname] || { label: "Dashboard" };
 
   return (
-    <header className="sticky top-0 z-30 flex h-13 shrink-0 items-center border-b border-border/60 bg-background/80 backdrop-blur-lg">
-      <div className="flex w-full items-center gap-2 px-4 sm:px-6">
+    <header className="sticky top-0 z-30 flex h-12 shrink-0 items-center border-b border-border/60 bg-background/80 backdrop-blur-lg">
+      <div className="flex w-full items-center gap-1.5 px-3 sm:px-4">
         <SidebarTrigger className="-ml-1 text-muted-foreground hover:text-foreground" />
-        <Separator orientation="vertical" className="mr-2 hidden h-4 sm:block" />
+        <Separator orientation="vertical" className="mr-1.5 hidden h-4 sm:block" />
 
         <Breadcrumb>
           <BreadcrumbList>


### PR DESCRIPTION
## Changes
Tightens padding and margins across the dashboard sidebar and topbar for a more compact, polished design.

### Spacing fixes
- **Sidebar outer**: Remove `p-2` wrapper padding, use tighter header/footer overrides (`p-2 pb-0` / `p-2 pt-0`)
- **Nav items**: Use default `h-8` instead of `h-9`, remove `px-2.5` override
- **Group labels**: Reduce from `h-8` to `h-7`, smaller font (`0.62rem`), tighter tracking
- **Group padding**: Override from default `p-2` to `py-1 px-2`
- **User avatar**: Shrink from `size-8` to `size-7`, tighten menu button padding
- **Topbar height**: Reduce from `h-13` (52px) to `h-12` (48px)
- **Header spacing**: Tighten horizontal gap from `gap-2` to `gap-1.5`, reduce padding
- **Main content**: Reduce vertical padding from `py-6` to `py-4`

### Files changed
- `app-sidebar.tsx` — sidebar shell padding
- `nav-main.tsx` — nav group and item sizing
- `nav-secondary.tsx` — secondary links sizing
- `nav-user.tsx` — user button compact
- `site-header.tsx` — topbar height and spacing
- `layout.tsx` — main content padding and header height

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>