### PR TITLE
refactor(dashboard): use standard shadcn sidebar-08 pattern

### DIFF
--- a/packages/dashboard/src/app/dashboard/layout.tsx
+++ b/packages/dashboard/src/app/dashboard/layout.tsx
@@ -1,19 +1,19 @@
-"use client";
+"use client"
 
-import { SignIn, useAuth } from "@clerk/react";
-import { AppSidebar } from "@/components/app-sidebar";
-import { SiteHeader } from "@/components/site-header";
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { SignIn, useAuth } from "@clerk/react"
+import { AppSidebar } from "@/components/app-sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-  const { isSignedIn, isLoaded } = useAuth();
+  const { isSignedIn, isLoaded } = useAuth()
 
   if (!isLoaded) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-background">
         <div className="size-6 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-foreground" />
       </div>
-    );
+    )
   }
 
   if (!isSignedIn) {
@@ -21,18 +21,18 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
       <div className="flex items-center justify-center min-h-screen bg-background">
         <SignIn routing="hash" />
       </div>
-    );
+    )
   }
 
   return (
-    <SidebarProvider style={{ "--header-height": "48px" } as React.CSSProperties}>
-      <AppSidebar variant="inset" />
-      <SidebarInset className="bg-background">
+    <SidebarProvider>
+      <AppSidebar />
+      <SidebarInset>
         <SiteHeader />
-        <main className="flex-1 px-4 py-4 sm:px-6 lg:px-8">
-          <div className="mx-auto w-full max-w-7xl">{children}</div>
-        </main>
+        <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+          {children}
+        </div>
       </SidebarInset>
     </SidebarProvider>
-  );
+  )
 }

--- a/packages/dashboard/src/app/globals.css
+++ b/packages/dashboard/src/app/globals.css
@@ -98,15 +98,15 @@
   --chart-4: #71717a;
   --chart-5: #a1a1aa;
 
-  /* sidebar — clean surface, subtle brand accent */
-  --sidebar: #ffffff;
-  --sidebar-foreground: #3f3f46;
-  --sidebar-primary: #18181b;
-  --sidebar-primary-foreground: #ffffff;
-  --sidebar-accent: #f4f4f5;
-  --sidebar-accent-foreground: #18181b;
-  --sidebar-border: #e4e4e7;
-  --sidebar-ring: #d9543a;
+  /* sidebar — shadcn neutral defaults */
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.141 0.005 285.823);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
 }
 
 .dark {
@@ -146,14 +146,14 @@
   --chart-4: #a1a1aa;
   --chart-5: #71717a;
 
-  --sidebar: #0c0c0d;
-  --sidebar-foreground: #d4d4d8;
-  --sidebar-primary: #fafafa;
-  --sidebar-primary-foreground: #18181b;
-  --sidebar-accent: #1a1a1d;
-  --sidebar-accent-foreground: #fafafa;
-  --sidebar-border: #222225;
-  --sidebar-ring: #e2664d;
+  --sidebar: oklch(0.141 0.005 285.823);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.439 0 0);
 }
 
 @layer base {

--- a/packages/dashboard/src/components/app-sidebar.tsx
+++ b/packages/dashboard/src/components/app-sidebar.tsx
@@ -1,6 +1,6 @@
-"use client";
+"use client"
 
-import { useAuth } from "@clerk/react";
+import { useAuth } from "@clerk/react"
 import {
   ActivityIcon,
   BlocksIcon,
@@ -9,13 +9,13 @@ import {
   LayoutDashboardIcon,
   MessageCircleIcon,
   SettingsIcon,
-} from "lucide-react";
-import Link from "next/link";
-import { Logo } from "@/components/brand/logo";
-import { OrganizationSwitcher } from "@/components/organization-switcher";
-import { NavMain } from "@/components/sidebar/nav-main";
-import { NavSecondary } from "@/components/sidebar/nav-secondary";
-import { NavUser } from "@/components/sidebar/nav-user";
+} from "lucide-react"
+import Link from "next/link"
+import { Logo } from "@/components/brand/logo"
+import { OrganizationSwitcher } from "@/components/organization-switcher"
+import { NavMain } from "@/components/sidebar/nav-main"
+import { NavSecondary } from "@/components/sidebar/nav-secondary"
+import { NavUser } from "@/components/sidebar/nav-user"
 import {
   Sidebar,
   SidebarContent,
@@ -25,7 +25,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarRail,
-} from "@/components/ui/sidebar";
+} from "@/components/ui/sidebar"
 
 const navGroups = [
   {
@@ -43,34 +43,33 @@ const navGroups = [
       { title: "Organizations", url: "/dashboard/settings/organizations", icon: SettingsIcon },
     ],
   },
-];
+]
 
 const secondaryItems = [
   { title: "Docs", url: "/docs", icon: BookOpenIcon },
   { title: "Home", url: "/", icon: HomeIcon },
-];
+]
 
 export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
-  const { isSignedIn } = useAuth();
+  const { isSignedIn } = useAuth()
 
   return (
-    <Sidebar collapsible="icon" {...props}>
-      <SidebarHeader className="gap-0 p-2 pb-0">
+    <Sidebar collapsible="icon" variant="inset" {...props}>
+      <SidebarHeader>
         <SidebarMenu>
           <SidebarMenuItem>
             <SidebarMenuButton
               size="lg"
               tooltip="AgentState"
-              className="p-1!"
-              render={<Link href="/dashboard" className="flex items-center gap-2.5" />}
+              render={<Link href="/dashboard" />}
             >
-              <Logo size={22} className="shrink-0 text-foreground" />
-              <span className="grid group-data-[collapsible=icon]:hidden">
-                <span className="font-display text-sm font-semibold leading-none text-foreground">
-                  AgentState
-                </span>
-                <span className="mt-0.5 font-mono text-[9px] text-faint">state operations</span>
-              </span>
+              <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
+                <Logo size={16} className="text-sidebar-primary-foreground" />
+              </div>
+              <div className="grid flex-1 text-left text-sm leading-tight">
+                <span className="truncate font-medium">AgentState</span>
+                <span className="truncate text-xs">state operations</span>
+              </div>
             </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>
@@ -82,11 +81,11 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
         <NavSecondary items={secondaryItems} className="mt-auto" />
       </SidebarContent>
 
-      <SidebarFooter className="p-2 pt-0">
+      <SidebarFooter>
         <NavUser />
       </SidebarFooter>
 
       <SidebarRail />
     </Sidebar>
-  );
+  )
 }

--- a/packages/dashboard/src/components/sidebar/nav-main.tsx
+++ b/packages/dashboard/src/components/sidebar/nav-main.tsx
@@ -1,61 +1,57 @@
-"use client";
+"use client"
 
-import type { LucideIcon } from "lucide-react";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
+import type { LucideIcon } from "lucide-react"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
 import {
   SidebarGroup,
   SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-} from "@/components/ui/sidebar";
+} from "@/components/ui/sidebar"
 
 interface NavItem {
-  title: string;
-  url: string;
-  icon: LucideIcon;
+  title: string
+  url: string
+  icon: LucideIcon
 }
 
 interface NavGroup {
-  label: string;
-  items: NavItem[];
+  label: string
+  items: NavItem[]
 }
 
 export function NavMain({ groups }: { groups: NavGroup[] }) {
-  const pathname = usePathname();
+  const pathname = usePathname()
 
   return (
     <>
       {groups.map((group) => (
-        <SidebarGroup key={group.label} className="py-1 px-2">
-          <SidebarGroupLabel className="h-7 px-2 text-[0.62rem] font-semibold uppercase tracking-wider text-sidebar-foreground/40">
-            {group.label}
-          </SidebarGroupLabel>
+        <SidebarGroup key={group.label}>
+          <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
           <SidebarMenu>
             {group.items.map((item) => {
               const isActive =
                 item.url === "/dashboard"
                   ? pathname === "/dashboard" || pathname === "/dashboard/"
-                  : pathname.startsWith(item.url);
+                  : pathname.startsWith(item.url)
               return (
                 <SidebarMenuItem key={item.url}>
-                  <Link href={item.url}>
-                    <SidebarMenuButton
-                      className={`rounded-md transition-colors ${isActive ? "bg-brand-soft text-brand font-medium" : "hover:bg-sidebar-accent"}`}
-                      isActive={isActive}
-                      tooltip={item.title}
-                    >
-                      <item.icon />
-                      <span>{item.title}</span>
-                    </SidebarMenuButton>
-                  </Link>
+                  <SidebarMenuButton
+                    isActive={isActive}
+                    tooltip={item.title}
+                    render={<Link href={item.url} />}
+                  >
+                    <item.icon />
+                    <span>{item.title}</span>
+                  </SidebarMenuButton>
                 </SidebarMenuItem>
-              );
+              )
             })}
           </SidebarMenu>
         </SidebarGroup>
       ))}
     </>
-  );
+  )
 }

--- a/packages/dashboard/src/components/sidebar/nav-secondary.tsx
+++ b/packages/dashboard/src/components/sidebar/nav-secondary.tsx
@@ -1,49 +1,45 @@
-"use client";
-
-import type { LucideIcon } from "lucide-react";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { cn } from "@/lib/utils";
+import type { LucideIcon } from "lucide-react"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
 import {
   SidebarGroup,
   SidebarGroupContent,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-} from "@/components/ui/sidebar";
+} from "@/components/ui/sidebar"
 
 interface NavItem {
-  title: string;
-  url: string;
-  icon: LucideIcon;
+  title: string
+  url: string
+  icon: LucideIcon
 }
 
-export function NavSecondary({ items, className }: { items: NavItem[]; className?: string }) {
-  const pathname = usePathname();
+export function NavSecondary({
+  items,
+  ...props
+}: {
+  items: NavItem[]
+} & React.ComponentPropsWithoutRef<typeof SidebarGroup>) {
+  const pathname = usePathname()
 
   return (
-    <SidebarGroup className={cn("py-1 px-2", className)}>
+    <SidebarGroup {...props}>
       <SidebarGroupContent>
         <SidebarMenu>
           {items.map((item) => {
-            const isActive = item.url === "/" ? pathname === "/" : pathname.startsWith(item.url);
+            const isActive = item.url === "/" ? pathname === "/" : pathname.startsWith(item.url)
             return (
-              <SidebarMenuItem key={item.url}>
-                <Link href={item.url}>
-                  <SidebarMenuButton
-                    className={`rounded-md transition-colors ${isActive ? "bg-brand-soft text-brand font-medium" : "hover:bg-sidebar-accent"}`}
-                    isActive={isActive}
-                    tooltip={item.title}
-                  >
-                    <item.icon />
-                    <span>{item.title}</span>
-                  </SidebarMenuButton>
-                </Link>
+              <SidebarMenuItem key={item.title}>
+                <SidebarMenuButton size="sm" isActive={isActive} render={<Link href={item.url} />}>
+                  <item.icon />
+                  <span>{item.title}</span>
+                </SidebarMenuButton>
               </SidebarMenuItem>
-            );
+            )
           })}
         </SidebarMenu>
       </SidebarGroupContent>
     </SidebarGroup>
-  );
+  )
 }

--- a/packages/dashboard/src/components/sidebar/nav-user.tsx
+++ b/packages/dashboard/src/components/sidebar/nav-user.tsx
@@ -1,31 +1,37 @@
-"use client";
+"use client"
 
-import { SignInButton, useAuth, useClerk, useUser } from "@clerk/react";
-import { ChevronsUpDownIcon, LogOutIcon, SettingsIcon, UserIcon } from "lucide-react";
-import Link from "next/link";
-import { ThemeToggle } from "@/components/theme-toggle";
+import { SignInButton, useAuth, useClerk, useUser } from "@clerk/react"
+import { ChevronsUpDown, LogOut, Settings, User } from "lucide-react"
+import Link from "next/link"
+import { ThemeToggle } from "@/components/theme-toggle"
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/components/ui/avatar"
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+} from "@/components/ui/dropdown-menu"
 import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
   useSidebar,
-} from "@/components/ui/sidebar";
+} from "@/components/ui/sidebar"
 
 export function NavUser() {
-  const { isSignedIn, isLoaded } = useAuth();
-  const { user } = useUser();
-  const { signOut } = useClerk();
-  const { isMobile } = useSidebar();
+  const { isSignedIn, isLoaded } = useAuth()
+  const { user } = useUser()
+  const { signOut } = useClerk()
+  const { isMobile } = useSidebar()
 
-  if (!isLoaded) return null;
+  if (!isLoaded) return null
 
   if (!isSignedIn) {
     return (
@@ -34,77 +40,85 @@ export function NavUser() {
           <SignInButton>
             <button
               type="button"
-              className="flex h-8 w-full items-center justify-center rounded-lg border border-border text-xs font-medium transition-colors hover:bg-accent"
+              className="flex h-8 w-full items-center justify-center rounded-md border text-xs font-medium hover:bg-sidebar-accent"
             >
               Sign in
             </button>
           </SignInButton>
         </SidebarMenuItem>
       </SidebarMenu>
-    );
+    )
   }
 
-  const initial =
-    user?.firstName?.[0] || user?.emailAddresses?.[0]?.emailAddress?.[0]?.toUpperCase() || "?";
+  const name = user?.fullName || "Account"
+  const email = user?.primaryEmailAddress?.emailAddress || ""
+  const initial = name[0]?.toUpperCase() || "U"
 
   return (
-    <DropdownMenu>
-      <SidebarMenu>
-        <SidebarMenuItem>
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
           <DropdownMenuTrigger
             render={
               <SidebarMenuButton
                 size="lg"
-                className="flex items-center gap-2 rounded-md p-1.5 data-[state=open]:bg-sidebar-accent"
-                aria-label="User menu"
+                className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
               />
             }
           >
-            <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-brand-soft">
-              <span className="text-[11px] font-semibold text-brand">{initial}</span>
+            <Avatar className="h-8 w-8 rounded-lg">
+              <AvatarFallback className="rounded-lg">{initial}</AvatarFallback>
+            </Avatar>
+            <div className="grid flex-1 text-left text-sm leading-tight">
+              <span className="truncate font-medium">{name}</span>
+              <span className="truncate text-xs">{email}</span>
             </div>
-            <div className="grid flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden">
-              <span className="truncate text-sm font-medium">{user?.fullName || "Account"}</span>
-              <span className="truncate text-[11px] text-muted-foreground">
-                {user?.primaryEmailAddress?.emailAddress || ""}
-              </span>
-            </div>
-            <ChevronsUpDownIcon className="ml-auto size-3.5 shrink-0 text-muted-foreground group-data-[collapsible=icon]:hidden" />
+            <ChevronsUpDown className="ml-auto size-4" />
           </DropdownMenuTrigger>
-        </SidebarMenuItem>
-      </SidebarMenu>
-      <DropdownMenuContent side={isMobile ? "bottom" : "right"} align="end" className="w-56">
-        <DropdownMenuLabel>
-          <div className="flex flex-col gap-0.5">
-            <span className="text-sm font-medium">{user?.fullName || "Account"}</span>
-            <span className="text-xs text-muted-foreground">
-              {user?.primaryEmailAddress?.emailAddress}
-            </span>
-          </div>
-        </DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem render={<Link href="/dashboard" />}>
-          <UserIcon className="size-4" />
-          Profile
-        </DropdownMenuItem>
-        <DropdownMenuItem render={<Link href="/dashboard/settings/organizations" />}>
-          <SettingsIcon className="size-4" />
-          Settings
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <div className="flex items-center justify-between px-2 py-1.5">
-          <span className="text-sm">Theme</span>
-          <ThemeToggle size="h-3.5 w-3.5" className="size-8" />
-        </div>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem
-          className="text-destructive focus:text-destructive"
-          onClick={() => signOut()}
-        >
-          <LogOutIcon className="size-4" />
-          Sign out
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
+          <DropdownMenuContent
+            className="w-56 rounded-lg"
+            side={isMobile ? "bottom" : "right"}
+            align="end"
+            sideOffset={4}
+          >
+            <DropdownMenuLabel className="p-0 font-normal">
+              <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+                <Avatar className="h-8 w-8 rounded-lg">
+                  <AvatarFallback className="rounded-lg">{initial}</AvatarFallback>
+                </Avatar>
+                <div className="grid flex-1 text-left text-sm leading-tight">
+                  <span className="truncate font-medium">{name}</span>
+                  <span className="truncate text-xs">{email}</span>
+                </div>
+              </div>
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuGroup>
+              <DropdownMenuItem render={<Link href="/dashboard" />}>
+                <User />
+                Account
+              </DropdownMenuItem>
+              <DropdownMenuItem render={<Link href="/dashboard/settings/organizations" />}>
+                <Settings />
+                Settings
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <div className="flex items-center justify-between px-2 py-1.5">
+              <span className="text-sm">Theme</span>
+              <ThemeToggle />
+            </div>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="text-destructive focus:text-destructive"
+              onClick={() => signOut()}
+            >
+              <LogOut />
+              Log out
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
 }

--- a/packages/dashboard/src/components/site-header.tsx
+++ b/packages/dashboard/src/components/site-header.tsx
@@ -1,17 +1,17 @@
-"use client";
+"use client"
 
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { Pill } from "@/components/brand/bits";
+import Link from "next/link"
+import { usePathname } from "next/navigation"
 import {
   Breadcrumb,
   BreadcrumbItem,
+  BreadcrumbLink,
   BreadcrumbList,
   BreadcrumbPage,
   BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
-import { Separator } from "@/components/ui/separator";
-import { SidebarTrigger } from "@/components/ui/sidebar";
+} from "@/components/ui/breadcrumb"
+import { Separator } from "@/components/ui/separator"
+import { SidebarTrigger } from "@/components/ui/sidebar"
 
 const routeMap: Record<string, { label: string; parent?: { href: string; label: string } }> = {
   "/dashboard": { label: "Projects" },
@@ -47,33 +47,27 @@ const routeMap: Record<string, { label: string; parent?: { href: string; label: 
     label: "Members",
     parent: { href: "/dashboard/settings/organizations", label: "Organizations" },
   },
-};
-
-const dashboardApiEndpoint = process.env.NEXT_PUBLIC_API_ENDPOINT || "agentstate.app/api";
+}
 
 export function SiteHeader() {
-  const pathname = usePathname();
-  const route = routeMap[pathname] || { label: "Dashboard" };
+  const pathname = usePathname()
+  const route = routeMap[pathname] || { label: "Dashboard" }
 
   return (
-    <header className="sticky top-0 z-30 flex h-12 shrink-0 items-center border-b border-border/60 bg-background/80 backdrop-blur-lg">
-      <div className="flex w-full items-center gap-1.5 px-3 sm:px-4">
-        <SidebarTrigger className="-ml-1 text-muted-foreground hover:text-foreground" />
-        <Separator orientation="vertical" className="mr-1.5 hidden h-4 sm:block" />
-
+    <header className="flex h-16 shrink-0 items-center gap-2">
+      <div className="flex items-center gap-2 px-4">
+        <SidebarTrigger className="-ml-1" />
+        <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
         <Breadcrumb>
           <BreadcrumbList>
             {route.parent && (
               <>
-                <BreadcrumbItem>
-                  <Link
-                    href={route.parent.href}
-                    className="transition-colors hover:text-foreground"
-                  >
+                <BreadcrumbItem className="hidden md:block">
+                  <Link href={route.parent.href} className="transition-colors hover:text-foreground">
                     {route.parent.label}
                   </Link>
                 </BreadcrumbItem>
-                <BreadcrumbSeparator />
+                <BreadcrumbSeparator className="hidden md:block" />
               </>
             )}
             <BreadcrumbItem>
@@ -81,17 +75,7 @@ export function SiteHeader() {
             </BreadcrumbItem>
           </BreadcrumbList>
         </Breadcrumb>
-
-        <div className="ml-auto flex items-center gap-2">
-          <Pill className="hidden py-[3px] sm:inline-flex">
-            <span className="size-2 rounded-full bg-brand" />
-            Live
-          </Pill>
-          <code className="hidden font-mono text-[11px] text-faint lg:block">
-            {dashboardApiEndpoint}
-          </code>
-        </div>
       </div>
     </header>
-  );
+  )
 }

--- a/packages/dashboard/src/components/ui/avatar.tsx
+++ b/packages/dashboard/src/components/ui/avatar.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import * as React from "react"
+import { Avatar as AvatarPrimitive } from "@base-ui/react/avatar"
+
+import { cn } from "@/lib/utils"
+
+function Avatar({
+  className,
+  size = "default",
+  ...props
+}: AvatarPrimitive.Root.Props & {
+  size?: "default" | "sm" | "lg"
+}) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      data-size={size}
+      className={cn(
+        "group/avatar relative flex size-8 shrink-0 rounded-full select-none after:absolute after:inset-0 after:rounded-full after:border after:border-border after:mix-blend-darken data-[size=lg]:size-10 data-[size=sm]:size-6 dark:after:mix-blend-lighten",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarImage({ className, ...props }: AvatarPrimitive.Image.Props) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn(
+        "aspect-square size-full rounded-full object-cover",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: AvatarPrimitive.Fallback.Props) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="avatar-badge"
+      className={cn(
+        "absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground bg-blend-color ring-2 ring-background select-none",
+        "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+        "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+        "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group"
+      className={cn(
+        "group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-background",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroupCount({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group-count"
+      className={cn(
+        "relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm text-muted-foreground ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarGroupCount,
+  AvatarBadge,
+}

--- a/packages/dashboard/src/components/ui/collapsible.tsx
+++ b/packages/dashboard/src/components/ui/collapsible.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import { Collapsible as CollapsiblePrimitive } from "@base-ui/react/collapsible"
+
+function Collapsible({ ...props }: CollapsiblePrimitive.Root.Props) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+}
+
+function CollapsibleTrigger({ ...props }: CollapsiblePrimitive.Trigger.Props) {
+  return (
+    <CollapsiblePrimitive.Trigger data-slot="collapsible-trigger" {...props} />
+  )
+}
+
+function CollapsibleContent({ ...props }: CollapsiblePrimitive.Panel.Props) {
+  return (
+    <CollapsiblePrimitive.Panel data-slot="collapsible-content" {...props} />
+  )
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }


### PR DESCRIPTION
## Changes
Rewrite all sidebar components to match the shadcn sidebar-08 block exactly, removing all custom className overrides and using default shadcn styling.

### What changed
- **globals.css**: Sidebar CSS variables updated to shadcn neutral oklch defaults
- **nav-main.tsx**: Clean shadcn pattern — no custom className, uses default `SidebarMenuButton` styling via `isActive`
- **nav-secondary.tsx**: Matches shadcn sidebar-08 `NavSecondary` exactly (size="sm", spread props)
- **nav-user.tsx**: Uses Avatar component, clean DropdownMenu pattern from shadcn
- **app-sidebar.tsx**: Matches shadcn sidebar-08 structure — brand in SidebarHeader via `SidebarMenuButton size="lg"`, `SidebarRail`
- **site-header.tsx**: Matches shadcn sidebar-08 page header — `h-16`, `SidebarTrigger` + `Separator` + `Breadcrumb`
- **layout.tsx**: Clean `SidebarProvider > AppSidebar + SidebarInset > SiteHeader + content` pattern
- **New**: Installed Avatar and Collapsible shadcn components

### Key principle
Zero custom className overrides on sidebar components. All styling comes from shadcn CSS variables and component defaults. The only adaptation is `asChild` → `render` prop for `@base-ui/react` compatibility.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added avatar component for enhanced user profile displays and visual integration

* **Style & UI Improvements**
  * Refreshed sidebar color theme with updated palette
  * Simplified dashboard header layout for improved clarity
  * Removed API endpoint information from header for cleaner display
  * Enhanced navigation menus with improved structure and styling
  * Refined visual design of sidebar and user menu components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->