### PR TITLE
fix(ci): replace deleted Cloudflare Pages preview action

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -82,9 +82,38 @@ jobs:
 
       - name: Delete previous preview deployments
         if: github.event_name == 'pull_request'
-        uses: johnbryant/actions-cloudflare-pages@v2
-        with:
-          api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          project: agentstate-dashboard
-          branch: ${{ github.head_ref }}
-          keep_last: 1
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_PAGES_PROJECT: agentstate-dashboard
+          CF_PAGES_BRANCH: ${{ github.head_ref }}
+          KEEP_LAST: '1'
+        run: |
+          set +e
+          : "${CF_API_TOKEN:?CLOUDFLARE_API_TOKEN secret is required}"
+          : "${CF_ACCOUNT_ID:?CLOUDFLARE_ACCOUNT_ID secret is required}"
+          : "${CF_PAGES_PROJECT:?project is required}"
+          : "${CF_PAGES_BRANCH:?branch is required}"
+
+          api="https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/pages/projects/${CF_PAGES_PROJECT}/deployments?per_page=100"
+
+          # Keep only the most recent KEEP_LAST preview deployments for this branch;
+          # never touch production deployments. Best-effort: a failed delete on one
+          # deployment does not abort pruning of the rest.
+          curl -fsSL -H "Authorization: Bearer ${CF_API_TOKEN}" "$api" \
+            | jq -r --arg branch "$CF_PAGES_BRANCH" '
+                .result // []
+                | map(select(
+                    (.environment // "") == "preview"
+                    and ((.deployment_trigger.metadata.branch // .branch // "") == $branch)
+                  ))
+                | sort_by(.created_on) | reverse
+                | .[($ENV.KEEP_LAST | tonumber):]
+                | .[].id' \
+            | while read -r dep_id; do
+                echo "Deleting stale preview deployment ${dep_id}"
+                curl -fsSL -X DELETE \
+                  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+                  "${api%/deployments*}/deployments/${dep_id}" \
+                  | jq -r '.success // false | "  -> " + (if . then "ok" else "failed" end)'
+              done


### PR DESCRIPTION
## Summary

The **Dashboard Preview Deploy** workflow is failing on every PR (e.g. [run 27468166387](https://github.com/duyet/agentstate/actions/runs/27468166387)) with:

```
Unable to resolve action `johnbryant/actions-cloudflare-pages`, repository not found
```

The third-party action `johnbryant/actions-cloudflare-pages@v2` (used by the "Delete previous preview deployments" step) was deleted upstream. Main CI (`ci.yml`) is unaffected and green — only this preview-deploy workflow breaks, only on PR events.

## What changed

Replaced the deleted action with a self-contained **bash step** that calls the [Cloudflare Pages API](https://developers.cloudflare.com/api/resources/pages/) directly via `curl` + `jq`. It preserves the original intent: prune old preview deployments for the PR branch, keeping the latest 1 (`keep_last: 1`).

### Replacement approach chosen: option (a) — direct API via curl + jq

Why this over the alternatives:
- **No new third-party action dependency** → cannot break again from an upstream repo deletion (the root cause here).
- **Preserves original behavior** — pruning still happens; no functionality lost.
- Both required secrets already exist (verified — see below), and `ubuntu-latest` ships `curl` + `jq`.
- The workflow already depends on `cloudflare/wrangler-action@v3` for the actual deploy; pruning via a second wrangler invocation would still need a bash loop, so going straight to the API is simpler.

### Safety guards
- **Never deletes production deployments** — filters to `environment == "preview"` only.
- **Branch-scoped** — only deletes deployments whose branch exactly matches `github.head_ref` (via `deployment_trigger.metadata.branch`).
- **`keep_last: 1` preserved** — sorts by `created_on` desc, skips the most recent, deletes the rest.
- **Best-effort** — a failed `DELETE` on one deployment does not abort pruning of the others (`set +e`).
- **Fails fast** on missing secrets/inputs via parameter expansion.

## Secrets

Required secrets are present in the repo (verified via `gh secret list`):
- `CLOUDFLARE_API_TOKEN` ✅
- `CLOUDFLARE_ACCOUNT_ID` ✅

## Validation

- YAML validated (`yaml.safe_load`) ✅
- `jq` filter dry-run on sample data: correctly keeps newest preview, excludes production + other-branch deployments ✅
- No build/deploy run (CI/workflow change only)

## Notes

- Left as a PR for maintainer review (CI/workflow change) — **not** auto-merged.
- Pre-existing `fmt` pre-commit hook error is unrelated to this change (biome on other files).

---
Co-Authored-By: duyetbot <duyetbot@users.noreply.github.com>

## Summary by Sourcery

Update the preview deploy workflow to remove dependency on a deleted third-party Cloudflare Pages action and perform preview cleanup via a built-in bash step calling the Cloudflare API.

Bug Fixes:
- Restore functioning of the Dashboard Preview Deploy workflow by replacing the deleted Cloudflare Pages preview cleanup action with an inline script.

CI:
- Change the Cloudflare Pages preview deployment cleanup step to use a curl+jq bash script against the Cloudflare API instead of a third-party GitHub Action, while preserving branch scoping and keep-last behavior.