### PR TITLE
fix(ci): set repo for release dispatch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,4 +43,5 @@ jobs:
         if: steps.release.outputs.release_created == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: gh workflow run release.yml -f tag=${{ steps.release.outputs.tag_name }}


### PR DESCRIPTION
## Summary
- Set GH_REPO for the release-please dispatch step so gh workflow run does not require a local .git checkout.

## Evidence
- Release Please run 27490265110 failed in job 81253875555 at step "Trigger release build".
- Log line: `gh workflow run release.yml -f tag=v0.1.1` failed with `fatal: not a git repository (or any of the parent directories): .git`.
- The workflow has no checkout step before dispatch, so GH_REPO is the minimal repo-context fix.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-please.yml"); puts "yaml ok"'`
- Pre-commit `bunx biome check --write packages/*/src/` reports existing dashboard lint/a11y diagnostics unrelated to this workflow-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow by explicitly setting the repository context for the build dispatch, enhancing the reliability of the automated release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->