### PR TITLE
feat(api): authenticate dashboard management routes (P0 security)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
     "packages/api": {
       "name": "@agentstate/api",
       "dependencies": {
+        "@clerk/backend": "^3.7.0",
         "drizzle-orm": "^0.45.2",
         "hono": "^4.12.21",
         "nanoid": "^5.1.0",
@@ -175,13 +176,13 @@
 
     "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
 
-    "@clerk/backend": ["@clerk/backend@3.4.11", "", { "dependencies": { "@clerk/shared": "^4.12.2", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-WT+4FrcMMofxe+irQYUkawoRWaHHXT9/wiRYhRbSb30cOPjN95ViydqPhAyp8ZWAHInHg4mILynQQRJH14SKZQ=="],
+    "@clerk/backend": ["@clerk/backend@3.7.0", "", { "dependencies": { "@clerk/shared": "^4.17.1", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-tdURxlfJ8sYR+zM6bUNsG4/BpxH7MV66E5NmHbjIoggUm48SdVoBtKUSjxT0uVa8MpdYHqPk/I0mMdI/EC1B/g=="],
 
     "@clerk/nextjs": ["@clerk/nextjs@7.3.7", "", { "dependencies": { "@clerk/backend": "^3.4.11", "@clerk/react": "^6.6.6", "@clerk/shared": "^4.12.2", "server-only": "0.0.1", "tslib": "2.8.1" }, "peerDependencies": { "next": "^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || ^15.6.0-0 || ^16.0.10 || ^16.1.0-0", "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-CLG63zKPHditk52Z/+c6BJ47V1Q68ACjeps0xHDRW3X/Yv/FZdM+IUKu9Egb5PJ/TkRFxsI1nU5SOY2B8o/WxA=="],
 
     "@clerk/react": ["@clerk/react@6.6.6", "", { "dependencies": { "@clerk/shared": "^4.12.2", "tslib": "2.8.1" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-MVHLDZeGobSbGSZgAdb4G1BbB8ZU5XAmBBdIVLXiPOLEst2TYM5bP137WRA76y9GlmVmKYdKzph/TUi87P/JOA=="],
 
-    "@clerk/shared": ["@clerk/shared@4.12.2", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-jDkip8tKTzYz/cPKMCsjOoACH3Xh37zcbCrssMRTYOq3GZypIpZ6WAs4m4G82URL0WY+yz5frrHVjRrHyAb6LA=="],
+    "@clerk/shared": ["@clerk/shared@4.17.1", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.7" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-9Ej2bLA7pWY1e07/PHmPNtQwiV1594rwacNYbppoDUPq9yRkBRZ+pDcpySkfpokS5YXvOUv6aFoPPbEMbQUVgw=="],
 
     "@cloudflare/kumo": ["@cloudflare/kumo@2.5.2", "", { "dependencies": { "@base-ui/react": "^1.5.0", "@shikijs/langs": "^4.0.0", "@shikijs/themes": "^4.0.0", "clsx": "^2.1.1", "motion": "^12.34.1", "react-day-picker": "^9.13.2", "shiki": "^4.0.0", "tailwind-merge": "^3.4.0" }, "peerDependencies": { "@phosphor-icons/react": "^2.1.10", "echarts": "^6.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "zod": "^4.0.0" }, "optionalPeers": ["echarts", "zod"], "bin": { "kumo": "bin/kumo.js" } }, "sha512-HUNi40VG3ExJ7lV8HjqPQcGpCmm2CqG/SzjJ+K+NhCwZRYTBvagdoMDPX2XZ8AW/ZPEeuFoId0VYmzrX+luyXQ=="],
 
@@ -1231,7 +1232,7 @@
 
     "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
-    "js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
+    "js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
 
     "js-tiktoken": ["js-tiktoken@1.0.21", "", { "dependencies": { "base64-js": "^1.5.1" } }, "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g=="],
 
@@ -1841,7 +1842,11 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
-    "@clerk/shared/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+    "@clerk/nextjs/@clerk/backend": ["@clerk/backend@3.4.11", "", { "dependencies": { "@clerk/shared": "^4.12.2", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-WT+4FrcMMofxe+irQYUkawoRWaHHXT9/wiRYhRbSb30cOPjN95ViydqPhAyp8ZWAHInHg4mILynQQRJH14SKZQ=="],
+
+    "@clerk/nextjs/@clerk/shared": ["@clerk/shared@4.12.2", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-jDkip8tKTzYz/cPKMCsjOoACH3Xh37zcbCrssMRTYOq3GZypIpZ6WAs4m4G82URL0WY+yz5frrHVjRrHyAb6LA=="],
+
+    "@clerk/react/@clerk/shared": ["@clerk/shared@4.12.2", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-jDkip8tKTzYz/cPKMCsjOoACH3Xh37zcbCrssMRTYOq3GZypIpZ6WAs4m4G82URL0WY+yz5frrHVjRrHyAb6LA=="],
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
@@ -1964,6 +1969,14 @@
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "zrender/tslib": ["tslib@2.3.0", "", {}, "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="],
+
+    "@clerk/nextjs/@clerk/shared/js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
+
+    "@clerk/nextjs/@clerk/shared/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "@clerk/react/@clerk/shared/js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
+
+    "@clerk/react/@clerk/shared/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
     "@dotenvx/dotenvx/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@clerk/backend": "^3.7.0",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.21",
     "nanoid": "^5.1.0",

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -3,6 +3,7 @@ import { cors } from "hono/cors";
 import { OPENAPI_SPEC } from "./content/openapi";
 import { AGENTS_MD, LLMS_TXT } from "./content/static";
 import { errorResponse } from "./lib/helpers";
+import { clerkDashboardAuth } from "./middleware/clerk-dashboard-auth";
 import { dbMiddleware } from "./middleware/db";
 import { requestIdMiddleware } from "./middleware/request-id";
 import aiRouter from "./routes/ai";
@@ -65,6 +66,22 @@ app.use(
 app.use("*", dbMiddleware);
 
 // ---------------------------------------------------------------------------
+// Dashboard-management auth (Clerk session)
+// ---------------------------------------------------------------------------
+// These routes are used by the dashboard (Clerk-authenticated, same-origin)
+// to manage projects, analytics, domains, and organizations. They MUST NOT be
+// reachable without a verified Clerk session — fail-closed via
+// clerkDashboardAuth. Registered before the route mounts below so the guard
+// runs on every matching request.
+// See the route classification in docs/security for the full audit.
+// ---------------------------------------------------------------------------
+
+app.use("/api/v1/projects/*", clerkDashboardAuth);
+app.use("/api/v1/organizations/*", clerkDashboardAuth);
+app.use("/api/v/projects/*", clerkDashboardAuth);
+app.use("/api/v/organizations/*", clerkDashboardAuth);
+
+// ---------------------------------------------------------------------------
 // API health check
 // ---------------------------------------------------------------------------
 
@@ -104,6 +121,7 @@ app.route("/api/v1/capability-tokens", capabilityTokensV2Router);
 app.route("/api/v1/claims", claimsV2Router);
 
 // Organizations: /api/v1/organizations/*
+// Dashboard-management route — protected by Clerk session auth below.
 app.route("/api/v1/organizations", organizationsV2Router);
 
 // --- API-key-auth routes ---
@@ -141,7 +159,8 @@ app.route("/v1", tagsRouter);
 app.route("/v1/analytics", analyticsPublicRouter);
 
 // ---------------------------------------------------------------------------
-// Dashboard routes at /api/v/* (no API key auth)
+// Dashboard-management routes at /api/v/* — protected by clerkDashboardAuth
+// (registered above). These are NOT reachable without a verified Clerk session.
 // ---------------------------------------------------------------------------
 
 import projectsV2Router from "./routes/v2/projects";

--- a/packages/api/src/lib/clerk-session.ts
+++ b/packages/api/src/lib/clerk-session.ts
@@ -1,0 +1,73 @@
+import { verifyToken } from "@clerk/backend";
+import type { Bindings } from "../types";
+
+/**
+ * Clerk session JWT claim shape (subset used by the dashboard).
+ * See {@link https://clerk.com/docs/backend-requests/handling-manual-jwt}.
+ */
+export interface ClerkSessionClaims {
+  /** User id (Clerk `sub` claim). */
+  sub?: string;
+  /** Active organization id (Clerk `o_id` claim) — present when an org is active. */
+  o_id?: string;
+  /** Legacy/fallback claim name for the active org id. */
+  org_id?: string;
+}
+
+/**
+ * Origins permitted as JWT `azp` (authorized party). Clerk recommends passing
+ * `authorizedParties` to defend against the subdomain-cookie-leaking attack.
+ */
+export const AUTHORIZED_PARTIES = [
+  "https://agentstate.app",
+  "http://localhost:3000",
+  "http://127.0.0.1:3000",
+];
+
+export interface VerifiedSession {
+  clerkUserId: string;
+  orgId: string;
+}
+
+/**
+ * Verify a Clerk session token and return the verified claims.
+ *
+ * Returns the user id (`sub`) and active org id (`o_id`, falling back to
+ * `org_id`, then to the default org). Throws on any verification failure so
+ * callers can translate to a single 401.
+ *
+ * This is a thin seam over `@clerk/backend`'s `verifyToken`, extracted so it
+ * can be replaced wholesale in tests (see `lib/clerk-session.ts` mock).
+ */
+export async function verifyDashboardSession(
+  token: string,
+  env: Pick<Bindings, "CLERK_SECRET_KEY" | "CLERK_JWT_KEY">,
+): Promise<VerifiedSession> {
+  const result = await verifyToken(token, {
+    secretKey: env.CLERK_SECRET_KEY,
+    authorizedParties: AUTHORIZED_PARTIES,
+    ...(env.CLERK_JWT_KEY ? { jwtKey: env.CLERK_JWT_KEY } : {}),
+  });
+
+  // Public export resolves to the payload directly; the internal
+  // {data, errors} shape is handled defensively in case of version drift.
+  if (
+    result &&
+    typeof result === "object" &&
+    "errors" in result &&
+    (result as { errors?: unknown }).errors
+  ) {
+    throw new Error("token verification failed");
+  }
+
+  const claims = result as unknown as ClerkSessionClaims;
+  const clerkUserId = claims.sub;
+  if (!clerkUserId) {
+    throw new Error("token missing sub claim");
+  }
+
+  return {
+    clerkUserId,
+    orgId: claims.o_id ?? claims.org_id ?? "default",
+  };
+}

--- a/packages/api/src/middleware/clerk-dashboard-auth.ts
+++ b/packages/api/src/middleware/clerk-dashboard-auth.ts
@@ -1,0 +1,80 @@
+import { createMiddleware } from "hono/factory";
+import { verifyDashboardSession } from "../lib/clerk-session";
+import { errorResponse } from "../lib/helpers";
+import type { Bindings, Variables } from "../types";
+
+/**
+ * Read the Clerk session token from (in priority order) the `__session` cookie,
+ * the `__clerk_db_jwt` dev cookie, or an `Authorization: Bearer` header.
+ */
+function readSessionToken(req: { header: (name: string) => string | undefined }): string | null {
+  // Explicit bearer token takes precedence (programmatic dashboard client).
+  const authHeader = req.header("Authorization");
+  if (authHeader?.startsWith("Bearer ")) {
+    const token = authHeader.slice(7).trim();
+    if (token) return token;
+  }
+
+  // Parse the Cookie header directly (works across Hono versions).
+  const cookieHeader = req.header("Cookie") ?? "";
+  const cookies = new Map<string, string>();
+  for (const part of cookieHeader.split(";")) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    cookies.set(trimmed.slice(0, eq).trim(), trimmed.slice(eq + 1).trim());
+  }
+
+  // Production: __session cookie (set by Clerk on the same origin).
+  const sessionCookie = cookies.get("__session");
+  if (sessionCookie) return sessionCookie;
+
+  // Dev: __clerk_db_jwt cookie (Clerk dev-browser session).
+  const devCookie = cookies.get("__clerk_db_jwt");
+  if (devCookie) return devCookie;
+
+  return null;
+}
+
+/**
+ * Auth middleware for dashboard-management routes.
+ *
+ * Verifies a Clerk session JWT and, on success, exposes the verified Clerk
+ * organization id (`orgId`) and user id (`clerkUserId`) on the Hono context.
+ *
+ * FAIL-CLOSED: if `CLERK_SECRET_KEY` is unset (config error) OR the token is
+ * missing/invalid/expired, the request is rejected with 401. No request ever
+ * reaches the dashboard-management handlers without a verified session.
+ */
+export const clerkDashboardAuth = createMiddleware<{ Bindings: Bindings; Variables: Variables }>(
+  async (c, next) => {
+    const secretKey = c.env.CLERK_SECRET_KEY;
+
+    // Config error — never let requests through without the ability to verify.
+    if (!secretKey) {
+      console.error(
+        "[security] CLERK_SECRET_KEY is not set. Dashboard-management routes are refusing all requests (fail-closed).",
+      );
+      return errorResponse(c, "UNAUTHORIZED", "Authentication required", 401);
+    }
+
+    const token = readSessionToken(c.req);
+    if (!token) {
+      return errorResponse(c, "UNAUTHORIZED", "Authentication required", 401);
+    }
+
+    let session: { clerkUserId: string; orgId: string };
+    try {
+      session = await verifyDashboardSession(token, c.env);
+    } catch {
+      // verifyToken rejects on invalid/expired/tampered tokens — fail-closed.
+      return errorResponse(c, "UNAUTHORIZED", "Authentication required", 401);
+    }
+
+    c.set("clerkUserId", session.clerkUserId);
+    c.set("orgId", session.orgId);
+
+    await next();
+  },
+);

--- a/packages/api/src/routes/analytics.ts
+++ b/packages/api/src/routes/analytics.ts
@@ -1,6 +1,7 @@
 import { and, eq, gte, sql } from "drizzle-orm";
 import { Hono } from "hono";
-import { conversations, messages } from "../db/schema";
+import { conversations, messages, organizations, projects } from "../db/schema";
+import { errorResponse } from "../lib/helpers";
 import type { Bindings, Variables } from "../types";
 
 // ---------------------------------------------------------------------------
@@ -24,7 +25,7 @@ function getTtlForRange(range: string): number {
 }
 
 // ---------------------------------------------------------------------------
-// GET /v1/projects/:id/analytics — Usage analytics for a project
+// GET /v1/projects/:id/analytics — Usage analytics for a project (org-scoped)
 // ---------------------------------------------------------------------------
 
 const RANGE_DAYS: Record<string, number> = { "7d": 7, "30d": 30, "90d": 90 };
@@ -32,6 +33,23 @@ const RANGE_DAYS: Record<string, number> = { "7d": 7, "30d": 30, "90d": 90 };
 app.get("/:id/analytics", async (c) => {
   const db = c.get("db");
   const projectId = c.req.param("id");
+
+  // Resolve the session Clerk org id to the internal org id, then verify the
+  // project belongs to that org.
+  const clerkOrgId = c.get("orgId");
+  const [org] = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.clerkOrgId, clerkOrgId ?? ""))
+    .limit(1);
+  const [project] = await db
+    .select({ orgId: projects.orgId })
+    .from(projects)
+    .where(eq(projects.id, projectId))
+    .limit(1);
+  if (!project || !org || project.orgId !== org.id) {
+    return errorResponse(c, "NOT_FOUND", "Project not found", 404);
+  }
 
   const rangeParam = c.req.query("range") ?? "30d";
   const days = RANGE_DAYS[rangeParam] ?? 30;

--- a/packages/api/src/routes/domains.ts
+++ b/packages/api/src/routes/domains.ts
@@ -1,5 +1,7 @@
+import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
+import { organizations, projects } from "../db/schema";
 import type { AppContext } from "../lib/helpers";
 import { errorResponse, parseJsonBody, validationError } from "../lib/helpers";
 import {
@@ -28,6 +30,37 @@ function handleDomainError(c: AppContext, e: unknown) {
   throw e;
 }
 
+/** Resolve the session's Clerk org id to the internal org id. */
+async function resolveSessionOrgId(c: AppContext): Promise<string | null> {
+  const db = c.get("db");
+  const clerkOrgId = c.get("orgId");
+  if (!clerkOrgId) return null;
+  const [org] = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.clerkOrgId, clerkOrgId))
+    .limit(1);
+  return org?.id ?? null;
+}
+
+/**
+ * Verify the requested project belongs to the authenticated Clerk org.
+ * Resolves the session Clerk org id to the internal org id before comparing.
+ */
+async function authorizeProjectOrg(c: AppContext, projectId: string): Promise<Response | null> {
+  const db = c.get("db");
+  const sessionInternalOrgId = await resolveSessionOrgId(c);
+  const [project] = await db
+    .select({ orgId: projects.orgId })
+    .from(projects)
+    .where(eq(projects.id, projectId))
+    .limit(1);
+  if (!project || !sessionInternalOrgId || project.orgId !== sessionInternalOrgId) {
+    return errorResponse(c, "NOT_FOUND", "Project not found", 404);
+  }
+  return null;
+}
+
 // Validation schemas
 
 const createDomainSchema = z.object({
@@ -39,11 +72,15 @@ const createDomainSchema = z.object({
 // ---------------------------------------------------------------------------
 
 /**
- * List all custom domains for a project.
+ * List all custom domains for a project (org-scoped).
  */
 router.get("/api/v1/projects/:projectId/domains", async (c) => {
   const db = c.get("db");
   const projectId = c.req.param("projectId");
+
+  const unauthorized = await authorizeProjectOrg(c, projectId);
+  if (unauthorized) return unauthorized;
+
   const domains = await listDomains(db, projectId);
   return c.json({ data: domains });
 });
@@ -53,14 +90,14 @@ router.get("/api/v1/projects/:projectId/domains", async (c) => {
 // ---------------------------------------------------------------------------
 
 /**
- * Add a custom domain to a project.
- *
- * Generates a verification token and returns instructions for
- * domain ownership verification via DNS TXT record, HTTP file, or meta tag.
+ * Add a custom domain to a project (org-scoped).
  */
 router.post("/api/v1/projects/:projectId/domains", async (c) => {
   const db = c.get("db");
   const projectId = c.req.param("projectId");
+
+  const unauthorized = await authorizeProjectOrg(c, projectId);
+  if (unauthorized) return unauthorized;
 
   const { body, error } = await parseJsonBody(c);
   if (error) return error;
@@ -89,12 +126,15 @@ router.post("/api/v1/projects/:projectId/domains", async (c) => {
 // ---------------------------------------------------------------------------
 
 /**
- * Get a specific custom domain.
+ * Get a specific custom domain (org-scoped).
  */
 router.get("/api/v1/projects/:projectId/domains/:domainId", async (c) => {
   const db = c.get("db");
   const projectId = c.req.param("projectId");
   const domainId = c.req.param("domainId");
+
+  const unauthorized = await authorizeProjectOrg(c, projectId);
+  if (unauthorized) return unauthorized;
 
   const domain = await getDomain(db, domainId, projectId);
   if (!domain) return errorResponse(c, "DOMAIN_NOT_FOUND", "Custom domain not found", 404);
@@ -107,12 +147,15 @@ router.get("/api/v1/projects/:projectId/domains/:domainId", async (c) => {
 // ---------------------------------------------------------------------------
 
 /**
- * Delete a custom domain from a project.
+ * Delete a custom domain from a project (org-scoped).
  */
 router.delete("/api/v1/projects/:projectId/domains/:domainId", async (c) => {
   const db = c.get("db");
   const projectId = c.req.param("projectId");
   const domainId = c.req.param("domainId");
+
+  const unauthorized = await authorizeProjectOrg(c, projectId);
+  if (unauthorized) return unauthorized;
 
   try {
     await deleteDomain(db, domainId, projectId);
@@ -127,15 +170,15 @@ router.delete("/api/v1/projects/:projectId/domains/:domainId", async (c) => {
 // ---------------------------------------------------------------------------
 
 /**
- * Trigger a verification check for a custom domain.
- *
- * Checks if the domain has been verified by looking up the verification token
- * at the expected locations (DNS TXT, HTTP file, or meta tag).
+ * Trigger a verification check for a custom domain (org-scoped).
  */
 router.post("/api/v1/projects/:projectId/domains/:domainId/verify", async (c) => {
   const db = c.get("db");
   const projectId = c.req.param("projectId");
   const domainId = c.req.param("domainId");
+
+  const unauthorized = await authorizeProjectOrg(c, projectId);
+  if (unauthorized) return unauthorized;
 
   try {
     const result = await verifyDomain(db, domainId, projectId);

--- a/packages/api/src/routes/projects.ts
+++ b/packages/api/src/routes/projects.ts
@@ -1,5 +1,13 @@
+import { eq } from "drizzle-orm";
 import { Hono } from "hono";
-import { errorResponse, parseJsonBody, parseLimitParam, validationError } from "../lib/helpers";
+import { organizations, projects } from "../db/schema";
+import {
+  type AppContext,
+  errorResponse,
+  parseJsonBody,
+  parseLimitParam,
+  validationError,
+} from "../lib/helpers";
 import { CreateApiKeySchema, CreateProjectSchema } from "../lib/validation";
 import { projectCreationRateLimit } from "../middleware/project-creation-rate-limit";
 import {
@@ -18,6 +26,45 @@ import type { Bindings, Variables } from "../types";
 const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
 // ---------------------------------------------------------------------------
+// Tenancy helpers
+// The Clerk session exposes the Clerk org id (o_id claim). Projects store the
+// internal org id (organizations.id). We resolve Clerk org id -> internal id
+// before comparing, so the check is correct across the two namespaces.
+// ---------------------------------------------------------------------------
+
+/** Resolve the session's Clerk org id to the internal org id. */
+async function resolveSessionOrgId(c: AppContext): Promise<string | null> {
+  const db = c.get("db");
+  const clerkOrgId = c.get("orgId");
+  if (!clerkOrgId) return null;
+  const [org] = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.clerkOrgId, clerkOrgId))
+    .limit(1);
+  return org?.id ?? null;
+}
+
+/**
+ * Verify a project belongs to the authenticated Clerk org.
+ * Returns null (authorized) or a 404 response. 404 (not 403) avoids leaking
+ * the existence of projects owned by other orgs.
+ */
+async function authorizeProjectOrg(c: AppContext, projectId: string): Promise<Response | null> {
+  const db = c.get("db");
+  const sessionInternalOrgId = await resolveSessionOrgId(c);
+  const [project] = await db
+    .select({ orgId: projects.orgId })
+    .from(projects)
+    .where(eq(projects.id, projectId))
+    .limit(1);
+  if (!project || !sessionInternalOrgId || project.orgId !== sessionInternalOrgId) {
+    return errorResponse(c, "NOT_FOUND", "Project not found", 404);
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
 // POST /v1/projects — Create project
 // ---------------------------------------------------------------------------
 
@@ -32,10 +79,13 @@ app.post("/", projectCreationRateLimit, async (c) => {
     return validationError(c, parsed.error);
   }
 
-  const { name, slug, org_id } = parsed.data;
+  // org_id is taken from the verified Clerk session, NOT the request body.
+  const name = parsed.data.name;
+  const slug = parsed.data.slug;
+  const sessionOrgId = c.get("orgId") ?? "default";
 
   try {
-    const result = await createProject(db, name, slug, org_id);
+    const result = await createProject(db, name, slug, sessionOrgId);
     return c.json(result, 201);
   } catch (err) {
     if (err instanceof Error && err.message.includes("already taken")) {
@@ -46,28 +96,30 @@ app.post("/", projectCreationRateLimit, async (c) => {
 });
 
 // ---------------------------------------------------------------------------
-// GET /v1/projects — List projects
+// GET /v1/projects — List projects (scoped to the authenticated org)
 // ---------------------------------------------------------------------------
 
 app.get("/", async (c) => {
   const db = c.get("db");
-  const orgIdParam = c.req.query("org_id");
+  // org_id is taken from the verified Clerk session, NOT the query string.
+  const sessionOrgId = c.get("orgId");
 
-  const data = await listProjects(db, orgIdParam);
+  const data = await listProjects(db, sessionOrgId);
   return c.json({ data });
 });
 
 // ---------------------------------------------------------------------------
-// GET /v1/projects/by-slug/:slug — Get project by slug
+// GET /v1/projects/by-slug/:slug — Get project by slug (org-scoped)
 // ---------------------------------------------------------------------------
 
 app.get("/by-slug/:slug", async (c) => {
   const db = c.get("db");
   const slug = c.req.param("slug");
+  const sessionInternalOrgId = await resolveSessionOrgId(c);
 
   const project = await getProjectBySlug(db, slug);
 
-  if (!project) {
+  if (!project || !sessionInternalOrgId || project.org_id !== sessionInternalOrgId) {
     return errorResponse(c, "NOT_FOUND", "Project not found", 404);
   }
 
@@ -81,6 +133,9 @@ app.get("/by-slug/:slug", async (c) => {
 app.get("/:id/conversations", async (c) => {
   const db = c.get("db");
   const projectId = c.req.param("id");
+
+  const unauthorized = await authorizeProjectOrg(c, projectId);
+  if (unauthorized) return unauthorized;
 
   const limit = parseLimitParam(c.req.query("limit"));
 
@@ -97,21 +152,25 @@ app.get("/:id/conversations/:convId/messages", async (c) => {
   const projectId = c.req.param("id");
   const convId = c.req.param("convId");
 
+  const unauthorized = await authorizeProjectOrg(c, projectId);
+  if (unauthorized) return unauthorized;
+
   const data = await listProjectMessages(db, projectId, convId);
   return c.json({ data });
 });
 
 // ---------------------------------------------------------------------------
-// GET /v1/projects/:id — Get project by ID
+// GET /v1/projects/:id — Get project by ID (org-scoped)
 // ---------------------------------------------------------------------------
 
 app.get("/:id", async (c) => {
   const db = c.get("db");
   const projectId = c.req.param("id");
+  const sessionInternalOrgId = await resolveSessionOrgId(c);
 
   const project = await getProjectById(db, projectId);
 
-  if (!project) {
+  if (!project || !sessionInternalOrgId || project.org_id !== sessionInternalOrgId) {
     return errorResponse(c, "NOT_FOUND", "Project not found", 404);
   }
 
@@ -125,6 +184,9 @@ app.get("/:id", async (c) => {
 app.post("/:id/keys", async (c) => {
   const db = c.get("db");
   const projectId = c.req.param("id");
+
+  const unauthorized = await authorizeProjectOrg(c, projectId);
+  if (unauthorized) return unauthorized;
 
   const { body, error } = await parseJsonBody(c);
   if (error) return error;
@@ -154,6 +216,9 @@ app.delete("/:id/keys/:keyId", async (c) => {
   const projectId = c.req.param("id");
   const keyId = c.req.param("keyId");
 
+  const unauthorized = await authorizeProjectOrg(c, projectId);
+  if (unauthorized) return unauthorized;
+
   await revokeApiKeyService(db, projectId, keyId);
 
   return c.body(null, 204);
@@ -166,6 +231,9 @@ app.delete("/:id/keys/:keyId", async (c) => {
 app.delete("/:id", async (c) => {
   const db = c.get("db");
   const projectId = c.req.param("id");
+
+  const unauthorized = await authorizeProjectOrg(c, projectId);
+  if (unauthorized) return unauthorized;
 
   try {
     await deleteProjectService(db, projectId);

--- a/packages/api/src/routes/v2/projects/crud.ts
+++ b/packages/api/src/routes/v2/projects/crud.ts
@@ -1,7 +1,9 @@
+import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
-import { DEFAULT_CLERK_ORG_ID } from "../../../lib/constants";
+import { organizations } from "../../../db/schema";
 import {
+  type AppContext,
   errorResponse,
   getCachedCount,
   notFound,
@@ -22,6 +24,19 @@ import type { Bindings, Variables } from "../../../types";
 
 const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
+// Resolve the session Clerk org id (o_id claim) to the internal org id.
+async function resolveSessionOrgId(c: AppContext): Promise<string | null> {
+  const db = c.get("db");
+  const clerkOrgId = c.get("orgId");
+  if (!clerkOrgId) return null;
+  const [org] = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.clerkOrgId, clerkOrgId))
+    .limit(1);
+  return org?.id ?? null;
+}
+
 // ---------------------------------------------------------------------------
 // Validation schemas
 // ---------------------------------------------------------------------------
@@ -29,7 +44,6 @@ const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 const CreateProjectSchema = z.object({
   name: z.string().min(1, "name is required"),
   slug: z.string().min(1, "slug is required").regex(SLUG_PATTERN),
-  org_id: z.string().optional(),
 });
 
 const UpdateProjectSchema = z
@@ -42,7 +56,7 @@ const UpdateProjectSchema = z
   });
 
 // ---------------------------------------------------------------------------
-// POST / — Create project
+// POST / — Create project (org_id from the verified Clerk session)
 // ---------------------------------------------------------------------------
 
 router.post("/", async (c) => {
@@ -50,8 +64,11 @@ router.post("/", async (c) => {
   if (error) return error;
   if (!data) return errorResponse(c, "BAD_REQUEST", "Validation failed", 400);
 
+  // Force org_id from the authenticated session; ignore any client-supplied value.
+  const sessionOrgId = c.get("orgId") ?? "default";
+
   try {
-    const result = await createProject(c.get("db"), data);
+    const result = await createProject(c.get("db"), { ...data, org_id: sessionOrgId });
     return c.json(result, 201);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -61,11 +78,12 @@ router.post("/", async (c) => {
 });
 
 // ---------------------------------------------------------------------------
-// GET / — List projects
+// GET / — List projects (scoped to the authenticated org)
 // ---------------------------------------------------------------------------
 
 router.get("/", async (c) => {
-  const clerkOrgId = c.req.query("org_id") ?? DEFAULT_CLERK_ORG_ID;
+  // org_id from the verified session — the query string is ignored.
+  const clerkOrgId = c.get("orgId") ?? "default";
   const limit = parseLimitParam(c.req.query("limit"));
   const cursor = c.req.query("cursor");
 
@@ -88,17 +106,19 @@ router.get("/", async (c) => {
 });
 
 // ---------------------------------------------------------------------------
-// GET /:id — Get project by ID
+// GET /:id — Get project by ID (org-scoped)
 // ---------------------------------------------------------------------------
 
 router.get("/:id", async (c) => {
   const project = await getProjectById(c.get("db"), c.req.param("id"));
-  if (!project) return notFound(c, "Project not found");
+  const sessionInternalOrgId = await resolveSessionOrgId(c);
+  if (!project || !sessionInternalOrgId || project.org_id !== sessionInternalOrgId)
+    return notFound(c, "Project not found");
   return c.json(project);
 });
 
 // ---------------------------------------------------------------------------
-// PATCH /:id — Update project
+// PATCH /:id — Update project (org-scoped)
 // ---------------------------------------------------------------------------
 
 router.patch("/:id", async (c) => {
@@ -107,6 +127,11 @@ router.patch("/:id", async (c) => {
   if (!data) return errorResponse(c, "BAD_REQUEST", "At least one field is required", 400);
 
   const id = c.req.param("id");
+  // Verify ownership before mutating.
+  const existing = await getProjectById(c.get("db"), id);
+  const sessionInternalOrgId = await resolveSessionOrgId(c);
+  if (!existing || !sessionInternalOrgId || existing.org_id !== sessionInternalOrgId)
+    return notFound(c, "Project not found");
 
   try {
     return c.json(
@@ -123,11 +148,16 @@ router.patch("/:id", async (c) => {
 });
 
 // ---------------------------------------------------------------------------
-// DELETE /:id — Delete project (cascade)
+// DELETE /:id — Delete project (cascade, org-scoped)
 // ---------------------------------------------------------------------------
 
 router.delete("/:id", async (c) => {
   const id = c.req.param("id");
+  // Verify ownership before deleting.
+  const existing = await getProjectById(c.get("db"), id);
+  const sessionInternalOrgId = await resolveSessionOrgId(c);
+  if (!existing || !sessionInternalOrgId || existing.org_id !== sessionInternalOrgId)
+    return notFound(c, "Project not found");
 
   try {
     await deleteProject(c.get("db"), id);

--- a/packages/api/src/routes/v2/projects/index.ts
+++ b/packages/api/src/routes/v2/projects/index.ts
@@ -1,29 +1,43 @@
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
-import { apiKeys, projects } from "../../../db/schema";
+import { apiKeys, organizations, projects } from "../../../db/schema";
 import { buildApiKey } from "../../../lib/api-key";
-import { notFound, parseJsonBody, validationError } from "../../../lib/helpers";
+import { type AppContext, notFound, parseJsonBody, validationError } from "../../../lib/helpers";
 import { CreateApiKeySchema } from "../../../lib/validation";
 import type { Bindings, Variables } from "../../../types";
 import crudRouter from "./crud";
 
 const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
+// Resolve the session Clerk org id to the internal org id.
+async function resolveSessionOrgId(c: AppContext): Promise<string | null> {
+  const db = c.get("db");
+  const clerkOrgId = c.get("orgId");
+  if (!clerkOrgId) return null;
+  const [org] = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.clerkOrgId, clerkOrgId))
+    .limit(1);
+  return org?.id ?? null;
+}
+
 // Mount CRUD router
 router.route("/", crudRouter);
 
 // ---------------------------------------------------------------------------
-// POST /:id/keys — Generate new API key
+// POST /:id/keys — Generate new API key (org-scoped)
 // ---------------------------------------------------------------------------
 
 router.post("/:id/keys", async (c) => {
   const db = c.get("db");
   const projectId = c.req.param("id");
 
-  // Verify the project exists
+  // Verify the project exists AND belongs to the authenticated org.
   const project = await db.select().from(projects).where(eq(projects.id, projectId)).get();
+  const sessionInternalOrgId = await resolveSessionOrgId(c);
 
-  if (!project) {
+  if (!project || !sessionInternalOrgId || project.orgId !== sessionInternalOrgId) {
     return notFound(c, "Project not found");
   }
 
@@ -51,13 +65,20 @@ router.post("/:id/keys", async (c) => {
 });
 
 // ---------------------------------------------------------------------------
-// DELETE /:id/keys/:keyId — Revoke API key
+// DELETE /:id/keys/:keyId — Revoke API key (org-scoped)
 // ---------------------------------------------------------------------------
 
 router.delete("/:id/keys/:keyId", async (c) => {
   const db = c.get("db");
   const projectId = c.req.param("id");
   const keyId = c.req.param("keyId");
+
+  // Verify the project belongs to the authenticated org before revoking.
+  const project = await db.select().from(projects).where(eq(projects.id, projectId)).get();
+  const sessionInternalOrgId = await resolveSessionOrgId(c);
+  if (!project || !sessionInternalOrgId || project.orgId !== sessionInternalOrgId) {
+    return notFound(c, "Project not found");
+  }
 
   await db
     .update(apiKeys)

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -8,6 +8,13 @@ export type Bindings = {
   RATE_LIMITS?: KVNamespace; // Optional KV namespace for sliding window rate limiting
   VECTORIZE_INDEX?: VectorizeIndex; // Optional Vectorize index for semantic search
   STATE_STREAM_HUB?: DurableObjectNamespace; // Optional Durable Object namespace for state watch SSE
+  /**
+   * Clerk secret key used to verify dashboard session JWTs.
+   * Required for dashboard-management routes — if unset, those routes fail-closed (401).
+   */
+  CLERK_SECRET_KEY?: string;
+  /** Optional Clerk JWT public key (PEM) for networkless session verification. */
+  CLERK_JWT_KEY?: string;
 };
 
 export type Variables = {
@@ -18,4 +25,8 @@ export type Variables = {
   apiKeyHash: string;
   authType: "api_key" | "capability_token";
   capabilityScopes: string[];
+  /** Clerk active organization id (o_id claim) — set by clerkDashboardAuth on dashboard-management routes. */
+  orgId?: string;
+  /** Clerk user id (sub claim) — set by clerkDashboardAuth on dashboard-management routes. */
+  clerkUserId?: string;
 };

--- a/packages/api/test/analytics.test.ts
+++ b/packages/api/test/analytics.test.ts
@@ -1,16 +1,40 @@
 import { SELF } from "cloudflare:test";
 import { beforeAll, describe, expect, it } from "vitest";
+import { sessionCookie, signTestSessionToken } from "./clerk-jwt";
 import { applyMigrations, authHeaders, seedProject, TEST_PROJECT_ID } from "./setup";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
+// Dashboard-management routes (including analytics) require a verified Clerk
+// session. The seeded project lives under clerk_org_id = "clerk_test_org_001".
+const SESSION_ORG_ID = "clerk_test_org_001";
+
+let dashboardCookie: string;
+
+beforeAll(async () => {
+  const token = await signTestSessionToken({ orgId: SESSION_ORG_ID });
+  dashboardCookie = sessionCookie(token);
+});
+
+/** Headers carrying a valid dashboard (Clerk) session. */
+function dashboardHeaders(extra: Record<string, string> = {}): Record<string, string> {
+  return { Cookie: dashboardCookie, ...extra };
+}
+
 async function createConversation(body: Record<string, unknown> = {}) {
   return SELF.fetch("http://localhost/v1/conversations", {
     method: "POST",
     headers: authHeaders(),
     body: JSON.stringify(body),
+  });
+}
+
+/** Fetch the analytics endpoint with a valid dashboard session. */
+function fetchAnalytics(suffix = ""): Promise<Response> {
+  return SELF.fetch(`http://localhost/api/v1/projects/${TEST_PROJECT_ID}/analytics${suffix}`, {
+    headers: dashboardHeaders(),
   });
 }
 
@@ -49,7 +73,7 @@ describe("Analytics", () => {
 
   describe("GET /api/v1/projects/:id/analytics", () => {
     it("returns the correct response shape", async () => {
-      const res = await SELF.fetch(`http://localhost/api/v1/projects/${TEST_PROJECT_ID}/analytics`);
+      const res = await fetchAnalytics();
       expect(res.status).toBe(200);
 
       const body = await res.json<AnalyticsResponse>();
@@ -66,12 +90,8 @@ describe("Analytics", () => {
 
     it("defaults to 30d range", async () => {
       // Both explicit ?range=30d and no range param should return the same result
-      const resDefault = await SELF.fetch(
-        `http://localhost/api/v1/projects/${TEST_PROJECT_ID}/analytics`,
-      );
-      const resExplicit = await SELF.fetch(
-        `http://localhost/api/v1/projects/${TEST_PROJECT_ID}/analytics?range=30d`,
-      );
+      const resDefault = await fetchAnalytics();
+      const resExplicit = await fetchAnalytics("?range=30d");
 
       expect(resDefault.status).toBe(200);
       expect(resExplicit.status).toBe(200);
@@ -84,9 +104,7 @@ describe("Analytics", () => {
     });
 
     it("supports 7d range", async () => {
-      const res = await SELF.fetch(
-        `http://localhost/api/v1/projects/${TEST_PROJECT_ID}/analytics?range=7d`,
-      );
+      const res = await fetchAnalytics("?range=7d");
       expect(res.status).toBe(200);
 
       const body = await res.json<AnalyticsResponse>();
@@ -96,9 +114,7 @@ describe("Analytics", () => {
 
     it("counts match actual data after creating conversations", async () => {
       // Record baseline
-      const baselineRes = await SELF.fetch(
-        `http://localhost/api/v1/projects/${TEST_PROJECT_ID}/analytics`,
-      );
+      const baselineRes = await fetchAnalytics();
       const baseline = await baselineRes.json<AnalyticsResponse>();
       const baseConvs = baseline.summary.total_conversations;
       const baseMsgs = baseline.summary.total_messages;
@@ -114,9 +130,7 @@ describe("Analytics", () => {
       });
 
       // Verify counts increased
-      const afterRes = await SELF.fetch(
-        `http://localhost/api/v1/projects/${TEST_PROJECT_ID}/analytics`,
-      );
+      const afterRes = await fetchAnalytics();
       const after = await afterRes.json<AnalyticsResponse>();
 
       expect(after.summary.total_conversations).toBe(baseConvs + 1);
@@ -129,7 +143,7 @@ describe("Analytics", () => {
       expect(createRes.status).toBe(201);
       const created = await createRes.json<{ id: string }>();
 
-      const res = await SELF.fetch(`http://localhost/api/v1/projects/${TEST_PROJECT_ID}/analytics`);
+      const res = await fetchAnalytics();
       const body = await res.json<AnalyticsResponse>();
 
       const recentIds = body.recent_conversations.map((c) => c.id);
@@ -137,7 +151,7 @@ describe("Analytics", () => {
     });
 
     it("reports active_api_keys count", async () => {
-      const res = await SELF.fetch(`http://localhost/api/v1/projects/${TEST_PROJECT_ID}/analytics`);
+      const res = await fetchAnalytics();
       const body = await res.json<AnalyticsResponse>();
 
       // The seed creates one active API key

--- a/packages/api/test/clerk-dashboard-auth.test.ts
+++ b/packages/api/test/clerk-dashboard-auth.test.ts
@@ -1,0 +1,243 @@
+import { env, SELF } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+import { sessionCookie, signTestSessionToken } from "./clerk-jwt";
+import { applyMigrations, seedProject, TEST_ORG_ID } from "./setup";
+
+// The test seed binds the org row to clerk_org_id = "clerk_test_org_001".
+// Our signed session tokens default to o_id = "clerk_test_org_001" so they
+// match the seeded org and its project.
+const SESSION_ORG_ID = "clerk_test_org_001";
+const OTHER_ORG_ID = "clerk_other_org_999";
+
+const JSON_HEADERS = { "Content-Type": "application/json" };
+
+describe("Dashboard-management auth (clerkDashboardAuth)", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await seedProject();
+  });
+
+  // -------------------------------------------------------------------------
+  // Fail-closed / unauthenticated
+  // -------------------------------------------------------------------------
+
+  describe("unauthenticated requests are rejected", () => {
+    it("GET /api/v1/projects without a session returns 401", async () => {
+      const res = await SELF.fetch("http://localhost/api/v1/projects");
+      expect(res.status).toBe(401);
+      const body = await res.json<{ error: { code: string } }>();
+      expect(body.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("POST /api/v1/projects without a session returns 401 (no project created)", async () => {
+      const before = await env.DB.prepare("SELECT COUNT(*) as n FROM projects").first<{
+        n: number;
+      }>();
+      const res = await SELF.fetch("http://localhost/api/v1/projects", {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ name: "Should Not Exist", slug: "should-not-exist" }),
+      });
+      expect(res.status).toBe(401);
+      const after = await env.DB.prepare("SELECT COUNT(*) as n FROM projects").first<{
+        n: number;
+      }>();
+      expect(after?.n).toBe(before?.n);
+    });
+
+    it("DELETE /api/v1/projects/:id without a session returns 401", async () => {
+      const res = await SELF.fetch(`http://localhost/api/v1/projects/${"proj_test_000000000001"}`, {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("POST /api/v1/projects/:id/keys without a session returns 401", async () => {
+      const res = await SELF.fetch("http://localhost/api/v1/projects/proj_test_000000000001/keys", {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ name: "x" }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("GET /api/v1/projects/:id/analytics without a session returns 401", async () => {
+      const res = await SELF.fetch(
+        "http://localhost/api/v1/projects/proj_test_000000000001/analytics",
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("GET /api/v1/projects/:id/domains without a session returns 401", async () => {
+      const res = await SELF.fetch(
+        "http://localhost/api/v1/projects/proj_test_000000000001/domains",
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("GET /api/v/organizations/:id without a session returns 401", async () => {
+      const res = await SELF.fetch("http://localhost/api/v/organizations/some-org");
+      expect(res.status).toBe(401);
+    });
+
+    it("GET /api/v/projects without a session returns 401", async () => {
+      const res = await SELF.fetch("http://localhost/api/v/projects");
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects a malformed/unsigned bearer token", async () => {
+      const res = await SELF.fetch("http://localhost/api/v1/projects", {
+        headers: { Authorization: "Bearer not-a-real-jwt" },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects an expired session token", async () => {
+      const token = await signTestSessionToken({ expiresInSec: -10 });
+      const res = await SELF.fetch("http://localhost/api/v1/projects", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Authenticated + org-scoped
+  // -------------------------------------------------------------------------
+
+  describe("authenticated requests are scoped to the session org", () => {
+    it("GET /api/v1/projects returns 200 with a valid session cookie", async () => {
+      const token = await signTestSessionToken({ orgId: SESSION_ORG_ID });
+      const res = await SELF.fetch("http://localhost/api/v1/projects", {
+        headers: { Cookie: sessionCookie(token) },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json<{ data: Array<{ org_id: string }> }>();
+      expect(Array.isArray(body.data)).toBe(true);
+      // Every returned project must belong to the session's org.
+      for (const p of body.data) {
+        expect(p.org_id).toBeTruthy();
+      }
+    });
+
+    it("accepts the token via Authorization: Bearer header too", async () => {
+      const token = await signTestSessionToken({ orgId: SESSION_ORG_ID });
+      const res = await SELF.fetch("http://localhost/api/v1/projects", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("POST /api/v1/projects scopes the new project to the session org (ignores body org_id)", async () => {
+      const token = await signTestSessionToken({ orgId: SESSION_ORG_ID });
+      const slug = `authed-create-${Date.now()}`;
+      // Try to spoof a different org_id in the body — must be ignored.
+      const res = await SELF.fetch("http://localhost/api/v1/projects", {
+        method: "POST",
+        headers: { ...JSON_HEADERS, Cookie: sessionCookie(token) },
+        body: JSON.stringify({ name: "Authed Create", slug, org_id: OTHER_ORG_ID }),
+      });
+      expect(res.status).toBe(201);
+      const body = await res.json<{ project: { id: string; org_id: string } }>();
+      expect(body.project.id).toBeTruthy();
+
+      // The created project must be owned by the session org, not the spoofed one.
+      const row = await env.DB.prepare("SELECT org_id FROM projects WHERE id = ?")
+        .bind(body.project.id)
+        .first<{ org_id: string }>();
+      expect(row?.org_id).toBe(TEST_ORG_ID);
+    });
+
+    it("GET /api/v1/projects/:id returns 404 for a project in another org", async () => {
+      // Create a project owned by a different org directly in the DB.
+      const otherProjectId = `proj_other_${Date.now()}`;
+      const now = Date.now();
+      // Ensure the other org exists.
+      await env.DB.prepare(
+        "INSERT OR IGNORE INTO organizations (id, clerk_org_id, name, created_at) VALUES (?, ?, ?, ?)",
+      )
+        .bind(`org_other_${Date.now()}`, OTHER_ORG_ID, "Other Org", now)
+        .run();
+      const orgRow = await env.DB.prepare("SELECT id FROM organizations WHERE clerk_org_id = ?")
+        .bind(OTHER_ORG_ID)
+        .first<{ id: string }>();
+      await env.DB.prepare(
+        "INSERT INTO projects (id, org_id, name, slug, created_at) VALUES (?, ?, ?, ?, ?)",
+      )
+        .bind(otherProjectId, orgRow?.id, "Other Project", `other-${Date.now()}`, now)
+        .run();
+
+      // Authenticated as SESSION_ORG_ID — must NOT see the other org's project.
+      const token = await signTestSessionToken({ orgId: SESSION_ORG_ID });
+      const res = await SELF.fetch(`http://localhost/api/v1/projects/${otherProjectId}`, {
+        headers: { Cookie: sessionCookie(token) },
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("DELETE /api/v1/projects/:id cannot delete another org's project", async () => {
+      const otherProjectId = `proj_del_other_${Date.now()}`;
+      const now = Date.now();
+      const orgRow = await env.DB.prepare("SELECT id FROM organizations WHERE clerk_org_id = ?")
+        .bind(OTHER_ORG_ID)
+        .first<{ id: string }>();
+      await env.DB.prepare(
+        "INSERT INTO projects (id, org_id, name, slug, created_at) VALUES (?, ?, ?, ?, ?)",
+      )
+        .bind(otherProjectId, orgRow?.id, "Other Del", `del-other-${Date.now()}`, now)
+        .run();
+
+      const token = await signTestSessionToken({ orgId: SESSION_ORG_ID });
+      const res = await SELF.fetch(`http://localhost/api/v1/projects/${otherProjectId}`, {
+        method: "DELETE",
+        headers: { Cookie: sessionCookie(token) },
+      });
+      expect(res.status).toBe(404);
+
+      // The project must still exist.
+      const row = await env.DB.prepare("SELECT id FROM projects WHERE id = ?")
+        .bind(otherProjectId)
+        .first<{ id: string }>();
+      expect(row?.id).toBe(otherProjectId);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Intentionally-public routes remain open
+  // -------------------------------------------------------------------------
+
+  describe("public routes are unaffected", () => {
+    it("GET /api health returns 200 unauthenticated", async () => {
+      const res = await SELF.fetch("http://localhost/api");
+      expect(res.status).toBe(200);
+    });
+
+    it("GET /llms.txt returns 200 unauthenticated", async () => {
+      const res = await SELF.fetch("http://localhost/llms.txt");
+      expect(res.status).toBe(200);
+    });
+
+    it("GET /agents.md returns 200 unauthenticated", async () => {
+      const res = await SELF.fetch("http://localhost/agents.md");
+      expect(res.status).toBe(200);
+    });
+
+    it("GET /openapi.json returns 200 unauthenticated", async () => {
+      const res = await SELF.fetch("http://localhost/openapi.json");
+      expect(res.status).toBe(200);
+    });
+
+    it("GET /verify-domain/:token returns 200 unauthenticated", async () => {
+      const res = await SELF.fetch(
+        "http://localhost/verify-domain/agentstate-verify-abc123def456ghij",
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("API-key conversations route still requires an API key (not Clerk)", async () => {
+      // No API key and no Clerk session -> 401 from apiKeyAuth.
+      const res = await SELF.fetch("http://localhost/api/v1/conversations");
+      expect(res.status).toBe(401);
+    });
+  });
+});

--- a/packages/api/test/clerk-jwt.ts
+++ b/packages/api/test/clerk-jwt.ts
@@ -1,0 +1,88 @@
+// ---------------------------------------------------------------------------
+// Test-only Clerk session JWT signer.
+// Signs RS256 JWTs with the private key matching the public key in
+// wrangler.test.jsonc (CLERK_JWT_KEY). Lets tests exercise the real
+// verifyToken path networkless, without calling Clerk or mocking modules.
+// ---------------------------------------------------------------------------
+
+// Private RSA JWK matching CLERK_JWT_KEY in wrangler.test.jsonc.
+const TEST_PRIVATE_JWK = {
+  kty: "RSA" as const,
+  n: "txMkYQsRsixcwsh57x9uONb95zUj4-HTeWW1ZEF6FV087NEcN7AWoE3AOiiz5is8y1hc4l-1cF6Pniu8yglT8NWd3ESTYx9z0xs_KaXICsAl_H1YGKn_2XQVeUbNK7hmOHIJGy-2zJ7khBAqBkGXoDNmBSBhSBKYhjVCT6JAjKFIDqa5NBjfD4VLZJZFtQcKM0ep1eesDeQO71RtxDh7JhG7aG45KJmEsIQc75gbCkZGTaTX_2Emx2YxlASbKnbL0DTbnHiPnYoxxDKE_jotxwu4rMQkE3nr1iW0ycWIR4bhFVoWHnCClfjHhVtNScTKnkBFoICpXdzQFs1OIuwg3Q",
+  e: "AQAB",
+  d: "Dv7ZpZGX9Q7sAzATcsTRjQTT08l3GN5MFDRtR5q9t_xvi4XzqH5l1WLA-n06gmwrZOGQ7CGYSu29QvYErEzYIWYx8b3z5PQ0KHLMeT9ryQZPpjnodSQO7EjKoyjWOzz1sde_YLNyEZp4j8uuJt3eYFV4HLaNWVoH6xhM3UPQ7ePP1k2ON8TLLfE_Q4sOGCM474dluUJelUNJ0lWc8UTudeUbcQedOl00kOPXyXFwRZ3zGKh00YSg5JNhKXNl57JWS_ZpanZgxD_E8CqCmD6gv2fct5m3WFfMbKpRClhz4xfbWDE3iV8hi8KZDkqNCBmpj5ihr6XDqfbUWWHs9VPbaQ",
+  p: "-24yqZ4BCT4M9836AHMB20Q7h0KUzKJWK9kCAU-gDM4iwp01Sn_GswiEcGKwS8drq3UmFaqfIUWpMNadYrmc9HQpgXVPvXxg_7v3moHvJffeRfuS3_3Nvx9I9cVMZDHTu-VLxmq5qHXTciCfbf0DLbYcJnUoiD2Rf_A-FQel-7k",
+  q: "umbp1iUe4j_6PwEnJqr_Pxq3A3h7bZVgPIfQSk6-ffRAcN1rz_fuaBVi6TOVrKjxLvq1rrA0YXMuGT2IkfHyOQNM8VBomSicVAqqLbIEMD6E0BjsfBbDNzg3RT05SS1ITOgU-A6L4ENHLIVoaZ2IXb3wV3H7fXQf0kjXyC2diEU",
+  dp: "rgSsPeck0m_G6-_8uzjeLRNBnDFB6Yvl1j1A_QVOQe6d8lJ6YtCjBqC7gUlcuWYRqD7RmCdaMd4T5sBzd7P95NdNLtOx1_Tw8a74BVEu4vl2NruTAUKZl1Eg3zGp2KL_58kgs_iD_QtnyFK55Zc7DvU-8IMgBYOPY5w0a7u6bsk",
+  dq: "ZcoFL5edwddGBFnQ02DVedRQ1GhanoDPyL4xlCJkC8vx1LBVS4AMhHIJTWeJ-HtZGVp3FCnMsNqA9e-QQIJqz49p2O0b8Wcn1wzr2YA4oU_CnxC9MxYLDIB6Tikcu0UrEjQ6HytyXsjeeQVw-xu3d9ldAaOQvfVH20FD9GBUgjE",
+  qi: "lBlGElGdy1O79ywGKL1t2bfJtVmiQr7ELIo3e_haysAoHU4Jt_paM624xiAZpPsGD8YWdK4yZgzr8EItQ7QpJEviroLcuwQow-PWuocL_6_GMkZqnuuaIIxzS2aZnggo2JfZkYeypRJztXZraV3jZSWbTRwEdyEDiBkDc-GDt48",
+};
+
+function base64Url(input: ArrayBuffer | Uint8Array): string {
+  const bytes = input instanceof Uint8Array ? input : new Uint8Array(input);
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function strToBytes(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+export interface TestSessionOptions {
+  /** Clerk user id (sub claim). */
+  userId?: string;
+  /** Clerk active org id (o_id claim). Defaults to a stable test org. */
+  orgId?: string;
+  /** Authorized party (azp). Defaults to the dashboard origin. */
+  azp?: string;
+  /** Seconds until expiry. Defaults to 3600. */
+  expiresInSec?: number;
+}
+
+/**
+ * Sign a Clerk-shaped session JWT valid against CLERK_JWT_KEY in the test env.
+ */
+export async function signTestSessionToken(opts: TestSessionOptions = {}): Promise<string> {
+  const userId = opts.userId ?? "user_test_001";
+  const orgId = opts.orgId ?? "clerk_test_org_001";
+  const azp = opts.azp ?? "http://localhost:3000";
+  const expiresInSec = opts.expiresInSec ?? 3600;
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "RS256", typ: "JWT" };
+  const payload = {
+    iss: "https://test.clerk.accounts.dev",
+    sub: userId,
+    aud: "test-app",
+    azp,
+    iat: now,
+    nbf: now,
+    exp: now + expiresInSec,
+    sid: "sess_test_001",
+    // Clerk org claims
+    o_id: orgId,
+    o_slug: "test-org",
+    o_role: "org:admin",
+  };
+
+  const encHeader = base64Url(strToBytes(JSON.stringify(header)));
+  const encPayload = base64Url(strToBytes(JSON.stringify(payload)));
+  const signingInput = `${encHeader}.${encPayload}`;
+
+  const key = await crypto.subtle.importKey(
+    "jwk",
+    TEST_PRIVATE_JWK,
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", key, strToBytes(signingInput));
+
+  return `${signingInput}.${base64Url(signature)}`;
+}
+
+/** Build a Cookie header value carrying a __session token. */
+export function sessionCookie(token: string): string {
+  return `__session=${token}`;
+}

--- a/packages/api/test/projects.test.ts
+++ b/packages/api/test/projects.test.ts
@@ -1,6 +1,24 @@
 import { env, SELF } from "cloudflare:test";
 import { beforeAll, describe, expect, it } from "vitest";
+import { sessionCookie, signTestSessionToken } from "./clerk-jwt";
 import { applyMigrations, seedProject } from "./setup";
+
+// Dashboard-management routes now require a verified Clerk session. Tests sign
+// a session JWT (matching CLERK_JWT_KEY in the test env) and send it as the
+// __session cookie. The session org matches the seeded org.
+const SESSION_ORG_ID = "clerk_test_org_001";
+
+let authCookie: string;
+
+beforeAll(async () => {
+  const token = await signTestSessionToken({ orgId: SESSION_ORG_ID });
+  authCookie = sessionCookie(token);
+});
+
+/** Headers that carry a valid dashboard (Clerk) session. */
+function dashboardHeaders(extra: Record<string, string> = {}): Record<string, string> {
+  return { Cookie: authCookie, ...extra };
+}
 
 const TEST_PROJECT_CREATION_RATE_LIMIT = 10000;
 
@@ -75,7 +93,7 @@ interface ProjectListItem extends Project {
 async function createProject(body: Record<string, unknown>) {
   return SELF.fetch("http://localhost/api/v1/projects", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: dashboardHeaders({ "Content-Type": "application/json" }),
     body: JSON.stringify(body),
   });
 }
@@ -142,7 +160,9 @@ describe("Projects (/api/v1/projects)", () => {
       expect(body.error.code).toBe("CONFLICT");
     });
 
-    it("allows the same slug in different orgs", async () => {
+    it("rejects a duplicate slug in the same session org (org_id body value ignored)", async () => {
+      // org_id is now taken from the verified session, so two creates with the
+      // same slug land in the same org and the second must conflict.
       const slug = `shared-slug-${Date.now()}`;
       const first = await createProject({ name: "Org A App", slug, org_id: `org-a-${Date.now()}` });
       expect(first.status).toBe(201);
@@ -152,7 +172,7 @@ describe("Projects (/api/v1/projects)", () => {
         slug,
         org_id: `org-b-${Date.now()}`,
       });
-      expect(second.status).toBe(201);
+      expect(second.status).toBe(409);
     });
 
     it("returns 400 when name is missing", async () => {
@@ -184,7 +204,7 @@ describe("Projects (/api/v1/projects)", () => {
     it("returns 400 for invalid JSON body", async () => {
       const res = await SELF.fetch("http://localhost/api/v1/projects", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: dashboardHeaders({ "Content-Type": "application/json" }),
         body: "not-json",
       });
       expect(res.status).toBe(400);
@@ -262,11 +282,13 @@ describe("Projects (/api/v1/projects)", () => {
   // -------------------------------------------------------------------------
 
   describe("GET /api/v1/projects", () => {
-    it("lists projects for the default org", async () => {
+    it("lists projects for the session org", async () => {
       // Ensure at least one exists
       await createProject({ name: "List Test", slug: `list-test-${Date.now()}` });
 
-      const res = await SELF.fetch("http://localhost/api/v1/projects");
+      const res = await SELF.fetch("http://localhost/api/v1/projects", {
+        headers: dashboardHeaders(),
+      });
       expect(res.status).toBe(200);
 
       const body = await res.json<{ data: ProjectListItem[] }>();
@@ -280,7 +302,9 @@ describe("Projects (/api/v1/projects)", () => {
       const created = await createRes.json<{ project: Project; api_key: ApiKeyCreated }>();
       const projectId = created.project.id;
 
-      const res = await SELF.fetch("http://localhost/api/v1/projects");
+      const res = await SELF.fetch("http://localhost/api/v1/projects", {
+        headers: dashboardHeaders(),
+      });
       const body = await res.json<{ data: ProjectListItem[] }>();
 
       const found = body.data.find((p) => p.id === projectId);
@@ -289,27 +313,31 @@ describe("Projects (/api/v1/projects)", () => {
       expect(found!.key_count).toBeGreaterThanOrEqual(1);
     });
 
-    it("returns empty list for an org with no projects", async () => {
-      const res = await SELF.fetch("http://localhost/api/v1/projects?org_id=nonexistent-org-999");
+    it("ignores the org_id query param (session org is authoritative)", async () => {
+      // The session is scoped to SESSION_ORG_ID; passing a bogus org_id must NOT
+      // change which projects are returned.
+      const res = await SELF.fetch("http://localhost/api/v1/projects?org_id=nonexistent-org-999", {
+        headers: dashboardHeaders(),
+      });
       expect(res.status).toBe(200);
 
       const body = await res.json<{ data: ProjectListItem[] }>();
-      expect(body.data).toEqual([]);
+      // The session org has seeded projects, so this returns those — not empty.
+      expect(Array.isArray(body.data)).toBe(true);
     });
 
-    it("filters by org_id query param", async () => {
-      const orgId = `filter-org-${Date.now()}`;
-      await createProject({ name: "Filter Test", slug: `filter-${Date.now()}`, org_id: orgId });
+    it("scopes results to the session org", async () => {
+      await createProject({ name: "Filter Test", slug: `filter-${Date.now()}` });
 
-      const res = await SELF.fetch(
-        `http://localhost/api/v1/projects?org_id=${encodeURIComponent(orgId)}`,
-      );
+      const res = await SELF.fetch("http://localhost/api/v1/projects", {
+        headers: dashboardHeaders(),
+      });
       expect(res.status).toBe(200);
 
       const body = await res.json<{ data: ProjectListItem[] }>();
       expect(body.data.length).toBeGreaterThanOrEqual(1);
       for (const p of body.data) {
-        // All returned projects should belong to the queried org
+        // All returned projects belong to the session org (org rows resolve to TEST_ORG_ID).
         expect(p.org_id).toBeTruthy();
       }
     });
@@ -328,7 +356,9 @@ describe("Projects (/api/v1/projects)", () => {
       const created = await createRes.json<{ project: Project; api_key: ApiKeyCreated }>();
       const projectId = created.project.id;
 
-      const res = await SELF.fetch(`http://localhost/api/v1/projects/${projectId}`);
+      const res = await SELF.fetch(`http://localhost/api/v1/projects/${projectId}`, {
+        headers: dashboardHeaders(),
+      });
       expect(res.status).toBe(200);
 
       const body = await res.json<ProjectWithKeys>();
@@ -345,7 +375,9 @@ describe("Projects (/api/v1/projects)", () => {
     });
 
     it("returns 404 for a non-existent project", async () => {
-      const res = await SELF.fetch("http://localhost/api/v1/projects/nonexistent_id_xyz");
+      const res = await SELF.fetch("http://localhost/api/v1/projects/nonexistent_id_xyz", {
+        headers: dashboardHeaders(),
+      });
       expect(res.status).toBe(404);
 
       const body = await res.json<{ error: { code: string } }>();
@@ -368,7 +400,7 @@ describe("Projects (/api/v1/projects)", () => {
 
       const res = await SELF.fetch(`http://localhost/api/v1/projects/${projectId}/keys`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: dashboardHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify({ name: "Production Key" }),
       });
       expect(res.status).toBe(201);
@@ -390,7 +422,7 @@ describe("Projects (/api/v1/projects)", () => {
 
       const res = await SELF.fetch(`http://localhost/api/v1/projects/${created.project.id}/keys`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: dashboardHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify({}),
       });
       expect(res.status).toBe(400);
@@ -399,7 +431,7 @@ describe("Projects (/api/v1/projects)", () => {
     it("returns 404 for a non-existent project", async () => {
       const res = await SELF.fetch("http://localhost/api/v1/projects/nonexistent_xyz/keys", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: dashboardHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify({ name: "Key" }),
       });
       expect(res.status).toBe(404);
@@ -423,7 +455,7 @@ describe("Projects (/api/v1/projects)", () => {
       // Generate a second key to revoke (keeps one active)
       const keyRes = await SELF.fetch(`http://localhost/api/v1/projects/${projectId}/keys`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: dashboardHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify({ name: "To Revoke" }),
       });
       const newKey = await keyRes.json<ApiKeyCreated>();
@@ -431,12 +463,14 @@ describe("Projects (/api/v1/projects)", () => {
       // Revoke it
       const revokeRes = await SELF.fetch(
         `http://localhost/api/v1/projects/${projectId}/keys/${newKey.id}`,
-        { method: "DELETE" },
+        { method: "DELETE", headers: dashboardHeaders() },
       );
       expect(revokeRes.status).toBe(204);
 
       // Verify revocation visible in project detail
-      const detailRes = await SELF.fetch(`http://localhost/api/v1/projects/${projectId}`);
+      const detailRes = await SELF.fetch(`http://localhost/api/v1/projects/${projectId}`, {
+        headers: dashboardHeaders(),
+      });
       const detail = await detailRes.json<ProjectWithKeys>();
 
       const revokedKey = detail.api_keys.find((k) => k.id === newKey.id);
@@ -453,7 +487,7 @@ describe("Projects (/api/v1/projects)", () => {
 
       const res = await SELF.fetch(
         `http://localhost/api/v1/projects/${created.project.id}/keys/nonexistent_key_id`,
-        { method: "DELETE" },
+        { method: "DELETE", headers: dashboardHeaders() },
       );
       expect(res.status).toBe(204);
     });
@@ -470,7 +504,9 @@ describe("Projects (/api/v1/projects)", () => {
       const created = await createRes.json<{ project: Project; api_key: ApiKeyCreated }>();
       const projectId = created.project.id;
 
-      const res = await SELF.fetch(`http://localhost/api/v1/projects/by-slug/${slug}`);
+      const res = await SELF.fetch(`http://localhost/api/v1/projects/by-slug/${slug}`, {
+        headers: dashboardHeaders(),
+      });
       expect(res.status).toBe(200);
 
       const body = await res.json<ProjectWithKeys>();
@@ -489,6 +525,7 @@ describe("Projects (/api/v1/projects)", () => {
     it("returns 404 for an unknown slug", async () => {
       const res = await SELF.fetch(
         "http://localhost/api/v1/projects/by-slug/slug-that-does-not-exist-999",
+        { headers: dashboardHeaders() },
       );
       expect(res.status).toBe(404);
 
@@ -536,7 +573,9 @@ describe("Projects (/api/v1/projects)", () => {
     it("returns an empty list for a project with no conversations", async () => {
       const { projectId } = await createProjectWithKey("empty");
 
-      const res = await SELF.fetch(`http://localhost/api/v1/projects/${projectId}/conversations`);
+      const res = await SELF.fetch(`http://localhost/api/v1/projects/${projectId}/conversations`, {
+        headers: dashboardHeaders(),
+      });
       expect(res.status).toBe(200);
 
       const body = await res.json<{ data: Conversation[] }>();
@@ -551,7 +590,9 @@ describe("Projects (/api/v1/projects)", () => {
       const conv1 = await createConversation(authHeaders, { title: "Alpha" });
       const conv2 = await createConversation(authHeaders, { title: "Beta" });
 
-      const res = await SELF.fetch(`http://localhost/api/v1/projects/${projectId}/conversations`);
+      const res = await SELF.fetch(`http://localhost/api/v1/projects/${projectId}/conversations`, {
+        headers: dashboardHeaders(),
+      });
       expect(res.status).toBe(200);
 
       const body = await res.json<{ data: Conversation[] }>();
@@ -578,6 +619,7 @@ describe("Projects (/api/v1/projects)", () => {
 
       const res = await SELF.fetch(
         `http://localhost/api/v1/projects/${projectId}/conversations?limit=2`,
+        { headers: dashboardHeaders() },
       );
       expect(res.status).toBe(200);
 
@@ -592,7 +634,9 @@ describe("Projects (/api/v1/projects)", () => {
       await createConversation(p1Headers, { title: "Project A conversation" });
       await createConversation(p2Headers, { title: "Project B conversation" });
 
-      const res = await SELF.fetch(`http://localhost/api/v1/projects/${p1Id}/conversations`);
+      const res = await SELF.fetch(`http://localhost/api/v1/projects/${p1Id}/conversations`, {
+        headers: dashboardHeaders(),
+      });
       const body = await res.json<{ data: Conversation[] }>();
 
       // Only project-1 conversations should be returned
@@ -621,6 +665,7 @@ describe("Projects (/api/v1/projects)", () => {
 
       const deleteRes = await SELF.fetch(`http://localhost/api/v1/projects/${project.id}`, {
         method: "DELETE",
+        headers: dashboardHeaders(),
       });
       expect(deleteRes.status).toBe(204);
     });
@@ -628,6 +673,7 @@ describe("Projects (/api/v1/projects)", () => {
     it("returns 404 for a non-existent project", async () => {
       const res = await SELF.fetch("http://localhost/api/v1/projects/nonexistent_proj_id_xyz", {
         method: "DELETE",
+        headers: dashboardHeaders(),
       });
       expect(res.status).toBe(404);
 
@@ -665,19 +711,37 @@ describe("Projects (/api/v1/projects)", () => {
       // Delete the project
       const deleteRes = await SELF.fetch(`http://localhost/api/v1/projects/${project.id}`, {
         method: "DELETE",
+        headers: dashboardHeaders(),
       });
       expect(deleteRes.status).toBe(204);
 
       // Verify the project is gone
-      const getRes = await SELF.fetch(`http://localhost/api/v1/projects/${project.id}`);
+      const getRes = await SELF.fetch(`http://localhost/api/v1/projects/${project.id}`, {
+        headers: dashboardHeaders(),
+      });
       expect(getRes.status).toBe(404);
 
-      // Verify conversations listing returns empty (project no longer exists)
+      // The project is deleted, so its conversations endpoint must 404 (the
+      // org-scoped authorization fails because the project no longer exists).
       const convsRes = await SELF.fetch(
         `http://localhost/api/v1/projects/${project.id}/conversations`,
+        { headers: dashboardHeaders() },
       );
-      const convsBody = await convsRes.json<{ data: Conversation[] }>();
-      expect(convsBody.data).toEqual([]);
+      expect(convsRes.status).toBe(404);
+
+      // Cascade: conversations, messages, and keys rows are physically gone.
+      const convRows = await env.DB.prepare(
+        "SELECT COUNT(*) as n FROM conversations WHERE project_id = ?",
+      )
+        .bind(project.id)
+        .first<{ n: number }>();
+      expect(convRows?.n).toBe(0);
+      const keyRows = await env.DB.prepare(
+        "SELECT COUNT(*) as n FROM api_keys WHERE project_id = ?",
+      )
+        .bind(project.id)
+        .first<{ n: number }>();
+      expect(keyRows?.n).toBe(0);
     });
 
     it("does not affect other projects", async () => {
@@ -693,17 +757,22 @@ describe("Projects (/api/v1/projects)", () => {
       // Delete project B
       const deleteRes = await SELF.fetch(`http://localhost/api/v1/projects/${projectB.id}`, {
         method: "DELETE",
+        headers: dashboardHeaders(),
       });
       expect(deleteRes.status).toBe(204);
 
       // Project A must still exist
-      const getResA = await SELF.fetch(`http://localhost/api/v1/projects/${projectA.id}`);
+      const getResA = await SELF.fetch(`http://localhost/api/v1/projects/${projectA.id}`, {
+        headers: dashboardHeaders(),
+      });
       expect(getResA.status).toBe(200);
       const bodyA = await getResA.json<ProjectWithKeys>();
       expect(bodyA.id).toBe(projectA.id);
 
       // Project B must be gone
-      const getResB = await SELF.fetch(`http://localhost/api/v1/projects/${projectB.id}`);
+      const getResB = await SELF.fetch(`http://localhost/api/v1/projects/${projectB.id}`, {
+        headers: dashboardHeaders(),
+      });
       expect(getResB.status).toBe(404);
     });
   });
@@ -747,6 +816,7 @@ describe("Projects (/api/v1/projects)", () => {
 
       const res = await SELF.fetch(
         `http://localhost/api/v1/projects/${projectId}/conversations/${conv.id}/messages`,
+        { headers: dashboardHeaders() },
       );
       expect(res.status).toBe(200);
 
@@ -767,6 +837,7 @@ describe("Projects (/api/v1/projects)", () => {
 
       const res = await SELF.fetch(
         `http://localhost/api/v1/projects/${projectId}/conversations/${conv.id}/messages`,
+        { headers: dashboardHeaders() },
       );
       expect(res.status).toBe(200);
 
@@ -790,6 +861,7 @@ describe("Projects (/api/v1/projects)", () => {
 
       const res = await SELF.fetch(
         `http://localhost/api/v1/projects/${projectId}/conversations/${conv.id}/messages`,
+        { headers: dashboardHeaders() },
       );
       const body = await res.json<{ data: Message[] }>();
 
@@ -807,6 +879,7 @@ describe("Projects (/api/v1/projects)", () => {
       // The dashboard route doesn't do a 404 check — it returns empty data for unknown conv IDs
       const res = await SELF.fetch(
         `http://localhost/api/v1/projects/${projectId}/conversations/nonexistent_conv_id/messages`,
+        { headers: dashboardHeaders() },
       );
       expect(res.status).toBe(200);
 

--- a/packages/api/wrangler.test.jsonc
+++ b/packages/api/wrangler.test.jsonc
@@ -33,7 +33,13 @@
   // No AI binding — tests mock it via miniflare bindings
   "vars": {
     "PROJECT_CREATION_RATE_LIMIT_MAX": "10000",
-    "RATE_LIMIT_MAX": "10000"
+    "RATE_LIMIT_MAX": "10000",
+    // Non-empty secret so clerkDashboardAuth does not fail-closed on the
+    // "unset secret" check. Networkless verification uses CLERK_JWT_KEY below.
+    "CLERK_SECRET_KEY": "test_secret_unused_networkless",
+    // RSA public key (SPKI PEM) matching the private key in test/clerk-jwt.ts.
+    // Test-only keypair — never used in production.
+    "CLERK_JWT_KEY": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtxMkYQsRsixcwsh57x9u\nONb95zUj4+HTeWW1ZEF6FV087NEcN7AWoE3AOiiz5is8y1hc4l+1cF6Pniu8yglT\n8NWd3ESTYx9z0xs/KaXICsAl/H1YGKn/2XQVeUbNK7hmOHIJGy+2zJ7khBAqBkGX\noDNmBSBhSBKYhjVCT6JAjKFIDqa5NBjfD4VLZJZFtQcKM0ep1eesDeQO71RtxDh7\nJhG7aG45KJmEsIQc75gbCkZGTaTX/2Emx2YxlASbKnbL0DTbnHiPnYoxxDKE/jot\nxwu4rMQkE3nr1iW0ycWIR4bhFVoWHnCClfjHhVtNScTKnkBFoICpXdzQFs1OIuwg\n3QIDAQAB\n-----END PUBLIC KEY-----\n"
   },
   "logpush": false
 }

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -9,12 +9,18 @@ export async function api<T>(
   const { orgId, ...restOptions } = options ?? {};
   const url = new URL(`${API_BASE}${path}`, window.location.origin);
 
+  // org_id is now taken from the verified Clerk session server-side, but we
+  // keep the helper for any legacy callers. It is ignored by the API for scoping.
   if (orgId) {
     url.searchParams.set("org_id", orgId);
   }
 
   const res = await fetch(url.toString(), {
     ...restOptions,
+    // Same-origin: send the Clerk session cookie (__session) so dashboard-management
+    // routes can verify the session. Without this, some browsers/envs may omit
+    // cookies on programmatic fetch; "include" guarantees the cookie is sent.
+    credentials: "include",
     headers: {
       "Content-Type": "application/json",
       ...restOptions?.headers,


### PR DESCRIPTION
## 🚨 This fixes a critical, actively-exploitable vulnerability

**Unauthenticated callers could read all tenants' data and take over any project.** Confirmed live: \`curl https://agentstate.app/api/v1/projects\` returned every project across all orgs (HTTP 200, no auth).

The dashboard-facing routers were mounted with **no authentication** (\`index.ts:144\` literally documented \`// Dashboard routes at /api/v/* (no API key auth)\`), and the dashboard client sent no auth header. This meant anyone on the internet could:

- List **all** projects across every org
- Read any project's **conversations, messages, analytics**
- **Mint a valid API key for any project** (\`POST /:id/keys\`) → full write access
- **Delete any project** (\`DELETE /:id\`) → data destruction

## The fix
- Adds \`@clerk/backend\`; verifies the Clerk session JWT from the \`__session\` cookie (prod), \`__clerk_db_jwt\` (dev), or \`Authorization: Bearer\`.
- New \`clerkDashboardAuth\` middleware — **fail-closed**: 401 when \`CLERK_SECRET_KEY\` is unset, or the token is missing/invalid/expired.
- Applied to \`/api/v1/projects/*\`, \`/api/v1/organizations/*\`, \`/api/v/projects/*\`, \`/api/v/organizations/*\` before the route mounts.
- **Fixes the tenancy bypass:** \`org_id\` now comes from the verified session, never the request. Every project read / key-mint / delete is org-scoped via \`authorizeProjectOrg\` (resolves Clerk org id → internal org id; returns **404 cross-org** so existence isn't leaked).
- Dashboard client sets \`credentials: \"include\"\` so the same-origin Clerk cookie travels.
- Agent-facing API-key routes (conversations, \`/api/projects\` keys, states, leases, tokens, claims, webhooks) are **untouched**.

## Verification
- \`tsc --noEmit\` clean
- \`vitest run\` → **260/260 pass** (18 files)
- Tests sign **real RS256 JWTs** with a test keypair (no mocking of the crypto, no Clerk calls): unauth → 401 across all dashboard routes; expired/malformed → 401; valid session → 200; org-spoofing from the request body ignored; cross-org project → 404; cross-org delete blocked; intentionally-public routes still 200.
- Route classification of every mount in \`index.ts\` is exhaustive (see review); nothing missed.

## ⛔ DO NOT MERGE YET — deploy gate
This middleware is **fail-closed**. If it deploys before \`CLERK_SECRET_KEY\` is set in production, **all dashboard-management routes return 401 for everyone**, including legitimate users.

**Before merging, provision the secret:**
\`\`\`bash
cd packages/api && wrangler secret put CLERK_SECRET_KEY   # Clerk dashboard → API Keys → Secret key
# Optional, enables networkless JWT verification:
cd packages/api && wrangler secret put CLERK_JWT_KEY      # Clerk → Advanced → Public key (PEM)
\`\`\`
And add \`CLERK_SECRET_KEY\` to **GitHub Actions secrets** (repo → Settings → Secrets) so CI deploys include it.

After the secret is set → merge → ci.yml deploys → verify:
\`\`\`bash
curl -s -o /dev/null -w '%{http_code}' https://agentstate.app/api/v1/projects   # must be 401
\`\`\`

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>