### PR TITLE
fix(api): tie-break cursor pagination so shared-timestamp rows are not dropped

### DIFF
--- a/packages/api/src/routes/conversations/messages.ts
+++ b/packages/api/src/routes/conversations/messages.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gt } from "drizzle-orm";
+import { and, asc, eq, gt, or, type SQL, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { messages } from "../../db/schema";
 import {
@@ -55,32 +55,39 @@ router.get("/:id/messages", async (c) => {
 
   const after = c.req.query("after");
 
-  const conditions = [eq(messages.conversationId, id)];
-
+  // Page by (createdAt, rowid). Messages appended in one batch share a single
+  // createdAt (services/messages.ts uses one `now` per append), so rowid — the
+  // SQLite insertion order — is the stable tie-breaker. Without it, a page
+  // boundary inside a batch drops the rows after the cursor.
+  let cursorCond: SQL | undefined;
   if (after) {
-    // Resolve the created_at of the cursor message for stable pagination
     const [cursorMsg] = await db
-      .select()
+      .select({ createdAt: messages.createdAt, rowid: sql<number>`rowid` })
       .from(messages)
       .where(and(eq(messages.id, after), eq(messages.conversationId, id)))
       .limit(1);
-
     if (cursorMsg) {
-      conditions.push(gt(messages.createdAt, cursorMsg.createdAt));
+      cursorCond = or(
+        gt(messages.createdAt, cursorMsg.createdAt),
+        and(eq(messages.createdAt, cursorMsg.createdAt), sql`rowid > ${cursorMsg.rowid}`),
+      );
     }
   }
 
   const rows = await db
     .select()
     .from(messages)
-    .where(and(...conditions))
-    .orderBy(asc(messages.createdAt))
-    .limit(limit);
+    .where(and(eq(messages.conversationId, id), cursorCond))
+    .orderBy(asc(messages.createdAt), asc(sql`rowid`))
+    .limit(limit + 1);
 
-  const nextCursor = rows.length === limit ? rows[rows.length - 1].id : null;
+  // Fetch one extra row to detect a next page without a trailing empty page.
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+  const nextCursor = hasMore && page.length > 0 ? page[page.length - 1].id : null;
 
   return c.json({
-    data: rows.map(deserializeMessage),
+    data: page.map(deserializeMessage),
     pagination: {
       limit,
       next_cursor: nextCursor,

--- a/packages/api/src/services/conversations.ts
+++ b/packages/api/src/services/conversations.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, lt } from "drizzle-orm";
+import { and, asc, desc, eq, gt, lt, or } from "drizzle-orm";
 import { conversations, conversationTags, messages } from "../db/schema";
 import { generateId } from "../lib/id";
 import { serializeMetadata } from "../lib/serialization";
@@ -277,14 +277,23 @@ export async function listConversations(
 }> {
   const { limit, cursor, order, tag } = options;
 
-  // Validate cursor if provided
+  // Cursor format: "<updatedAt>.<id>" (composite, tie-break by id) or legacy
+  // bare "<updatedAt>". Ties on updatedAt are common — batch inserts share one
+  // timestamp — so ordering and cursoring on (updatedAt, id) keeps tie groups
+  // intact across pages instead of dropping the rows after the page boundary.
+  let cursorTs: number | undefined;
+  let cursorId: string | undefined;
   if (cursor !== undefined) {
-    const cursorNum = Number(cursor);
+    const dot = cursor.lastIndexOf(".");
+    const tsStr = dot === -1 ? cursor : cursor.slice(0, dot);
+    const idStr = dot === -1 ? undefined : cursor.slice(dot + 1);
+    const cursorNum = Number(tsStr);
     if (
       Number.isNaN(cursorNum) ||
       !Number.isFinite(cursorNum) ||
       cursorNum < 0 ||
-      cursorNum > Number.MAX_SAFE_INTEGER
+      cursorNum > Number.MAX_SAFE_INTEGER ||
+      (dot !== -1 && !idStr)
     ) {
       return {
         rows: [],
@@ -296,6 +305,8 @@ export async function listConversations(
         },
       };
     }
+    cursorTs = cursorNum;
+    cursorId = idStr;
   }
 
   // Validate tag format
@@ -316,16 +327,30 @@ export async function listConversations(
 
   const conditions = [eq(conversations.projectId, projectId)];
 
-  if (cursor) {
-    const cursorTs = parseInt(cursor, 10);
-    if (!Number.isNaN(cursorTs)) {
-      conditions.push(
-        order === "desc"
+  if (cursorTs !== undefined) {
+    // Composite (updatedAt, id) comparison so rows sharing the cursor's
+    // timestamp are not skipped when they sort after the cursor row.
+    const cursorCond =
+      cursorId !== undefined
+        ? order === "desc"
+          ? or(
+              lt(conversations.updatedAt, cursorTs),
+              and(eq(conversations.updatedAt, cursorTs), lt(conversations.id, cursorId)),
+            )
+          : or(
+              gt(conversations.updatedAt, cursorTs),
+              and(eq(conversations.updatedAt, cursorTs), gt(conversations.id, cursorId)),
+            )
+        : order === "desc"
           ? lt(conversations.updatedAt, cursorTs)
-          : gt(conversations.updatedAt, cursorTs),
-      );
-    }
+          : gt(conversations.updatedAt, cursorTs);
+    if (cursorCond) conditions.push(cursorCond);
   }
+
+  const ordering =
+    order === "desc"
+      ? [desc(conversations.updatedAt), desc(conversations.id)]
+      : [asc(conversations.updatedAt), asc(conversations.id)];
 
   let rows: (typeof conversations.$inferSelect)[];
 
@@ -351,20 +376,25 @@ export async function listConversations(
         and(eq(conversationTags.conversationId, conversations.id), eq(conversationTags.tag, tag)),
       )
       .where(and(...conditions))
-      .orderBy(order === "desc" ? desc(conversations.updatedAt) : asc(conversations.updatedAt))
-      .limit(limit);
+      .orderBy(...ordering)
+      .limit(limit + 1);
   } else {
     rows = await db
       .select()
       .from(conversations)
       .where(and(...conditions))
-      .orderBy(order === "desc" ? desc(conversations.updatedAt) : asc(conversations.updatedAt))
-      .limit(limit);
+      .orderBy(...ordering)
+      .limit(limit + 1);
   }
 
-  const nextCursor = rows.length === limit ? String(rows[rows.length - 1].updatedAt) : null;
+  // Fetch one extra row to detect a next page; this avoids emitting a
+  // trailing empty page when the final page is exactly full.
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+  const last = page[page.length - 1];
+  const nextCursor = hasMore && last ? `${last.updatedAt}.${last.id}` : null;
 
-  return { rows, nextCursor };
+  return { rows: page, nextCursor };
 }
 
 /**

--- a/packages/api/test/conversations.test.ts
+++ b/packages/api/test/conversations.test.ts
@@ -578,6 +578,47 @@ describe("Conversations", () => {
       expect(page2.data[0].content).toBe("Msg B");
     });
 
+    it("paginates batch-appended messages sharing one timestamp without dropping rows", async () => {
+      // A single append shares one createdAt across all messages (services/messages.ts
+      // uses one `now`). The cursor must tie-break by insertion order (rowid) so a
+      // page boundary inside the batch does not drop the rows after the cursor.
+      const createRes = await createConversation({});
+      const convId = (await createRes.json<ConversationWithMessages>()).id;
+
+      const appendRes = await SELF.fetch(`http://localhost/v1/conversations/${convId}/messages`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          messages: [
+            { role: "user", content: "B1" },
+            { role: "user", content: "B2" },
+            { role: "user", content: "B3" },
+            { role: "user", content: "B4" },
+            { role: "user", content: "B5" },
+          ],
+        }),
+      });
+      expect(appendRes.status).toBe(201);
+
+      const seen: string[] = [];
+      let cursor: string | null = null;
+      let pages = 0;
+      while (true) {
+        pages += 1;
+        if (pages > 10) throw new Error("pagination did not terminate");
+        const url = `http://localhost/v1/conversations/${convId}/messages?limit=2${cursor ? `&after=${cursor}` : ""}`;
+        const res = await SELF.fetch(url, { headers: authHeaders() });
+        expect(res.status).toBe(200);
+        const body = await res.json<ListResponse<Message>>();
+        for (const m of body.data) seen.push(m.content);
+        cursor = body.pagination.next_cursor;
+        if (!cursor) break;
+      }
+
+      // All 5 same-timestamp messages returned in insertion order, no drops/dupes.
+      expect(seen).toEqual(["B1", "B2", "B3", "B4", "B5"]);
+    });
+
     it("returns 404 for a non-existent conversation", async () => {
       const res = await SELF.fetch("http://localhost/v1/conversations/nonexistent_id/messages", {
         headers: authHeaders(),


### PR DESCRIPTION
## Bug
Cursor pagination dropped rows and emitted a trailing empty page.

1. **Dropped rows on ties.** The cursor filtered on a bare timestamp with strict `</>` and ordered by the timestamp alone. When multiple rows share a timestamp — common, because batch message inserts use one `now` (`services/messages.ts:25`) and bulk/rapid writes share `updatedAt` — a page boundary inside the tie group made the next page's `WHERE ts < cursor` exclude every sibling. Those rows vanished from results.
2. **Trailing empty page.** `nextCursor = rows.length === limit ? … : null` yielded a cursor on the last full page, so clients always fetched one extra empty page.

## Fix (agent-facing conversations path — disjoint from #132)
- **`listConversations`**: order + cursor on `(updatedAt, id)`; composite `(ts < cur) OR (ts = cur AND id < cur)`; fetch `limit+1` and only emit a cursor when more rows exist. Cursor is now `"<ts>.<id>"`; legacy bare-timestamp cursors are still accepted (no tie-breaker that page).
- **`GET /:id/messages`**: order + cursor on `(createdAt, rowid)`. Messages in one append share a `createdAt` and ids are random nanoids, so `rowid` (SQLite insertion order) is the stable tie-breaker that keeps batch order intact across pages.

## Verification
- `tsc --noEmit` clean
- `vitest run` → **240/240 pass** (17 files)
- New test: paginates 5 same-timestamp batch messages at `limit=2`, asserts all 5 return in insertion order with no drops/dupes.
- Existing message-ordering + cursor tests still pass (rowid preserves the insertion order the old `asc(createdAt)` relied on).

Disjoint from #132 (dashboard auth) and #133 (Kumo) — no file overlap, merges cleanly.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>