### PR TITLE
fix(ci): fall back to GITHUB_TOKEN in release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,7 +32,14 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v5
         with:
-          token: ${{ secrets.DUYETBOT_GITHUB_TOKEN }}
+          # Prefer the bot token (releases cut as duyetbot; and the default
+          # GITHUB_TOKEN push does not re-trigger workflows, so auto-cutting a
+          # release on the release-PR merge needs a PAT). Fall back to the
+          # auto-provided GITHUB_TOKEN when DUYETBOT_GITHUB_TOKEN is unset so the
+          # workflow stops failing "Bad credentials" — the release PR is still
+          # maintained; if auto-cut doesn't fire, run this workflow manually
+          # (workflow_dispatch) after merging the release PR.
+          token: ${{ secrets.DUYETBOT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
 


### PR DESCRIPTION
`release-please.yml` used `secrets.DUYETBOT_GITHUB_TOKEN` (unset), failing `Bad credentials` on every push to main.

**Fix:** `token: ${{ secrets.DUYETBOT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}` — prefers the bot token when present, else uses the auto-provided `GITHUB_TOKEN`. The workflow stops failing and keeps the release PR open.

Caveat (documented in-code): a release cut with the default `GITHUB_TOKEN` doesn't re-trigger workflows (GitHub anti-recursion), so auto-cutting on the release-PR merge still wants the bot token / a PAT. The workflow already has `workflow_dispatch`, so it can be run manually after merging the release PR if auto-cut doesn't fire.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved authentication handling in the automated release workflow to enhance reliability and prevent credential-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->