### PR TITLE
fix(ci): use GITHUB_TOKEN directly for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,14 +32,16 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v5
         with:
-          # Prefer the bot token (releases cut as duyetbot; and the default
-          # GITHUB_TOKEN push does not re-trigger workflows, so auto-cutting a
-          # release on the release-PR merge needs a PAT). Fall back to the
-          # auto-provided GITHUB_TOKEN when DUYETBOT_GITHUB_TOKEN is unset so the
-          # workflow stops failing "Bad credentials" — the release PR is still
-          # maintained; if auto-cut doesn't fire, run this workflow manually
-          # (workflow_dispatch) after merging the release PR.
-          token: ${{ secrets.DUYETBOT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          # Use the auto-provided GITHUB_TOKEN. DUYETBOT_GITHUB_TOKEN is set in
+          # repo secrets but invalid (expired), and a `||` fallback can't detect
+          # "set but invalid" (a non-empty secret is truthy), so it still failed
+          # "Bad credentials". GITHUB_TOKEN cuts the release fine as long as a
+          # human merges the release PR (its push re-triggers this workflow);
+          # only auto-merge by GITHUB_TOKEN hits GitHub's anti-recursion rule.
+          # To restore duyetbot attribution, rotate DUYETBOT_GITHUB_TOKEN to a
+          # valid value and switch this back to
+          # `${{ secrets.DUYETBOT_GITHUB_TOKEN }}`.
+          token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
 


### PR DESCRIPTION
Follow-up to #138. The `|| GITHUB_TOKEN` fallback still failed `Bad credentials` because `DUYETBOT_GITHUB_TOKEN` is **set in repo secrets but invalid** (expired) — a non-empty secret is truthy, so `||` returns the broken token. No expression can detect "set but invalid".

**Fix:** `token: ${{ secrets.GITHUB_TOKEN }}` (the auto-provided token). release-please now runs and maintains the release PR; releases cut fine when a human merges the release PR (that push re-triggers this workflow — only auto-merge by `GITHUB_TOKEN` hits GitHub's anti-recursion rule).

To restore `duyetbot` attribution later: rotate `DUYETBOT_GITHUB_TOKEN` to a valid value and switch the token line back.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>