### PR TITLE
feat(dashboard): port /dashboard projects route to Astro

### DIFF
--- a/packages/dashboard/src/components/dashboard/projects/_create-project-form-actions.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/_create-project-form-actions.tsx
@@ -1,0 +1,24 @@
+import { Button } from "@cloudflare/kumo/components/button";
+
+interface CreateProjectFormActionsProps {
+  onCancel: () => void;
+  onCreate: () => void;
+  disabled: boolean;
+}
+
+export function CreateProjectFormActions({
+  onCancel,
+  onCreate,
+  disabled,
+}: CreateProjectFormActionsProps) {
+  return (
+    <>
+      <Button size="sm" variant="ghost" onClick={onCancel}>
+        Cancel
+      </Button>
+      <Button size="sm" variant="primary" onClick={onCreate} disabled={disabled}>
+        Create project
+      </Button>
+    </>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/projects/_create-project-form-header.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/_create-project-form-header.tsx
@@ -1,0 +1,14 @@
+import { Text } from "@cloudflare/kumo/components/text";
+
+export function CreateProjectFormHeader() {
+  return (
+    <div className="flex flex-col gap-1">
+      <Text variant="heading3" as="h2">
+        Create project
+      </Text>
+      <Text variant="secondary" size="sm" as="p">
+        Give your project a name. The slug is used in API paths.
+      </Text>
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/projects/_create-project-form.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/_create-project-form.tsx
@@ -1,0 +1,66 @@
+import { LayerCard } from "@cloudflare/kumo/components/layer-card";
+import { CreateProjectFormActions } from "./_create-project-form-actions";
+import { CreateProjectFormHeader } from "./_create-project-form-header";
+import { ProjectNameInput } from "./_project-name-input";
+import { ProjectSlugInput } from "./_project-slug-input";
+
+interface CreateProjectFormProps {
+  name: string;
+  slug: string;
+  slugStatus: "idle" | "checking" | "available" | "taken";
+  onNameChange: (name: string) => void;
+  onSlugChange: (slug: string) => void;
+  onCreate: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * CreateProjectForm - Form for creating a new project with name and slug.
+ *
+ * Features:
+ * - Auto-generates slug from name
+ * - Real-time slug availability checking
+ * - Visual feedback for slug status (checking, available, taken)
+ *
+ * @example
+ * ```tsx
+ * <CreateProjectForm
+ *   name={name}
+ *   slug={slug}
+ *   slugStatus={slugStatus}
+ *   onNameChange={setNewName}
+ *   onSlugChange={setSlug}
+ *   onCreate={handleCreate}
+ *   onCancel={handleCancel}
+ * />
+ * ```
+ */
+export function CreateProjectForm({
+  name,
+  slug,
+  slugStatus,
+  onNameChange,
+  onSlugChange,
+  onCreate,
+  onCancel,
+}: CreateProjectFormProps) {
+  const isSubmitDisabled =
+    !name.trim() || !slug || slugStatus === "taken" || slugStatus === "checking";
+
+  return (
+    <LayerCard className="mb-6 flex flex-col gap-4 p-6">
+      <CreateProjectFormHeader />
+      <div className="flex flex-col gap-4">
+        <ProjectNameInput value={name} onChange={onNameChange} onSubmit={onCreate} />
+        <ProjectSlugInput value={slug} status={slugStatus} onChange={onSlugChange} />
+      </div>
+      <div className="flex justify-end gap-2">
+        <CreateProjectFormActions
+          onCancel={onCancel}
+          onCreate={onCreate}
+          disabled={isSubmitDisabled}
+        />
+      </div>
+    </LayerCard>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/projects/_dashboard-content.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/_dashboard-content.tsx
@@ -1,0 +1,87 @@
+import type { ProjectListItem } from "@agentstate/shared";
+import { CardListSkeleton } from "@/components/dashboard/loading-states";
+import { CreateProjectForm } from "./_create-project-form";
+import { ProjectsEmptyState } from "./_projects-empty-state";
+import { ProjectsTable } from "./_projects-table";
+
+interface DashboardContentProps {
+  projects: ProjectListItem[];
+  loadingProjects: boolean;
+  showCreate: boolean;
+  name: string;
+  slug: string;
+  slugStatus: "idle" | "checking" | "available" | "taken";
+  onNameChange: (name: string) => void;
+  onSlugChange: (slug: string) => void;
+  onCreate: () => void;
+  onCancel: () => void;
+  onCreateClick: () => void;
+}
+
+/**
+ * DashboardContent - Main content area for the projects dashboard.
+ *
+ * Orchestrates the display of:
+ * - Create project form (when shown)
+ * - Loading skeleton (when loading)
+ * - Projects table (when projects exist)
+ * - Empty state (when no projects)
+ *
+ * @example
+ * ```tsx
+ * <DashboardContent
+ *   projects={projects}
+ *   loadingProjects={loading}
+ *   showCreate={showCreate}
+ *   name={name}
+ *   slug={slug}
+ *   slugStatus={slugStatus}
+ *   onNameChange={setNewName}
+ *   onSlugChange={setSlug}
+ *   onCreate={handleCreate}
+ *   onCancel={handleCancel}
+ *   onCreateClick={handleStartCreate}
+ * />
+ * ```
+ */
+export function DashboardContent({
+  projects,
+  loadingProjects,
+  showCreate,
+  name,
+  slug,
+  slugStatus,
+  onNameChange,
+  onSlugChange,
+  onCreate,
+  onCancel,
+  onCreateClick,
+}: DashboardContentProps) {
+  return (
+    <>
+      {/* Create form */}
+      {showCreate && (
+        <CreateProjectForm
+          name={name}
+          slug={slug}
+          slugStatus={slugStatus}
+          onNameChange={onNameChange}
+          onSlugChange={onSlugChange}
+          onCreate={onCreate}
+          onCancel={onCancel}
+        />
+      )}
+
+      {/* Loading state */}
+      {loadingProjects && !showCreate && <CardListSkeleton count={3} />}
+
+      {/* Project list */}
+      {!loadingProjects && projects.length > 0 && <ProjectsTable projects={projects} />}
+
+      {/* Empty state */}
+      {!loadingProjects && projects.length === 0 && !showCreate && (
+        <ProjectsEmptyState onCreateClick={onCreateClick} />
+      )}
+    </>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/projects/_dashboard-header.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/_dashboard-header.tsx
@@ -1,0 +1,33 @@
+import { Button } from "@cloudflare/kumo/components/button";
+import { Plus } from "@phosphor-icons/react";
+import { PageHeader } from "@/components/dashboard/page-header";
+
+interface DashboardHeaderProps {
+  onCreateClick: () => void;
+}
+
+/**
+ * DashboardHeader - Page header for the projects dashboard.
+ *
+ * Features:
+ * - Title and description
+ * - "New Project" action button
+ *
+ * @example
+ * ```tsx
+ * <DashboardHeader onCreateClick={handleStartCreate} />
+ * ```
+ */
+export function DashboardHeader({ onCreateClick }: DashboardHeaderProps) {
+  return (
+    <PageHeader
+      title="Projects"
+      description="Manage your API projects and keys."
+      actions={
+        <Button size="sm" variant="primary" icon={<Plus aria-hidden />} onClick={onCreateClick}>
+          New Project
+        </Button>
+      }
+    />
+  );
+}

--- a/packages/dashboard/src/components/dashboard/projects/_project-name-input.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/_project-name-input.tsx
@@ -1,0 +1,20 @@
+import { Input } from "@cloudflare/kumo/components/input";
+
+interface ProjectNameInputProps {
+  value: string;
+  onChange: (name: string) => void;
+  onSubmit: () => void;
+}
+
+export function ProjectNameInput({ value, onChange, onSubmit }: ProjectNameInputProps) {
+  return (
+    <Input
+      label="Project name"
+      placeholder="My Chatbot"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onKeyDown={(e) => e.key === "Enter" && onSubmit()}
+      autoFocus
+    />
+  );
+}

--- a/packages/dashboard/src/components/dashboard/projects/_project-slug-input.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/_project-slug-input.tsx
@@ -1,0 +1,39 @@
+import { Input } from "@cloudflare/kumo/components/input";
+import { Check, Spinner, X } from "@phosphor-icons/react";
+
+type SlugStatus = "idle" | "checking" | "available" | "taken";
+
+interface ProjectSlugInputProps {
+  value: string;
+  status: SlugStatus;
+  onChange: (slug: string) => void;
+}
+
+export function ProjectSlugInput({ value, status, onChange }: ProjectSlugInputProps) {
+  const isTaken = status === "taken";
+  const isAvailable = status === "available" && !!value;
+
+  return (
+    <div className="relative">
+      <Input
+        label="Project slug"
+        placeholder="my-chatbot"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        variant={isTaken ? "error" : "default"}
+        className="font-mono pr-8"
+        error={isTaken ? "This slug is already taken. Choose a different one." : undefined}
+        description={isAvailable ? "Available" : undefined}
+      />
+      {value && (
+        <div className="pointer-events-none absolute top-[34px] right-2.5" aria-hidden="true">
+          {status === "checking" && (
+            <Spinner className="size-4 animate-spin text-muted-foreground" />
+          )}
+          {isAvailable && <Check className="size-4 text-emerald-600" />}
+          {isTaken && <X className="size-4 text-kumo-danger" />}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/projects/_projects-empty-state.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/_projects-empty-state.tsx
@@ -1,0 +1,33 @@
+import { LayerCard } from "@cloudflare/kumo/components/layer-card";
+import { Folder } from "@phosphor-icons/react";
+import { EmptyState } from "@/components/dashboard/empty-state";
+
+interface ProjectsEmptyStateProps {
+  onCreateClick: () => void;
+}
+
+/**
+ * ProjectsEmptyState - Empty state when user has no projects.
+ *
+ * Uses EmptyState component wrapped in a dashed LayerCard for visual consistency.
+ *
+ * @example
+ * ```tsx
+ * <ProjectsEmptyState onCreateClick={handleCreate} />
+ * ```
+ */
+export function ProjectsEmptyState({ onCreateClick }: ProjectsEmptyStateProps) {
+  return (
+    <LayerCard>
+      <EmptyState
+        icon={<Folder aria-hidden />}
+        title="No projects yet"
+        description="Projects group your conversations and API keys."
+        action={{
+          label: "Create your first project",
+          onClick: onCreateClick,
+        }}
+      />
+    </LayerCard>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/projects/_projects-table.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/_projects-table.tsx
@@ -1,0 +1,84 @@
+import type { ProjectListItem } from "@agentstate/shared";
+import { LayerCard } from "@cloudflare/kumo/components/layer-card";
+import { Table } from "@cloudflare/kumo/components/table";
+import { Folder, Key } from "@phosphor-icons/react";
+import { useRouter } from "next/navigation";
+
+type Project = ProjectListItem;
+
+interface ProjectsTableProps {
+  projects: Project[];
+}
+
+/**
+ * ProjectsTable - Table displaying list of projects with click navigation.
+ *
+ * Features:
+ * - Clickable rows with keyboard navigation
+ * - Project name and slug display
+ * - API key count
+ * - Created date
+ *
+ * @example
+ * ```tsx
+ * <ProjectsTable projects={projects} />
+ * ```
+ */
+export function ProjectsTable({ projects }: ProjectsTableProps) {
+  const router = useRouter();
+
+  return (
+    <LayerCard className="overflow-hidden p-0">
+      <Table>
+        <Table.Header>
+          <Table.Row className="bg-muted hover:bg-muted">
+            <Table.Head>Name</Table.Head>
+            <Table.Head className="hidden sm:table-cell">API Keys</Table.Head>
+            <Table.Head className="hidden sm:table-cell">Created</Table.Head>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {projects.map((project) => (
+            <Table.Row
+              key={project.id}
+              className="cursor-pointer hover:bg-muted"
+              onClick={() => router.push(`/dashboard/project/?slug=${project.slug}`)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  router.push(`/dashboard/project/?slug=${project.slug}`);
+                }
+              }}
+              tabIndex={0}
+              aria-label={`Open ${project.name}`}
+            >
+              <Table.Cell className="py-3.5">
+                <div className="flex items-center gap-3">
+                  <span className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border bg-muted text-muted-foreground">
+                    <Folder className="size-4" aria-hidden />
+                  </span>
+                  <div>
+                    <p className="text-sm font-semibold text-foreground">{project.name}</p>
+                    <p className="font-mono text-[11.5px] text-muted-foreground">{project.slug}</p>
+                  </div>
+                </div>
+              </Table.Cell>
+              <Table.Cell className="hidden sm:table-cell">
+                <div className="flex items-center gap-1.5 text-[13px] text-muted-foreground">
+                  <Key className="size-3.5 text-muted-foreground" aria-hidden />
+                  {project.key_count ?? 0}
+                </div>
+              </Table.Cell>
+              <Table.Cell
+                suppressHydrationWarning
+                className="hidden text-[13px] text-muted-foreground sm:table-cell"
+              >
+                {new Date(project.created_at).toLocaleDateString()}
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+    </LayerCard>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/projects/_use-create-project.ts
+++ b/packages/dashboard/src/components/dashboard/projects/_use-create-project.ts
@@ -1,0 +1,111 @@
+import type { ProjectListItem } from "@agentstate/shared";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import { generateName, toSlug } from "@/lib/name-generator";
+import { useSlugAvailability } from "@/lib/slug-validation";
+
+type Project = ProjectListItem;
+
+/**
+ * useCreateProject - Hook for managing project creation state and logic.
+ *
+ * Features:
+ * - Form state management (name, slug, visibility)
+ * - Auto-generates slug from name
+ * - Real-time slug availability checking (debounced)
+ * - Project creation with API call
+ * - Key storage for one-time display
+ * - Navigation to new project
+ *
+ * @example
+ * ```tsx
+ * const {
+ *   showCreate,
+ *   name,
+ *   slug,
+ *   slugStatus,
+ *   handleStartCreate,
+ *   handleCreate,
+ *   handleCancel
+ * } = useCreateProject(projects);
+ * ```
+ */
+export function useCreateProject(projects: Project[]) {
+  const router = useRouter();
+  const [showCreate, setShowCreate] = useState(false);
+  const [name, setName] = useState("");
+  const [slug, setSlug] = useState("");
+  const [slugEdited, setSlugEdited] = useState(false);
+  const [apiError, setApiError] = useState(false);
+  const existingSlugs = projects.map((p) => p.slug);
+  const slugStatus = useSlugAvailability(slug, existingSlugs);
+
+  // Combine availability status with API error state
+  const effectiveSlugStatus: "idle" | "checking" | "available" | "taken" = apiError
+    ? "taken"
+    : slugStatus;
+
+  // Auto-generate slug from name
+  useEffect(() => {
+    if (!slugEdited && name) {
+      setSlug(toSlug(name));
+    }
+    if (!name) {
+      setSlug("");
+      setSlugEdited(false);
+    }
+  }, [name, slugEdited]);
+
+  const handleCreate = useCallback(async () => {
+    if (!name.trim() || !slug) return;
+    setApiError(false);
+    try {
+      const res = await api<{ project: Project; api_key: { key: string } }>("/v1/projects", {
+        method: "POST",
+        body: JSON.stringify({ name: name.trim(), slug }),
+      });
+      // Store key in sessionStorage (not URL) — shown once on project page
+      sessionStorage.setItem(`new_key_${res.project.slug}`, res.api_key.key);
+      router.push(`/dashboard/project/?slug=${res.project.slug}`);
+    } catch {
+      // Show error (e.g., slug taken)
+      setApiError(true);
+    }
+  }, [name, slug, router]);
+
+  const handleCancel = useCallback(() => {
+    setShowCreate(false);
+    setName("");
+    setSlug("");
+    setSlugEdited(false);
+    setApiError(false);
+  }, []);
+
+  const handleStartCreate = useCallback(() => {
+    setName(generateName());
+    setSlugEdited(false);
+    setShowCreate(true);
+  }, []);
+
+  const handleSlugChange = useCallback((value: string) => {
+    setSlug(toSlug(value));
+    setSlugEdited(true);
+  }, []);
+
+  const handleNameChange = useCallback((value: string) => {
+    setName(value);
+  }, []);
+
+  return {
+    showCreate,
+    name,
+    slug,
+    slugStatus: effectiveSlugStatus,
+    handleStartCreate,
+    handleCreate,
+    handleCancel,
+    handleSlugChange,
+    handleNameChange,
+  };
+}

--- a/packages/dashboard/src/components/dashboard/projects/_use-projects-data.ts
+++ b/packages/dashboard/src/components/dashboard/projects/_use-projects-data.ts
@@ -1,0 +1,31 @@
+import type { ProjectListItem } from "@agentstate/shared";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+
+/**
+ * useProjectsData - Hook for fetching and managing projects data.
+ *
+ * Features:
+ * - Fetches projects on mount
+ * - Loading state management
+ * - Error handling with toast notifications
+ *
+ * @example
+ * ```tsx
+ * const { projects, loadingProjects } = useProjectsData();
+ * ```
+ */
+export function useProjectsData() {
+  const [projects, setProjects] = useState<ProjectListItem[]>([]);
+  const [loadingProjects, setLoadingProjects] = useState(true);
+
+  useEffect(() => {
+    api<{ data: ProjectListItem[] }>("/v1/projects")
+      .then((res) => setProjects(res.data))
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load projects"))
+      .finally(() => setLoadingProjects(false));
+  }, []);
+
+  return { projects, loadingProjects };
+}

--- a/packages/dashboard/src/components/dashboard/projects/projects-page.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/projects-page.tsx
@@ -1,0 +1,67 @@
+import { DashboardShell } from "@/components/dashboard-shell";
+import { DashboardContent } from "./_dashboard-content";
+import { DashboardHeader } from "./_dashboard-header";
+import { useCreateProject } from "./_use-create-project";
+import { useProjectsData } from "./_use-projects-data";
+
+/**
+ * ProjectsContent - Main dashboard page body for managing API projects.
+ *
+ * Features:
+ * - Display list of projects
+ * - Create new projects with name and slug
+ * - Real-time slug availability checking
+ * - Empty state when no projects exist
+ *
+ * State management split into focused hooks:
+ * - useProjectsData: Fetch and manage projects list
+ * - useCreateProject: Handle project creation form and logic
+ */
+function ProjectsContent() {
+  const { projects, loadingProjects } = useProjectsData();
+  const {
+    showCreate,
+    name,
+    slug,
+    slugStatus,
+    handleStartCreate,
+    handleCreate,
+    handleCancel,
+    handleSlugChange,
+    handleNameChange,
+  } = useCreateProject(projects);
+
+  return (
+    <div className="px-4 lg:px-6">
+      <DashboardHeader onCreateClick={handleStartCreate} />
+      <DashboardContent
+        projects={projects}
+        loadingProjects={loadingProjects}
+        showCreate={showCreate}
+        name={name}
+        slug={slug}
+        slugStatus={slugStatus}
+        onNameChange={handleNameChange}
+        onSlugChange={handleSlugChange}
+        onCreate={handleCreate}
+        onCancel={handleCancel}
+        onCreateClick={handleStartCreate}
+      />
+    </div>
+  );
+}
+
+/**
+ * ProjectsPage - client:only island for the /dashboard route.
+ *
+ * Wraps the page body in DashboardShell (Clerk Providers + auth gate +
+ * sidebar/header chrome). Rendered as `client:only="react"` from
+ * src/pages/dashboard/index.astro.
+ */
+export function ProjectsPage() {
+  return (
+    <DashboardShell>
+      <ProjectsContent />
+    </DashboardShell>
+  );
+}

--- a/packages/dashboard/src/pages/dashboard/index.astro
+++ b/packages/dashboard/src/pages/dashboard/index.astro
@@ -1,0 +1,8 @@
+---
+import { ProjectsPage } from "@/components/dashboard/projects/projects-page";
+import DashboardLayout from "@/layouts/DashboardLayout.astro";
+---
+
+<DashboardLayout>
+  <ProjectsPage client:only="react" />
+</DashboardLayout>


### PR DESCRIPTION
Phase 2 Astro migration of the `/dashboard` (projects list) route, following the Phase 1 page pattern.

## Changes
- `src/pages/dashboard/index.astro` — new page rendering a single `client:only="react"` island inside `DashboardLayout`.
- `src/components/dashboard/projects/projects-page.tsx` — `ProjectsPage` wraps the old `page.tsx` body (now `ProjectsContent`) in `DashboardShell`.
- `src/components/dashboard/projects/` — copies of the 11 co-located files from `src/app/dashboard/`, relative imports intact, `'use client'` stripped.

Project CRUD, create-project form, slug availability, and empty state preserved 1:1. `src/app/dashboard/` left untouched.

## Verification
- `bunx astro check` — 0 errors, 0 warnings
- `curl /dashboard/` — HTTP 200
- `bunx biome check --write` on new files

Co-authored with @duyetbot.