### PR TITLE
feat(dashboard): port /conversations route to Astro

### DIFF
--- a/packages/dashboard/src/components/dashboard/conversations/_components.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/_components.tsx
@@ -1,0 +1,18 @@
+// Re-export all conversation components for convenience
+export type { Conversation } from "./_conversation-row";
+export { ConversationRow } from "./_conversation-row";
+
+export type { _ConversationsTableProps } from "./_conversations-table";
+export { _ConversationsTable } from "./_conversations-table";
+export type {
+  MessagesPanel as MessagesPanelType,
+  RoleBadge as RoleBadgeType,
+} from "./_messages-panel";
+export { MessageRow, MessagesPanel, RoleBadge } from "./_messages-panel";
+export type { _EmptyProjectsProps, _ProjectSelectorProps } from "./_project-selectors";
+export { _EmptyProjects, _ProjectSelector } from "./_project-selectors";
+export { CONVERSATIONS_EMPTY_STATE, getConversationsColumns } from "./_table-columns";
+export type { Message } from "./_use-messages";
+
+import { DataTableLoadMore } from "@/components/dashboard/data-table";
+export const _LoadMoreButton = DataTableLoadMore;

--- a/packages/dashboard/src/components/dashboard/conversations/_conversation-row.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/_conversation-row.tsx
@@ -1,0 +1,78 @@
+import type { ConversationResponse } from "@agentstate/shared";
+import { Table } from "@cloudflare/kumo";
+import { CaretRightIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import { formatDateShort } from "@/lib/format";
+import { formatCostMicrodollars } from "@/lib/format-cost";
+import { cn } from "@/lib/utils";
+import { MessagesPanel } from "./_messages-panel";
+
+export type Conversation = ConversationResponse & { project_id: string };
+
+export function ConversationRow({ conv }: { conv: Conversation }) {
+  const [open, setOpen] = useState(false);
+  const title = conv.title ?? "Untitled";
+
+  return (
+    <>
+      <Table.Row
+        className="cursor-pointer focus-visible:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+        onClick={() => setOpen((v) => !v)}
+        tabIndex={0}
+        role="button"
+        aria-expanded={open}
+        aria-controls={`messages-${conv.id}`}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setOpen((v) => !v);
+          }
+        }}
+      >
+        <Table.Cell className="py-3.5">
+          <div className="flex items-center gap-2.5">
+            <CaretRightIcon
+              className={cn(
+                "size-3.5 shrink-0 text-muted-foreground transition-transform duration-150",
+                open && "rotate-90",
+              )}
+              aria-hidden="true"
+            />
+            <span className="max-w-[200px] truncate text-sm font-medium text-foreground sm:max-w-xs">
+              {title}
+            </span>
+          </div>
+        </Table.Cell>
+        <Table.Cell
+          suppressHydrationWarning
+          className="hidden font-mono text-xs text-muted-foreground sm:table-cell"
+        >
+          {conv.message_count.toLocaleString()}
+        </Table.Cell>
+        <Table.Cell
+          suppressHydrationWarning
+          className="hidden font-mono text-xs text-muted-foreground sm:table-cell"
+        >
+          {conv.token_count.toLocaleString()}
+        </Table.Cell>
+        <Table.Cell className="hidden font-mono text-xs text-muted-foreground tabular-nums sm:table-cell">
+          {formatCostMicrodollars(conv.total_cost_microdollars)}
+        </Table.Cell>
+        <Table.Cell className="hidden text-xs text-muted-foreground md:table-cell">
+          {formatDateShort(conv.created_at)}
+        </Table.Cell>
+        <Table.Cell className="hidden text-xs text-muted-foreground md:table-cell">
+          {formatDateShort(conv.updated_at)}
+        </Table.Cell>
+      </Table.Row>
+
+      {open && (
+        <Table.Row className="bg-muted hover:bg-muted" id={`messages-${conv.id}`}>
+          <Table.Cell colSpan={6} className="bg-muted px-6 py-3">
+            <MessagesPanel projectId={conv.project_id} conversationId={conv.id} />
+          </Table.Cell>
+        </Table.Row>
+      )}
+    </>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/conversations/_conversations-table.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/_conversations-table.tsx
@@ -1,0 +1,32 @@
+import type { ProjectResponse } from "@agentstate/shared";
+import { ChatCircleIcon } from "@phosphor-icons/react";
+import { DataTable } from "@/components/dashboard/data-table";
+import { type Conversation, ConversationRow } from "./_conversation-row";
+import { CONVERSATIONS_EMPTY_STATE, getConversationsColumns } from "./_table-columns";
+
+export interface _ConversationsTableProps {
+  selectedProject: ProjectResponse | undefined;
+  loading: boolean;
+  conversations: Conversation[];
+}
+
+export function _ConversationsTable({
+  selectedProject,
+  loading,
+  conversations,
+}: _ConversationsTableProps) {
+  return (
+    <DataTable
+      data={conversations}
+      columns={getConversationsColumns(selectedProject)}
+      loading={loading}
+      loadingRows={5}
+      empty={{
+        ...CONVERSATIONS_EMPTY_STATE,
+        icon: <ChatCircleIcon className="h-6 w-6 text-muted-foreground" />,
+      }}
+      rowKey={(conv) => conv.id}
+      renderRow={(conv) => <ConversationRow key={conv.id} conv={conv} />}
+    />
+  );
+}

--- a/packages/dashboard/src/components/dashboard/conversations/_hooks.ts
+++ b/packages/dashboard/src/components/dashboard/conversations/_hooks.ts
@@ -1,0 +1,3 @@
+export type { Conversation } from "./_use-conversations-data";
+export { useConversationsData } from "./_use-conversations-data";
+export { useConversationsPagination } from "./_use-conversations-pagination";

--- a/packages/dashboard/src/components/dashboard/conversations/_messages-panel.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/_messages-panel.tsx
@@ -1,0 +1,77 @@
+import { Badge } from "@cloudflare/kumo";
+import { useState } from "react";
+import { MessageListSkeleton } from "@/components/dashboard/loading-states";
+import { formatDate } from "@/lib/format";
+import { type Message, useMessages } from "./_use-messages";
+
+export function RoleBadge({ role }: { role: string }) {
+  return (
+    <Badge variant="secondary" className="font-mono text-[10px] uppercase tracking-wide!">
+      {role}
+    </Badge>
+  );
+}
+
+export function MessageRow({ msg }: { msg: Message }) {
+  const [expanded, setExpanded] = useState(false);
+  const limit = 200;
+  const truncated = msg.content.length > limit;
+  const displayed = expanded || !truncated ? msg.content : `${msg.content.slice(0, limit)}…`;
+
+  return (
+    <div className="flex gap-3 border-b border-border/50 py-2.5 last:border-b-0">
+      <div className="pt-0.5">
+        <RoleBadge role={msg.role} />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-xs text-foreground whitespace-pre-wrap break-words leading-relaxed">
+          {displayed}
+        </p>
+        {truncated && (
+          <button
+            type="button"
+            className="mt-1 text-[11px] text-muted-foreground hover:text-foreground hover:underline"
+            onClick={() => setExpanded((v) => !v)}
+            aria-expanded={expanded}
+            aria-label={expanded ? "Show less of this message" : "Show more of this message"}
+          >
+            {expanded ? "Show less" : "Show more"}
+          </button>
+        )}
+      </div>
+      <span className="shrink-0 pt-0.5 text-[11px] text-muted-foreground">
+        {formatDate(msg.created_at)}
+      </span>
+    </div>
+  );
+}
+
+interface MessagesPanelProps {
+  projectId: string;
+  conversationId: string;
+}
+
+export function MessagesPanel({ projectId, conversationId }: MessagesPanelProps) {
+  const { messages, loading, error } = useMessages(projectId, conversationId);
+
+  return (
+    <section aria-live="polite" aria-busy={loading}>
+      {loading && <MessageListSkeleton lines={3} />}
+      {error && (
+        <p className="py-2 text-xs text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+      {messages !== null && messages.length === 0 && (
+        <p className="text-xs text-muted-foreground py-2">No messages in this conversation.</p>
+      )}
+      {messages !== null && messages.length > 0 && (
+        <div>
+          {messages.map((m) => (
+            <MessageRow key={m.id} msg={m} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/conversations/_project-selectors.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/_project-selectors.tsx
@@ -1,0 +1,56 @@
+import type { ProjectResponse } from "@agentstate/shared";
+import { Label, LayerCard, Select } from "@cloudflare/kumo";
+import { ChatCircleIcon } from "@phosphor-icons/react";
+import { EmptyState } from "@/components/dashboard/empty-state";
+
+export interface _ProjectSelectorProps {
+  projects: ProjectResponse[];
+  selectedProjectId: string;
+  onSelectProject: (id: string) => void;
+}
+
+export function _ProjectSelector({
+  projects,
+  selectedProjectId,
+  onSelectProject,
+}: _ProjectSelectorProps) {
+  if (projects.length <= 1) return null;
+
+  const projectItems = Object.fromEntries(projects.map((p) => [p.id, p.name]));
+
+  return (
+    <div className="flex items-center gap-2.5">
+      <Label htmlFor="project-select" className="shrink-0">
+        Project
+      </Label>
+      <Select
+        aria-label="Select project"
+        size="sm"
+        className="w-[200px] font-mono text-xs"
+        value={selectedProjectId}
+        onValueChange={(v) => onSelectProject(v ?? "")}
+        items={projectItems}
+      />
+    </div>
+  );
+}
+
+export interface _EmptyProjectsProps {
+  onCreateProject: () => void;
+}
+
+export function _EmptyProjects({ onCreateProject }: _EmptyProjectsProps) {
+  return (
+    <LayerCard>
+      <EmptyState
+        icon={<ChatCircleIcon aria-hidden="true" />}
+        title="No projects yet"
+        description="Create a project first, then conversations will appear here."
+        action={{
+          label: "Create your first project",
+          onClick: onCreateProject,
+        }}
+      />
+    </LayerCard>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/conversations/_table-columns.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/_table-columns.tsx
@@ -1,0 +1,34 @@
+import type { ProjectResponse } from "@agentstate/shared";
+import type { Column } from "@/components/dashboard/data-table";
+import type { Conversation } from "./_conversation-row";
+
+export function getConversationsColumns(
+  selectedProject: ProjectResponse | undefined,
+): Column<Conversation>[] {
+  return [
+    {
+      key: "title",
+      label: selectedProject ? (
+        <span>
+          Title
+          <span className="ml-1.5 text-muted-foreground/60 font-normal">
+            — {selectedProject.name}
+          </span>
+        </span>
+      ) : (
+        "Title"
+      ),
+    },
+    { key: "messages", label: "Messages", className: "hidden sm:table-cell" },
+    { key: "tokens", label: "Tokens", className: "hidden sm:table-cell" },
+    { key: "cost", label: "Cost", className: "hidden sm:table-cell" },
+    { key: "created", label: "Created", className: "hidden md:table-cell" },
+    { key: "updated", label: "Updated", className: "hidden md:table-cell" },
+  ];
+}
+
+export const CONVERSATIONS_EMPTY_STATE = {
+  icon: null,
+  title: "No conversations yet",
+  description: "Conversations will appear here once your agents start logging to this project.",
+} as const;

--- a/packages/dashboard/src/components/dashboard/conversations/_use-conversations-data.ts
+++ b/packages/dashboard/src/components/dashboard/conversations/_use-conversations-data.ts
@@ -1,0 +1,77 @@
+import type { ConversationResponse, ProjectResponse } from "@agentstate/shared";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+
+export type Conversation = ConversationResponse & { project_id: string };
+
+interface UseConversationsDataState {
+  projects: ProjectResponse[];
+  selectedProjectId: string;
+  conversations: Conversation[];
+  loadingProjects: boolean;
+  loadingConversations: boolean;
+  hasMore: boolean;
+}
+
+interface UseConversationsDataActions {
+  setSelectedProjectId: (id: string) => void;
+  appendConversations: (newConversations: Conversation[]) => void;
+  setHasMore: (value: boolean) => void;
+}
+
+export type UseConversationsDataResult = UseConversationsDataState & UseConversationsDataActions;
+
+export function useConversationsData(): UseConversationsDataResult {
+  const [projects, setProjects] = useState<ProjectResponse[]>([]);
+  const [selectedProjectId, setSelectedProjectId] = useState<string>("");
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [loadingProjects, setLoadingProjects] = useState(true);
+  const [loadingConversations, setLoadingConversations] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+
+  // Fetch projects on mount
+  useEffect(() => {
+    setLoadingProjects(true);
+    api<{ data: ProjectResponse[] }>("/v1/projects")
+      .then((res) => {
+        setProjects(res.data);
+        if (res.data.length > 0) {
+          setSelectedProjectId(res.data[0].id);
+        }
+      })
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load data"))
+      .finally(() => setLoadingProjects(false));
+  }, []);
+
+  // Fetch conversations when selected project changes
+  useEffect(() => {
+    if (!selectedProjectId) return;
+    setLoadingConversations(true);
+    setConversations([]);
+    setHasMore(true);
+    api<{ data: Conversation[] }>(`/v1/projects/${selectedProjectId}/conversations?limit=50`)
+      .then((res) => {
+        setConversations(res.data);
+        setHasMore(res.data.length >= 50);
+      })
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load data"))
+      .finally(() => setLoadingConversations(false));
+  }, [selectedProjectId]);
+
+  const appendConversations = (newConversations: Conversation[]) => {
+    setConversations((prev) => [...prev, ...newConversations]);
+  };
+
+  return {
+    projects,
+    selectedProjectId,
+    conversations,
+    loadingProjects,
+    loadingConversations,
+    hasMore,
+    setSelectedProjectId,
+    appendConversations,
+    setHasMore,
+  };
+}

--- a/packages/dashboard/src/components/dashboard/conversations/_use-conversations-pagination.ts
+++ b/packages/dashboard/src/components/dashboard/conversations/_use-conversations-pagination.ts
@@ -1,0 +1,39 @@
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+import type { Conversation } from "./_use-conversations-data";
+
+interface UseConversationsPaginationResult {
+  isLoadingMore: boolean;
+  loadMore: () => void;
+}
+
+export function useConversationsPagination(
+  selectedProjectId: string,
+  conversations: Conversation[],
+  appendConversations: (newConversations: Conversation[]) => void,
+  setHasMore: (value: boolean) => void,
+  hasMore: boolean,
+): UseConversationsPaginationResult {
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+  const loadMore = useCallback(() => {
+    if (!selectedProjectId || isLoadingMore || !hasMore) return;
+
+    setIsLoadingMore(true);
+    const lastConv = conversations[conversations.length - 1];
+    const cursor = lastConv?.updated_at?.toString();
+
+    api<{ data: Conversation[] }>(
+      `/v1/projects/${selectedProjectId}/conversations?limit=50&cursor=${cursor}`,
+    )
+      .then((res) => {
+        appendConversations(res.data);
+        setHasMore(res.data.length >= 50);
+      })
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load more"))
+      .finally(() => setIsLoadingMore(false));
+  }, [selectedProjectId, isLoadingMore, hasMore, conversations, appendConversations, setHasMore]);
+
+  return { isLoadingMore, loadMore };
+}

--- a/packages/dashboard/src/components/dashboard/conversations/_use-messages.ts
+++ b/packages/dashboard/src/components/dashboard/conversations/_use-messages.ts
@@ -1,0 +1,39 @@
+import type { MessageResponse } from "@agentstate/shared";
+import { useEffect, useRef, useState } from "react";
+import { api } from "@/lib/api";
+
+export type Message = MessageResponse;
+
+interface UseMessagesResult {
+  messages: Message[] | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useMessages(projectId: string, conversationId: string): UseMessagesResult {
+  const [messages, setMessages] = useState<Message[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const loaded = useRef(false);
+
+  useEffect(() => {
+    if (loaded.current) return;
+    loaded.current = true;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await api<{ data: Message[] }>(
+          `/v1/projects/${projectId}/conversations/${conversationId}/messages`,
+        );
+        setMessages(res.data);
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : "Failed to load messages");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [projectId, conversationId]);
+
+  return { messages, loading, error };
+}

--- a/packages/dashboard/src/components/dashboard/conversations/conversations-page.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/conversations-page.tsx
@@ -1,0 +1,88 @@
+import { useRouter } from "next/navigation";
+import { useCallback } from "react";
+import { CardListSkeleton } from "@/components/dashboard/loading-states";
+import { PageHeader } from "@/components/dashboard/page-header";
+import { DashboardShell } from "@/components/dashboard-shell";
+import {
+  _ConversationsTable,
+  _EmptyProjects,
+  _LoadMoreButton,
+  _ProjectSelector,
+} from "./_components";
+import { useConversationsData, useConversationsPagination } from "./_hooks";
+
+function ConversationsContent() {
+  const router = useRouter();
+
+  const {
+    projects,
+    selectedProjectId,
+    conversations,
+    loadingProjects,
+    loadingConversations,
+    hasMore,
+    setSelectedProjectId,
+    appendConversations,
+    setHasMore,
+  } = useConversationsData();
+
+  const { isLoadingMore, loadMore } = useConversationsPagination(
+    selectedProjectId,
+    conversations,
+    appendConversations,
+    setHasMore,
+    hasMore,
+  );
+
+  const selectedProject = projects.find((p) => p.id === selectedProjectId);
+  const handleCreateProject = useCallback(() => router.push("/dashboard"), [router]);
+  const handleSelectProject = useCallback(
+    (id: string) => setSelectedProjectId(id),
+    [setSelectedProjectId],
+  );
+
+  return (
+    <div className="px-4 lg:px-6">
+      <PageHeader
+        title="Conversations"
+        description="Browse conversation history across all projects."
+        actions={
+          <_ProjectSelector
+            projects={projects}
+            selectedProjectId={selectedProjectId}
+            onSelectProject={handleSelectProject}
+          />
+        }
+      />
+
+      {loadingProjects && <CardListSkeleton count={3} />}
+
+      {!loadingProjects && projects.length === 0 && (
+        <_EmptyProjects onCreateProject={handleCreateProject} />
+      )}
+
+      {!loadingProjects && projects.length > 0 && (
+        <>
+          <_ConversationsTable
+            selectedProject={selectedProject}
+            loading={loadingConversations}
+            conversations={conversations}
+          />
+          <_LoadMoreButton
+            hasNext={hasMore && conversations.length > 0}
+            loading={isLoadingMore}
+            onLoadMore={loadMore}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+export function ConversationsPage() {
+  return (
+    <DashboardShell>
+      <ConversationsContent />
+    </DashboardShell>
+  );
+}

--- a/packages/dashboard/src/pages/dashboard/conversations.astro
+++ b/packages/dashboard/src/pages/dashboard/conversations.astro
@@ -1,0 +1,8 @@
+---
+import { ConversationsPage } from "@/components/dashboard/conversations/conversations-page";
+import DashboardLayout from "@/layouts/DashboardLayout.astro";
+---
+
+<DashboardLayout>
+  <ConversationsPage client:only="react" />
+</DashboardLayout>


### PR DESCRIPTION
Phase 2 of the Next.js → Astro migration of `packages/dashboard`.

## What

Ports the `/dashboard/conversations` route to the Astro foundation:

- **`src/pages/dashboard/conversations.astro`** — renders a single `client:only="react"` island wrapped in `DashboardLayout`, matching the established pattern (`src/components/dashboard-shell.tsx`).
- **`src/components/dashboard/conversations/conversations-page.tsx`** — `ConversationsPage` island that wraps the original page body (`ConversationsContent`) in `<DashboardShell>`. The body uses `useRouter` (next/navigation shim) but **not** `useSearchParams`, so no `<Suspense>` boundary is required.
- **`src/components/dashboard/conversations/_*.tsx` / `_use-*.ts`** — copies of the 10 co-located files from `src/app/dashboard/conversations/`, with relative imports kept intact and `'use client'` directives stripped.

## Rules followed

- Source under `src/app/` left untouched (copy-out only).
- `next/navigation` import left as-is (aliased to the local shim via tsconfig + Vite).
- Shared components referenced via `@/components/...` (not recreated).
- 1:1 port — pagination (`useConversationsPagination`) and message-loading (`useMessages`, single-load ref guard) logic preserved exactly.

## Verify

- `bunx biome check --write` on new files — clean (2 unsafe-suggestion warnings on the .astro frontmatter `DashboardLayout` import are false positives; it is used in the template).
- `bunx astro check` — **0 errors**, 0 warnings (92 pre-existing deprecation hints in shared components, none from these files).
- `bunx astro dev --port 4324` → `curl /dashboard/conversations/` returns **200** with the DashboardLayout shell.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>