### PR TITLE
feat(dashboard): port /integrate route to Astro

### DIFF
--- a/packages/dashboard/src/components/dashboard/integrate/integrate-content.tsx
+++ b/packages/dashboard/src/components/dashboard/integrate/integrate-content.tsx
@@ -1,0 +1,227 @@
+import { Button } from "@cloudflare/kumo/components/button";
+import { LayerCard } from "@cloudflare/kumo/components/layer-card";
+import { ArrowUpRightIcon } from "@phosphor-icons/react";
+import Link from "next/link";
+import { useState } from "react";
+import { Pill } from "@/components/brand/bits";
+import { CodeBlock } from "@/components/brand/code-block";
+import { FRAMEWORKS, type FrameworkId, FwGlyph } from "@/components/brand/frameworks";
+import { CopyButton } from "@/components/copy-button";
+import { PageHeader } from "@/components/dashboard/page-header";
+import { cn } from "@/lib/utils";
+
+// Per-framework adapter snippets — copy one of these and you're persisting state.
+const ADAPTER_SNIPPETS: Record<FrameworkId, string> = {
+  vercel: `import { generateText } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { AgentState } from "@agentstate/sdk";
+
+const state = new AgentState({ apiKey: AS_KEY });
+const conv = await state.getConversation(id);
+
+const { text } = await generateText({
+  model: openai("gpt-4o"),
+  messages: conv.messages,
+});
+await state.appendMessages(id, [
+  { role: "assistant", content: text },
+]);`,
+  tanstack: `import { AgentState } from "@agentstate/sdk";
+import { createTanStackStore } from "@agentstate/sdk/tanstack";
+
+const state = new AgentState({ apiKey: AS_KEY });
+const store = createTanStackStore(state, {
+  queryKey: ["chat", chatId],
+});
+
+// reads + writes flow through TanStack cache
+const messages = await store.load(chatId);
+await store.append(chatId, turn);`,
+  langgraph: `import { AgentState } from "@agentstate/sdk";
+import { AgentStateCheckpointSaver } from "@agentstate/sdk/langgraph";
+
+const client = new AgentState({ apiKey: AS_KEY });
+const saver = new AgentStateCheckpointSaver(client);
+
+await saver.put(
+  { configurable: { thread_id: "thread-1" } },
+  { id: "cp-1", values: {} },
+  { step: 0 }, {},
+);`,
+  cfagents: `import { Agent } from "agents";
+import { AgentState } from "@agentstate/sdk";
+
+export class ChatAgent extends Agent<Env> {
+  state = new AgentState({ apiKey: this.env.AS_KEY });
+
+  async onMessage(conn, message) {
+    const conv = await this.state.getConversation(this.id);
+    // ...generate reply, then persist
+    await this.state.appendMessages(this.id, turns);
+  }
+}`,
+  workersai: `import { AgentState } from "@agentstate/sdk";
+
+export default {
+  async fetch(req, env) {
+    const state = new AgentState({ apiKey: env.AS_KEY });
+    const conv = await state.getConversation(id);
+    const out = await env.AI.run(
+      "@cf/meta/llama-3.1-8b-instruct",
+      { messages: conv.messages },
+    );
+    await state.appendMessages(id, [out]);
+  },
+};`,
+  openai: `import OpenAI from "openai";
+import { AgentState } from "@agentstate/sdk";
+
+const ai = new OpenAI();
+const state = new AgentState({ apiKey: AS_KEY });
+
+const conv = await state.getConversation(id);
+const res = await ai.chat.completions.create({
+  model: "gpt-4o",
+  messages: conv.messages,
+});
+await state.appendMessages(id, [res.choices[0].message]);`,
+  rest: `# create a conversation
+curl -X POST https://agentstate.app/api/v1/conversations \\
+  -H "Authorization: Bearer as_live_..." \\
+  -H "Content-Type: application/json" \\
+  -d '{"messages":[{"role":"user","content":"Hi"}]}'
+
+# retrieve it later
+curl https://agentstate.app/api/v1/conversations/:id \\
+  -H "Authorization: Bearer as_live_..."`,
+};
+
+const INTEGRATION_PROMPT = `Integrate AgentState into this project for persistent conversation storage.
+
+Read the full integration guide and implement it:
+https://agentstate.app/agents.md
+
+API Base: https://agentstate.app/api
+Auth: Bearer token in Authorization header (key starts with as_live_)
+
+After reading agents.md, store all conversation turns via the API so history persists across sessions.`;
+
+export default function IntegrateContent() {
+  const [fw, setFw] = useState<FrameworkId>("vercel");
+  const active = FRAMEWORKS.find((f) => f.id === fw) ?? FRAMEWORKS[0];
+  const isCurl = fw === "rest";
+
+  return (
+    <div className="flex flex-col gap-5 px-4 lg:px-6">
+      <PageHeader
+        title="Integrate"
+        description="Pick your framework — copy the adapter and you're persisting state."
+      />
+
+      {/* Adapter switcher */}
+      <div className="grid grid-cols-1 gap-[18px] md:grid-cols-[230px_1fr]">
+        {/* Framework list */}
+        <div className="flex flex-col gap-1.5">
+          {FRAMEWORKS.map((f) => {
+            const selected = f.id === fw;
+            return (
+              <button
+                key={f.id}
+                type="button"
+                onClick={() => setFw(f.id)}
+                aria-pressed={selected}
+                className={cn(
+                  "flex items-center gap-[11px] rounded-lg border px-3 py-[11px] text-left transition-all",
+                  selected
+                    ? "border-foreground bg-kumo-base shadow-sm"
+                    : "border-border bg-muted hover:border-foreground/20",
+                )}
+              >
+                <span className="flex size-[30px] flex-shrink-0 items-center justify-center rounded-lg border border-border bg-muted">
+                  <FwGlyph kind={f.glyph} size={16} />
+                </span>
+                <span className="min-w-0">
+                  <span className="block text-[13.5px] font-semibold text-foreground">
+                    {f.name}
+                  </span>
+                  <span className="block font-mono text-[10.5px] text-muted-foreground">
+                    {f.tag}
+                  </span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Active framework detail */}
+        <div className="flex flex-col gap-3.5">
+          <div className="flex items-center gap-3.5 rounded-lg border border-border bg-kumo-base p-[18px]">
+            <span className="flex size-11 flex-shrink-0 items-center justify-center rounded-[9px] border border-border bg-muted">
+              <FwGlyph kind={active.glyph} size={22} />
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="text-[17px] font-semibold text-foreground">{active.name}</div>
+              <div className="mt-0.5 font-mono text-[12px] text-muted-foreground">
+                {isCurl ? "no SDK required · raw REST" : "npm i @agentstate/sdk"}
+              </div>
+            </div>
+            <Pill>
+              <span className="size-1.5 rounded-full bg-brand" />
+              ready
+            </Pill>
+          </div>
+
+          <CodeBlock code={ADAPTER_SNIPPETS[fw]} title={isCurl ? "terminal" : `${active.tag}.ts`} />
+
+          <div className="flex items-center justify-between rounded-lg border border-border bg-muted px-4 py-3.5">
+            <span className="text-[13px] text-muted-foreground">
+              Need the full guide for {active.name}?
+            </span>
+            <a href="https://agentstate.app/agents.md" target="_blank" rel="noreferrer">
+              <Button size="sm" variant="ghost" className="text-muted-foreground">
+                agents.md
+                <ArrowUpRightIcon aria-hidden="true" />
+              </Button>
+            </a>
+          </div>
+        </div>
+      </div>
+
+      <hr className="my-1 border-border" />
+
+      {/* Coding-agent system prompt */}
+      <section className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1.5">
+          <span className="as-label text-[10.5px]">For coding agents</span>
+          <h2 className="text-[17px] font-semibold text-foreground">
+            Hand this to your coding agent
+          </h2>
+        </div>
+
+        <LayerCard className="overflow-hidden p-0">
+          <div className="flex items-center justify-between border border-b border-border bg-muted px-4 py-2.5">
+            <span className="font-mono text-[11px] text-muted-foreground">system-prompt.txt</span>
+            <CopyButton text={INTEGRATION_PROMPT} />
+          </div>
+          <pre className="overflow-x-auto whitespace-pre-wrap p-5 font-mono text-xs leading-relaxed text-foreground/80">
+            {INTEGRATION_PROMPT}
+          </pre>
+        </LayerCard>
+
+        <div className="flex items-center gap-5 font-mono text-xs text-muted-foreground">
+          <Link href="/docs" className="transition-colors hover:text-foreground">
+            API reference
+          </Link>
+          <Link
+            href="https://agentstate.app/agents.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="transition-colors hover:text-foreground"
+          >
+            agents.md
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/integrate/integrate-page.tsx
+++ b/packages/dashboard/src/components/dashboard/integrate/integrate-page.tsx
@@ -1,0 +1,14 @@
+import { DashboardShell } from "@/components/dashboard-shell";
+import IntegrateContent from "./integrate-content";
+
+/**
+ * Astro entry for the /dashboard/integrate route.
+ * Mounts the ported Next page body inside the shared auth-gated dashboard shell.
+ */
+export function IntegratePage() {
+  return (
+    <DashboardShell>
+      <IntegrateContent />
+    </DashboardShell>
+  );
+}

--- a/packages/dashboard/src/pages/dashboard/integrate.astro
+++ b/packages/dashboard/src/pages/dashboard/integrate.astro
@@ -1,0 +1,8 @@
+---
+import { IntegratePage } from "@/components/dashboard/integrate/integrate-page";
+import DashboardLayout from "@/layouts/DashboardLayout.astro";
+---
+
+<DashboardLayout>
+  <IntegratePage client:only="react" />
+</DashboardLayout>


### PR DESCRIPTION
Phase 2 of the Next.js → Astro dashboard migration.

Ports the `/dashboard/integrate` route (framework adapter picker + coding-agent system prompt). Page body is a `client:only="react"` island wrapped in `DashboardShell`; `next/link` resolves via the existing shim.

- `src/pages/dashboard/integrate.astro`
- `src/components/dashboard/integrate/integrate-page.tsx` (DashboardShell wrapper)
- `src/components/dashboard/integrate/integrate-content.tsx` (ported body)

Verified: `astro check` 0 errors, `biome check` clean. Legacy `src/app/` untouched (Phase 3 deletes it).