### PR TITLE
feat(dashboard): port /analytics route to Astro

### DIFF
--- a/packages/dashboard/src/components/dashboard/analytics/_active-projects-summary.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_active-projects-summary.tsx
@@ -1,0 +1,24 @@
+import { HashIcon } from "@phosphor-icons/react";
+
+import { MetricCard } from "./_metric-card";
+
+interface ActiveProjectsSummaryProps {
+  activeApiKeys: number;
+  totalMessages: number;
+}
+
+export function ActiveProjectsSummary({
+  activeApiKeys,
+  totalMessages,
+}: ActiveProjectsSummaryProps) {
+  return (
+    <MetricCard
+      title="Active Projects"
+      subtitle="API keys with activity"
+      value={activeApiKeys}
+      unit={activeApiKeys === 1 ? "project" : "projects"}
+      footnote={`${totalMessages.toLocaleString()} total messages`}
+      icon={HashIcon}
+    />
+  );
+}

--- a/packages/dashboard/src/components/dashboard/analytics/_analytics-content.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_analytics-content.tsx
@@ -1,0 +1,96 @@
+import type { AnalyticsResponse } from "@agentstate/shared";
+import { Text } from "@cloudflare/kumo";
+import { AreaChartCard } from "@/components/analytics/area-chart";
+import { RecentActivity } from "@/components/analytics/recent-activity";
+import { SummaryCards } from "@/components/analytics/summary-cards";
+import { formatCostMicrodollars } from "@/lib/format-cost";
+import {
+  ActiveProjectsSummary,
+  PeakUsage,
+  TokenTrendSummary,
+  TopConversations,
+} from "./_components";
+
+interface AnalyticsContentProps {
+  data: AnalyticsResponse;
+}
+
+export function AnalyticsContent({ data }: AnalyticsContentProps) {
+  const hasCost = data.cost_per_day && data.cost_per_day.length > 0;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <SummaryCards
+        totalConversations={data.summary.total_conversations}
+        totalMessages={data.summary.total_messages}
+        totalTokens={data.summary.total_tokens}
+        totalCostMicrodollars={data.summary.total_cost_microdollars}
+        activeApiKeys={data.summary.active_api_keys}
+      />
+
+      {/* Primary charts: conversations + messages side by side. */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <AreaChartCard
+          title="Conversations"
+          data={data.conversations_per_day.map((d) => ({ date: d.date, value: d.count }))}
+          color="var(--chart-1)"
+          valueLabel="Conversations"
+        />
+        <AreaChartCard
+          title="Messages"
+          data={data.messages_per_day.map((d) => ({ date: d.date, value: d.count }))}
+          color="var(--chart-2)"
+          valueLabel="Messages"
+        />
+      </div>
+
+      {/* Token usage spans full width with time-range filter. */}
+      <AreaChartCard
+        title="Token usage"
+        data={data.tokens_per_day.map((d) => ({ date: d.date, value: d.total }))}
+        color="var(--chart-3)"
+        valueLabel="Tokens"
+        showTimeRange
+      />
+
+      {hasCost && (
+        <AreaChartCard
+          title="Cost"
+          data={data.cost_per_day.map((d) => ({
+            date: d.date,
+            value: d.total_cost_microdollars / 1_000_000,
+          }))}
+          color="var(--chart-4)"
+          valueLabel="Cost ($)"
+          formatValue={(v) => formatCostMicrodollars(v * 1_000_000)}
+          showTimeRange
+        />
+      )}
+
+      {/* Derived insights from the same live data. */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <PeakUsage messagesPerDay={data.messages_per_day} />
+        <TokenTrendSummary tokensPerDay={data.tokens_per_day} />
+        <ActiveProjectsSummary
+          activeApiKeys={data.summary.active_api_keys}
+          totalMessages={data.summary.total_messages}
+        />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div className="flex flex-col gap-3">
+          <Text variant="heading3" as="h3">
+            Recent activity
+          </Text>
+          <RecentActivity conversations={data.recent_conversations} />
+        </div>
+        <div className="flex flex-col gap-3">
+          <Text variant="heading3" as="h3">
+            Top conversations
+          </Text>
+          <TopConversations conversations={data.recent_conversations} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/analytics/_analytics-empty.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_analytics-empty.tsx
@@ -1,0 +1,24 @@
+import { Button, LayerCard, Text } from "@cloudflare/kumo";
+import { ChartLineIcon } from "@phosphor-icons/react";
+import { useRouter } from "next/navigation";
+
+export function AnalyticsEmpty() {
+  const router = useRouter();
+
+  return (
+    <LayerCard className="flex flex-col items-center justify-center p-12 text-center">
+      <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-muted/60">
+        <ChartLineIcon className="h-6 w-6 text-muted-foreground" aria-hidden="true" />
+      </div>
+      <Text variant="heading3" as="h3">
+        No projects yet
+      </Text>
+      <Text variant="secondary" as="p" size="sm">
+        Create a project to start tracking conversations, messages, and token usage.
+      </Text>
+      <Button size="sm" variant="outline" onClick={() => router.push("/dashboard")}>
+        Create your first project
+      </Button>
+    </LayerCard>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/analytics/_analytics-header.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_analytics-header.tsx
@@ -1,0 +1,47 @@
+import type { ProjectResponse } from "@agentstate/shared";
+import { Select } from "@cloudflare/kumo";
+import { type TimeRange, TimeRangeSelect } from "@/components/analytics/time-range-select";
+import { PageHeader } from "@/components/dashboard/page-header";
+
+interface AnalyticsHeaderProps {
+  projects: ProjectResponse[];
+  selectedProjectId: string;
+  onProjectChange: (projectId: string) => void;
+  range: TimeRange;
+  onRangeChange: (range: TimeRange) => void;
+}
+
+export function AnalyticsHeader({
+  projects,
+  selectedProjectId,
+  onProjectChange,
+  range,
+  onRangeChange,
+}: AnalyticsHeaderProps) {
+  const projectItems = Object.fromEntries(projects.map((p) => [p.id, p.name]));
+
+  return (
+    <PageHeader
+      title="Analytics"
+      description="Usage metrics and activity for your project."
+      actions={
+        <>
+          {projects.length > 1 && (
+            <Select
+              aria-label="Select project"
+              className="w-[180px]"
+              value={selectedProjectId}
+              onValueChange={(value) => {
+                if (value) {
+                  onProjectChange(value);
+                }
+              }}
+              items={projectItems}
+            />
+          )}
+          <TimeRangeSelect value={range} onChange={onRangeChange} />
+        </>
+      }
+    />
+  );
+}

--- a/packages/dashboard/src/components/dashboard/analytics/_analytics-loading.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_analytics-loading.tsx
@@ -1,0 +1,29 @@
+import { Loader } from "@cloudflare/kumo";
+import { ChartCardSkeleton, StatsCardsSkeleton } from "@/components/dashboard/loading-states";
+
+interface AnalyticsLoadingProps {
+  hasData: boolean;
+}
+
+export function AnalyticsLoading({ hasData }: AnalyticsLoadingProps) {
+  if (hasData) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <Loader size="sm" aria-hidden="true" />
+        <span>Refreshing...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-6 flex flex-col gap-4">
+      <StatsCardsSkeleton count={4} />
+      <div className="grid gap-4 lg:grid-cols-2">
+        <ChartCardSkeleton height="h-64" />
+        <ChartCardSkeleton height="h-64" />
+      </div>
+      <ChartCardSkeleton height="h-64" />
+      <ChartCardSkeleton height="h-48" />
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/analytics/_components.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_components.tsx
@@ -1,0 +1,8 @@
+// Re-exports for analytics components
+
+export { ActiveProjectsSummary } from "./_active-projects-summary";
+export { EmptyCard } from "./_empty-card";
+export { MetricCard } from "./_metric-card";
+export { PeakUsage } from "./_peak-usage";
+export { TokenTrendSummary } from "./_token-trend-summary";
+export { TopConversations } from "./_top-conversations";

--- a/packages/dashboard/src/components/dashboard/analytics/_empty-card.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_empty-card.tsx
@@ -1,0 +1,20 @@
+import { LayerCard } from "@cloudflare/kumo";
+import type { Icon } from "@phosphor-icons/react";
+import { cn } from "@/lib/utils";
+
+interface EmptyCardProps {
+  icon: Icon;
+  message: string;
+  minHeight?: string;
+}
+
+export function EmptyCard({ icon: Icon, message, minHeight = "min-h-[140px]" }: EmptyCardProps) {
+  return (
+    <LayerCard
+      className={cn("flex flex-col items-center justify-center p-6 text-center", minHeight)}
+    >
+      <Icon className="h-6 w-6 text-muted-foreground mb-2" />
+      <p className="text-sm text-muted-foreground">{message}</p>
+    </LayerCard>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/analytics/_metric-card.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_metric-card.tsx
@@ -1,0 +1,52 @@
+import { LayerCard, Text } from "@cloudflare/kumo";
+import type { Icon } from "@phosphor-icons/react";
+import { cn } from "@/lib/utils";
+
+interface MetricCardProps {
+  title: string;
+  subtitle: string;
+  value: string | number;
+  unit: string;
+  footnote?: React.ReactNode;
+  icon: Icon;
+  iconBg?: string;
+  iconColor?: string;
+}
+
+export function MetricCard({
+  title,
+  subtitle,
+  value,
+  unit,
+  footnote,
+  icon: Icon,
+  iconBg = "bg-primary/10",
+  iconColor = "text-primary",
+}: MetricCardProps) {
+  return (
+    <LayerCard className="flex flex-col gap-4 p-5">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-col gap-1">
+          <Text variant="heading3" as="h3">
+            {title}
+          </Text>
+          <Text variant="secondary" as="p">
+            {subtitle}
+          </Text>
+        </div>
+        <div className={cn("flex size-8 items-center justify-center rounded-lg", iconBg)}>
+          <Icon className={iconColor} aria-hidden="true" />
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <div className="flex items-baseline gap-2">
+          <span className="text-3xl font-semibold tabular-nums">
+            {typeof value === "number" ? value.toLocaleString() : value}
+          </span>
+          <span className="text-sm text-muted-foreground">{unit}</span>
+        </div>
+        {footnote && <p className="text-xs text-muted-foreground">{footnote}</p>}
+      </div>
+    </LayerCard>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/analytics/_peak-usage.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_peak-usage.tsx
@@ -1,0 +1,40 @@
+import { ChartLineUpIcon } from "@phosphor-icons/react";
+
+import { EmptyCard } from "./_empty-card";
+import { MetricCard } from "./_metric-card";
+
+interface PeakUsageProps {
+  messagesPerDay: { date: string; count: number }[];
+}
+
+export function PeakUsage({ messagesPerDay }: PeakUsageProps) {
+  if (messagesPerDay.length === 0) {
+    return <EmptyCard icon={ChartLineUpIcon} message="No data yet" />;
+  }
+
+  const peak = messagesPerDay.reduce((max, curr) => (curr.count > max.count ? curr : max));
+  const total = messagesPerDay.reduce((sum, d) => sum + d.count, 0);
+  const average = Math.round(total / messagesPerDay.length);
+  const aboveAverage = Math.round(((peak.count - average) / average) * 100);
+
+  const formatDate = (dateStr: string) => {
+    const d = new Date(dateStr);
+    return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  };
+
+  return (
+    <MetricCard
+      title="Peak Daily Messages"
+      subtitle={formatDate(peak.date)}
+      value={peak.count}
+      unit="messages"
+      footnote={
+        <>
+          Average: {average.toLocaleString()}/day
+          <span className="ml-2 text-rose-500">(+{aboveAverage}% above avg)</span>
+        </>
+      }
+      icon={ChartLineUpIcon}
+    />
+  );
+}

--- a/packages/dashboard/src/components/dashboard/analytics/_token-trend-summary.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_token-trend-summary.tsx
@@ -1,0 +1,53 @@
+import { ArrowDownIcon, ArrowUpIcon, HashIcon } from "@phosphor-icons/react";
+
+import { cn } from "@/lib/utils";
+import { EmptyCard } from "./_empty-card";
+import { MetricCard } from "./_metric-card";
+
+interface TokenDataPoint {
+  date: string;
+  total: number;
+}
+
+interface TokenTrendSummaryProps {
+  tokensPerDay: TokenDataPoint[];
+}
+
+export function TokenTrendSummary({ tokensPerDay }: TokenTrendSummaryProps) {
+  if (tokensPerDay.length === 0) {
+    return <EmptyCard icon={HashIcon} message="No data yet" />;
+  }
+
+  const midPoint = Math.floor(tokensPerDay.length / 2);
+  const recent = tokensPerDay.slice(midPoint);
+  const earlier = tokensPerDay.slice(0, midPoint);
+
+  const recentTotal = recent.reduce((sum, d) => sum + d.total, 0);
+  const earlierTotal = earlier.reduce((sum, d) => sum + d.total, 0);
+  const recentAvg = Math.round(recentTotal / recent.length);
+  const earlierAvg = Math.round(earlierTotal / earlier.length);
+
+  const change = earlierAvg > 0 ? Math.round(((recentAvg - earlierAvg) / earlierAvg) * 100) : 0;
+  const isUp = change >= 0;
+
+  return (
+    <MetricCard
+      title="Token Trend"
+      subtitle="Recent vs earlier period"
+      value={recentAvg}
+      unit="tokens/day"
+      footnote={
+        <>
+          Was {earlierAvg.toLocaleString()}/day
+          <span className={cn("ml-2", isUp ? "text-emerald-600" : "text-rose-500")}>
+            ({isUp ? "+" : ""}
+            {change}%)
+          </span>
+        </>
+      }
+      icon={isUp ? ArrowUpIcon : ArrowDownIcon}
+      iconBg={isUp ? "bg-emerald-500/10" : "bg-rose-500/10"}
+      iconColor={isUp ? "text-emerald-600" : "text-rose-500"}
+    />
+  );
+}

--- a/packages/dashboard/src/components/dashboard/analytics/_top-conversations.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_top-conversations.tsx
@@ -1,0 +1,60 @@
+import { LayerCard, Text } from "@cloudflare/kumo";
+import { ChatCircleIcon } from "@phosphor-icons/react";
+import { EmptyState } from "@/components/dashboard/empty-state";
+
+interface ConversationData {
+  id: string;
+  title: string | null;
+  message_count: number;
+  token_count: number;
+  updated_at: number;
+}
+
+interface TopConversationsProps {
+  conversations: ConversationData[];
+  limit?: number;
+}
+
+export function TopConversations({ conversations, limit = 5 }: TopConversationsProps) {
+  const sorted = [...conversations]
+    .sort((a, b) => b.message_count - a.message_count)
+    .slice(0, limit);
+
+  if (sorted.length === 0) {
+    return (
+      <LayerCard className="h-full min-h-[200px]">
+        <EmptyState
+          icon={<ChatCircleIcon aria-hidden="true" />}
+          title="No conversations yet"
+          description="Top conversations will appear after messages are stored."
+        />
+      </LayerCard>
+    );
+  }
+
+  return (
+    <LayerCard className="h-full p-5">
+      <div className="flex flex-col gap-1">
+        <Text variant="heading3" as="h3">
+          Top Conversations
+        </Text>
+        <Text variant="secondary" as="p">
+          By message count
+        </Text>
+      </div>
+      <div className="mt-4 flex flex-col gap-3">
+        {sorted.map((conv, index) => (
+          <div key={conv.id} className="flex items-center gap-3">
+            <span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-muted text-xs font-medium tabular-nums">
+              {index + 1}
+            </span>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium truncate">{conv.title || "Untitled"}</p>
+              <p className="text-xs text-muted-foreground">{conv.message_count} messages</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </LayerCard>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/analytics/analytics-page-content.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/analytics-page-content.tsx
@@ -1,0 +1,65 @@
+import type { AnalyticsResponse, ProjectResponse } from "@agentstate/shared";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import type { TimeRange } from "@/components/analytics/time-range-select";
+import { api } from "@/lib/api";
+import { AnalyticsContent } from "./_analytics-content";
+import { AnalyticsEmpty } from "./_analytics-empty";
+import { AnalyticsHeader } from "./_analytics-header";
+import { AnalyticsLoading } from "./_analytics-loading";
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export function AnalyticsPageContent() {
+  const [projects, setProjects] = useState<ProjectResponse[]>([]);
+  const [selectedProjectId, setSelectedProjectId] = useState("");
+  const [range, setRange] = useState<TimeRange>("30d");
+  const [data, setData] = useState<AnalyticsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // Fetch projects
+  useEffect(() => {
+    api<{ data: ProjectResponse[] }>("/v1/projects")
+      .then((res) => {
+        setProjects(res.data);
+        if (res.data.length > 0) {
+          setSelectedProjectId(res.data[0].id);
+        }
+      })
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load data"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  // Fetch analytics when project or range changes
+  useEffect(() => {
+    if (!selectedProjectId) return;
+    setLoading(true);
+    api<AnalyticsResponse>(`/v1/projects/${selectedProjectId}/analytics?range=${range}`)
+      .then(setData)
+      .catch((e) => {
+        setData(null);
+        toast.error(e instanceof Error ? e.message : "Failed to load analytics");
+      })
+      .finally(() => setLoading(false));
+  }, [selectedProjectId, range]);
+
+  return (
+    <div className="flex flex-col gap-6 px-4 lg:px-6">
+      <AnalyticsHeader
+        projects={projects}
+        selectedProjectId={selectedProjectId}
+        onProjectChange={setSelectedProjectId}
+        range={range}
+        onRangeChange={setRange}
+      />
+
+      {loading && <AnalyticsLoading hasData={!!data} />}
+
+      {data && <AnalyticsContent data={data} />}
+
+      {!loading && projects.length === 0 && <AnalyticsEmpty />}
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/analytics/analytics-page.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/analytics-page.tsx
@@ -1,0 +1,17 @@
+import { DashboardShell } from "@/components/dashboard-shell";
+import { AnalyticsPageContent } from "./analytics-page-content";
+
+/**
+ * Astro client:only island for /dashboard/analytics.
+ *
+ * Wraps the ported Next.js page body in <DashboardShell> (Clerk Providers +
+ * auth gate + sidebar/header). The page uses local state only — no
+ * useSearchParams — so no <Suspense> boundary is required.
+ */
+export function AnalyticsPage() {
+  return (
+    <DashboardShell>
+      <AnalyticsPageContent />
+    </DashboardShell>
+  );
+}

--- a/packages/dashboard/src/pages/dashboard/analytics.astro
+++ b/packages/dashboard/src/pages/dashboard/analytics.astro
@@ -1,0 +1,8 @@
+---
+import { AnalyticsPage } from "@/components/dashboard/analytics/analytics-page";
+import DashboardLayout from "@/layouts/DashboardLayout.astro";
+---
+
+<DashboardLayout>
+  <AnalyticsPage client:only="react" />
+</DashboardLayout>


### PR DESCRIPTION
Phase 2 of the Next.js → Astro migration. Ports the `/dashboard/analytics` route.

## Changes
- `src/pages/dashboard/analytics.astro` — new Astro page rendering a single `client:only="react"` island inside `DashboardLayout`.
- `src/components/dashboard/analytics/analytics-page.tsx` — wraps the page body in `<DashboardShell>` (Clerk Providers + auth gate + sidebar/header chrome).
- `src/components/dashboard/analytics/analytics-page-content.tsx` — the ported page body (project fetch + range fetch + render).
- 11 co-located `_*.tsx` files copied 1:1 from `src/app/dashboard/analytics/` with relative imports intact; `'use client'` directives stripped.

## Notes
- Shared components (`@/components/analytics/*`, `@/components/dashboard/*`) resolve unchanged via the existing alias config — none recreated.
- `next/navigation` (`useRouter`) left intact per the shim convention (`src/lib/navigation.ts`).
- The page uses local state only (no `useSearchParams`), so no `<Suspense>` boundary is required.
- Echarts chart logic (area-chart, summary-cards, recent-activity, peak-usage, token-trend) preserved exactly — this is a pure route-port, no logic changes.

## Pattern
Follows the established Phase-2 pattern from `/dashboard/traces` (`traces.astro` + `traces-page.tsx`).

## Verification
- `bunx biome check` — TSX files clean (the lone biome warning on the `.astro` frontmatter is a known false-positive identical to `traces.astro` on `main`).
- `bunx astro check` — **0 errors, 0 warnings**.
- `curl http://localhost:4323/dashboard/analytics/` — `200`.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>