### PR TITLE
feat(dashboard): port /settings/organizations subtree to Astro

### DIFF
--- a/packages/dashboard/src/components/dashboard/organizations/create/_create-org-form.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/_create-org-form.tsx
@@ -1,0 +1,101 @@
+import { Button } from "@cloudflare/kumo/components/button";
+import { Input } from "@cloudflare/kumo/components/input";
+import { LayerCard } from "@cloudflare/kumo/components/layer-card";
+import { Text } from "@cloudflare/kumo/components/text";
+import { useRouter } from "next/navigation";
+import type * as React from "react";
+import { DomainWarning } from "./_domain-warning";
+import { useCreateOrganization } from "./_use-create-organization";
+
+interface CreateOrgFormProps {
+  organizationName: string;
+  setOrganizationName: (name: string) => void;
+  isSubmitting: boolean;
+  setIsSubmitting: (submitting: boolean) => void;
+  createOrganization: ((params: { name: string }) => Promise<{ id: string }>) | undefined;
+  setActive: ((params: { organization: string }) => Promise<void>) | undefined;
+  showWarning: boolean;
+  existingOrgName: string | undefined;
+  existingOrgDomain: string | undefined;
+}
+
+export function CreateOrgForm({
+  organizationName,
+  setOrganizationName,
+  isSubmitting,
+  setIsSubmitting,
+  createOrganization,
+  setActive,
+  showWarning,
+  existingOrgName,
+  existingOrgDomain,
+}: CreateOrgFormProps) {
+  const router = useRouter();
+  const { createOrganizationByName } = useCreateOrganization({
+    createOrganization,
+    setActive,
+    onSuccess: () => router.push("/dashboard/settings/organizations"),
+  });
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (isSubmitting) return;
+
+    setIsSubmitting(true);
+    await createOrganizationByName(organizationName);
+    setIsSubmitting(false);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <LayerCard className="flex max-w-xl flex-col gap-6 p-6">
+        <div className="flex flex-col gap-2">
+          <Text variant="heading3" as="h2">
+            Organization Details
+          </Text>
+          <Text variant="secondary" as="p">
+            Enter a name for your organization. You can invite members after creation.
+          </Text>
+        </div>
+        <div className="flex flex-col gap-2">
+          <Input
+            id="name"
+            type="text"
+            label="Organization Name"
+            value={organizationName}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setOrganizationName(e.currentTarget.value)
+            }
+            placeholder="Acme Inc"
+            disabled={isSubmitting}
+            required
+          />
+          {showWarning && (
+            <DomainWarning
+              existingOrgName={existingOrgName}
+              existingOrgDomain={existingOrgDomain}
+            />
+          )}
+        </div>
+        <div className="flex gap-2">
+          <Button
+            type="submit"
+            variant="primary"
+            disabled={!organizationName.trim() || isSubmitting}
+            loading={isSubmitting}
+          >
+            {isSubmitting ? "Creating..." : "Create Organization"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => router.push("/dashboard/settings/organizations")}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+        </div>
+      </LayerCard>
+    </form>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/organizations/create/_create-org-header.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/_create-org-header.tsx
@@ -1,0 +1,21 @@
+import { Button } from "@cloudflare/kumo/components/button";
+import { ArrowLeftIcon } from "@phosphor-icons/react";
+import Link from "next/link";
+
+export function CreateOrgHeader() {
+  return (
+    <header className="flex items-center gap-3 border-border border-b pb-5">
+      <Link href="/dashboard/settings/organizations">
+        <Button variant="ghost" shape="square" size="sm" aria-label="Back to organizations">
+          <ArrowLeftIcon aria-hidden="true" />
+        </Button>
+      </Link>
+      <div className="flex flex-col gap-1">
+        <h1 className="text-[26px] tracking-tight text-foreground">Create Organization</h1>
+        <p className="text-[14.5px] leading-6 text-muted-foreground">
+          Set up a new organization for your team
+        </p>
+      </div>
+    </header>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/organizations/create/_create-org-loading.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/_create-org-loading.tsx
@@ -1,0 +1,29 @@
+import { Button } from "@cloudflare/kumo/components/button";
+import { Surface } from "@cloudflare/kumo/components/surface";
+import { ArrowLeftIcon } from "@phosphor-icons/react";
+import Link from "next/link";
+import { FormSkeleton, PageHeaderSkeleton } from "@/components/dashboard/loading-states";
+
+export function CreateOrgLoading() {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center gap-4">
+        <Link href="/dashboard/settings/organizations">
+          <Button
+            variant="ghost"
+            shape="square"
+            size="sm"
+            disabled
+            aria-label="Back to organizations"
+          >
+            <ArrowLeftIcon aria-hidden="true" />
+          </Button>
+        </Link>
+        <PageHeaderSkeleton />
+      </div>
+      <Surface className="flex max-w-xl flex-col gap-6 p-6">
+        <FormSkeleton fields={1} />
+      </Surface>
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/organizations/create/_domain-warning.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/_domain-warning.tsx
@@ -1,0 +1,19 @@
+import { Banner } from "@cloudflare/kumo/components/banner";
+import { WarningIcon } from "@phosphor-icons/react";
+
+interface DomainWarningProps {
+  existingOrgName: string | undefined;
+  existingOrgDomain: string | undefined;
+}
+
+export function DomainWarning({ existingOrgName, existingOrgDomain }: DomainWarningProps) {
+  return (
+    <Banner
+      variant="alert"
+      icon={<WarningIcon aria-hidden="true" weight="fill" />}
+      description={`An organization ${existingOrgName ?? "Unknown"} already exists for the domain ${
+        existingOrgDomain ?? "unknown"
+      }.`}
+    />
+  );
+}

--- a/packages/dashboard/src/components/dashboard/organizations/create/_use-create-organization.ts
+++ b/packages/dashboard/src/components/dashboard/organizations/create/_use-create-organization.ts
@@ -1,0 +1,59 @@
+import { toast } from "sonner";
+
+interface CreateOrganizationParams {
+  name: string;
+}
+
+interface CreateOrganizationResult {
+  id: string;
+}
+
+interface UseCreateOrganizationOptions {
+  createOrganization?:
+    | ((params: CreateOrganizationParams) => Promise<CreateOrganizationResult>)
+    | undefined;
+  setActive?: ((params: { organization: string }) => Promise<void>) | undefined;
+  onSuccess?: () => void;
+}
+
+interface UseCreateOrganizationReturn {
+  createOrganizationByName: (
+    organizationName: string,
+  ) => Promise<{ success: boolean; organizationId?: string; error?: string }>;
+}
+
+export function useCreateOrganization({
+  createOrganization,
+  setActive,
+  onSuccess,
+}: UseCreateOrganizationOptions): UseCreateOrganizationReturn {
+  const createOrganizationByName = async (
+    organizationName: string,
+  ): Promise<{ success: boolean; organizationId?: string; error?: string }> => {
+    if (!organizationName.trim()) {
+      return { success: false, error: "Organization name is required" };
+    }
+
+    try {
+      const newOrganization = await createOrganization?.({
+        name: organizationName.trim(),
+      });
+
+      if (newOrganization) {
+        await setActive?.({ organization: newOrganization.id });
+        toast.success("Organization created successfully");
+        onSuccess?.();
+        return { success: true, organizationId: newOrganization.id };
+      }
+
+      return { success: false, error: "Failed to create organization" };
+    } catch (err: unknown) {
+      const error = err as { errors?: Array<{ message?: string }> };
+      const message = error?.errors?.[0]?.message ?? "Failed to create organization";
+      toast.error(message);
+      return { success: false, error: message };
+    }
+  };
+
+  return { createOrganizationByName };
+}

--- a/packages/dashboard/src/components/dashboard/organizations/create/create-org-content.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/create-org-content.tsx
@@ -1,0 +1,49 @@
+import { useOrganizationCreationDefaults, useOrganizationList, useUser } from "@clerk/react";
+import * as React from "react";
+import { CreateOrgForm } from "./_create-org-form";
+import { CreateOrgHeader } from "./_create-org-header";
+import { CreateOrgLoading } from "./_create-org-loading";
+
+export function CreateOrgContent() {
+  const { isLoaded, isSignedIn } = useUser();
+  const { isLoaded: isOrgListLoaded, createOrganization, setActive } = useOrganizationList();
+  const { data: defaults, isLoading: isLoadingDefaults } = useOrganizationCreationDefaults();
+  const [organizationName, setOrganizationName] = React.useState("");
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+
+  React.useEffect(() => {
+    if (defaults?.form.name) {
+      setOrganizationName(defaults.form.name);
+    }
+  }, [defaults?.form.name]);
+
+  if (!isLoaded || !isOrgListLoaded || isLoadingDefaults) {
+    return <CreateOrgLoading />;
+  }
+
+  if (!isSignedIn) {
+    return null;
+  }
+
+  const advisory = defaults?.advisory;
+  const showWarning = advisory?.code === "organization_already_exists";
+  const existingOrgName = advisory?.meta?.organization_name;
+  const existingOrgDomain = advisory?.meta?.organization_domain;
+
+  return (
+    <div className="flex flex-col gap-6 px-4 lg:px-6">
+      <CreateOrgHeader />
+      <CreateOrgForm
+        organizationName={organizationName}
+        setOrganizationName={setOrganizationName}
+        isSubmitting={isSubmitting}
+        setIsSubmitting={setIsSubmitting}
+        createOrganization={createOrganization}
+        setActive={setActive}
+        showWarning={showWarning}
+        existingOrgName={existingOrgName}
+        existingOrgDomain={existingOrgDomain}
+      />
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/organizations/create/create-org-page.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/create-org-page.tsx
@@ -1,0 +1,10 @@
+import { DashboardShell } from "@/components/dashboard-shell";
+import { CreateOrgContent } from "./create-org-content";
+
+export function CreateOrgPage() {
+  return (
+    <DashboardShell>
+      <CreateOrgContent />
+    </DashboardShell>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/organizations/list/organizations-list-content.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/list/organizations-list-content.tsx
@@ -1,0 +1,98 @@
+import { useOrganization, useUser } from "@clerk/react";
+import { Badge } from "@cloudflare/kumo/components/badge";
+import { Button } from "@cloudflare/kumo/components/button";
+import { LayerCard } from "@cloudflare/kumo/components/layer-card";
+import { BuildingsIcon, CaretRightIcon, PlusIcon } from "@phosphor-icons/react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { EmptyState } from "@/components/dashboard/empty-state";
+import { CardListSkeleton } from "@/components/dashboard/loading-states";
+import { PageHeader } from "@/components/dashboard/page-header";
+import { useOrganizationsList } from "@/hooks/_use-organizations-list";
+
+function OrgListSkeleton() {
+  return <CardListSkeleton count={3} />;
+}
+
+export function OrganizationsListContent() {
+  const router = useRouter();
+  const { isLoaded: isUserLoaded, isSignedIn } = useUser();
+  const { organizations, isLoaded: isOrgListLoaded } = useOrganizationsList();
+  const { organization: activeOrg } = useOrganization();
+
+  if (!isUserLoaded || !isOrgListLoaded) {
+    return (
+      <div className="flex flex-col gap-6 px-4 lg:px-6">
+        <PageHeader title="Organizations" description="Manage your organizations and members" />
+        <OrgListSkeleton />
+      </div>
+    );
+  }
+
+  if (!isSignedIn) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-6 px-4 lg:px-6">
+      <PageHeader
+        title="Organizations"
+        description="Manage your organizations and members"
+        actions={
+          <Link href="/dashboard/settings/organizations/create">
+            <Button variant="primary">
+              <PlusIcon aria-hidden="true" />
+              Create Organization
+            </Button>
+          </Link>
+        }
+      />
+
+      {organizations.length === 0 ? (
+        <LayerCard className="border border-border">
+          <EmptyState
+            icon={<BuildingsIcon aria-hidden="true" />}
+            title="No organizations"
+            description="You don't belong to any organizations yet. Create one to get started."
+            action={{
+              label: "Create your first organization",
+              onClick: () => {
+                router.push("/dashboard/settings/organizations/create");
+              },
+            }}
+          />
+        </LayerCard>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {organizations.map((org) => (
+            <LayerCard key={org.id} className="p-4">
+              <div className="flex items-center gap-4">
+                <div className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-border bg-muted text-muted-foreground">
+                  <BuildingsIcon className="size-5" aria-hidden="true" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <h3 className="truncate font-semibold text-foreground">{org.name}</h3>
+                    {activeOrg?.id === org.id && <Badge variant="primary">Active</Badge>}
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    Created {new Date(org.createdAt).toLocaleDateString()}
+                  </p>
+                </div>
+                <Link href={`/dashboard/settings/organizations/members?org=${org.id}`}>
+                  <Button
+                    variant="ghost"
+                    shape="square"
+                    aria-label={`View members for ${org.name}`}
+                  >
+                    <CaretRightIcon aria-hidden="true" />
+                  </Button>
+                </Link>
+              </div>
+            </LayerCard>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/organizations/list/organizations-list-page.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/list/organizations-list-page.tsx
@@ -1,0 +1,10 @@
+import { DashboardShell } from "@/components/dashboard-shell";
+import { OrganizationsListContent } from "./organizations-list-content";
+
+export function OrganizationsListPage() {
+  return (
+    <DashboardShell>
+      <OrganizationsListContent />
+    </DashboardShell>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/organizations/members/_avatar-icon.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_avatar-icon.tsx
@@ -1,0 +1,15 @@
+import { EnvelopeIcon, type Icon, UserIcon } from "@phosphor-icons/react";
+
+export interface AvatarIconProps {
+  readonly icon: "user" | "mail";
+}
+
+export function AvatarIcon({ icon }: AvatarIconProps) {
+  const Icon: Icon = icon === "user" ? UserIcon : EnvelopeIcon;
+
+  return (
+    <div className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border bg-muted text-muted-foreground">
+      <Icon className="size-4" aria-hidden="true" />
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/organizations/members/_components.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_components.tsx
@@ -1,0 +1,8 @@
+// Re-export all members components
+
+export type { Role } from "./_invite-member-form";
+export { InviteMemberForm } from "./_invite-member-form";
+export { MembersList } from "./_members-list";
+export { _MembersSkeleton } from "./_members-skeleton";
+export { _PageHeader } from "./_page-header";
+export { _PendingInvitationsList } from "./_pending-invitations-list";

--- a/packages/dashboard/src/components/dashboard/organizations/members/_invite-member-form.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_invite-member-form.tsx
@@ -1,0 +1,84 @@
+import { Button } from "@cloudflare/kumo/components/button";
+import { Input } from "@cloudflare/kumo/components/input";
+import { LayerCard } from "@cloudflare/kumo/components/layer-card";
+import { Select } from "@cloudflare/kumo/components/select";
+import { Text } from "@cloudflare/kumo/components/text";
+import { PlusIcon } from "@phosphor-icons/react";
+import * as React from "react";
+
+export type Role = "org:member" | "org:admin";
+
+export interface InviteMemberFormProps {
+  readonly isInviting: boolean;
+  readonly onInvite: (email: string, role: Role) => Promise<void>;
+}
+
+const ROLE_ITEMS: Array<{ label: string; value: Role }> = [
+  { label: "Member", value: "org:member" },
+  { label: "Admin", value: "org:admin" },
+];
+
+export function InviteMemberForm({ isInviting, onInvite }: InviteMemberFormProps) {
+  const [emailAddress, setEmailAddress] = React.useState("");
+  const [selectedRole, setSelectedRole] = React.useState<Role>("org:member");
+
+  const handleSubmit = React.useCallback(
+    async (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (!emailAddress.trim() || isInviting) return;
+
+      await onInvite(emailAddress.trim(), selectedRole);
+      setEmailAddress("");
+      setSelectedRole("org:member");
+    },
+    [emailAddress, isInviting, selectedRole, onInvite],
+  );
+
+  return (
+    <LayerCard className="flex flex-col gap-4 p-6">
+      <div className="flex flex-col gap-2">
+        <Text variant="heading3" as="h2">
+          Invite Member
+        </Text>
+        <Text variant="secondary" as="p">
+          Send an invitation to join this organization
+        </Text>
+      </div>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <Input
+          id="email"
+          type="email"
+          label="Email address"
+          placeholder="colleague@example.com"
+          value={emailAddress}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setEmailAddress(e.currentTarget.value)
+          }
+          disabled={isInviting}
+          required
+        />
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+          <Select<Role>
+            className="w-full sm:w-[180px]"
+            aria-label="Role"
+            label="Role"
+            value={selectedRole}
+            onValueChange={(v) => setSelectedRole((v ?? "org:member") as Role)}
+            items={ROLE_ITEMS}
+            disabled={isInviting}
+          />
+          <Button type="submit" variant="primary" disabled={isInviting} loading={isInviting}>
+            {isInviting ? (
+              "Sending..."
+            ) : (
+              <>
+                <PlusIcon aria-hidden="true" />
+                Invite
+              </>
+            )}
+          </Button>
+        </div>
+      </form>
+    </LayerCard>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/organizations/members/_member-cell.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_member-cell.tsx
@@ -1,0 +1,20 @@
+import { AvatarIcon } from "./_avatar-icon";
+
+export interface MemberCellProps {
+  readonly name: string;
+  readonly email: string;
+  readonly iconType: "user" | "mail";
+  readonly subtitle?: string;
+}
+
+export function MemberCell({ name, email, iconType, subtitle }: MemberCellProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <AvatarIcon icon={iconType} />
+      <div className="min-w-0">
+        <p className="truncate text-sm font-semibold text-foreground">{name}</p>
+        <p className="truncate text-sm text-muted-foreground">{subtitle ?? email}</p>
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/organizations/members/_member-list-card.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_member-list-card.tsx
@@ -1,0 +1,52 @@
+import { Surface } from "@cloudflare/kumo/components/surface";
+import { Text } from "@cloudflare/kumo/components/text";
+import type { ReactNode } from "react";
+import { type Column, DataTable } from "@/components/dashboard/data-table";
+
+export interface MemberListCardProps<T> {
+  readonly title: string;
+  readonly count?: number;
+  readonly countLabel?: string;
+  readonly data: readonly T[];
+  readonly columns: Column<T>[];
+  readonly isLoading: boolean;
+  readonly empty: {
+    readonly icon: ReactNode;
+    readonly title: string;
+    readonly description?: string;
+  };
+  readonly rowKey: (row: T) => string;
+}
+
+export function MemberListCard<T>({
+  title,
+  count,
+  countLabel,
+  data,
+  columns,
+  isLoading,
+  empty,
+  rowKey,
+}: MemberListCardProps<T>) {
+  return (
+    <Surface className="flex flex-col gap-4 p-6">
+      <div className="flex flex-col gap-1">
+        <Text variant="heading3" as="h2">
+          {title}
+        </Text>
+        <Text variant="secondary" as="p">
+          {count ?? 0} {countLabel ?? "item"}
+          {(count ?? 0) !== 1 ? "s" : ""}
+        </Text>
+      </div>
+      <DataTable
+        data={data as T[]}
+        columns={columns}
+        loading={isLoading}
+        loadingRows={3}
+        empty={empty}
+        rowKey={rowKey}
+      />
+    </Surface>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/organizations/members/_members-list.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_members-list.tsx
@@ -1,0 +1,67 @@
+import { UserIcon } from "@phosphor-icons/react";
+import * as React from "react";
+import type { Column } from "@/components/dashboard/data-table";
+import { MemberCell } from "./_member-cell";
+import { MemberListCard } from "./_member-list-card";
+import { RoleBadge } from "./_role-badge";
+
+export interface MembersListProps {
+  readonly isLoading: boolean;
+  readonly members: Array<{
+    readonly id: string;
+    readonly role: string;
+    readonly publicUserData?: {
+      readonly firstName: string | null;
+      readonly lastName: string | null;
+      readonly identifier?: string;
+    } | null;
+  } | null> | null;
+  readonly count?: number;
+}
+
+export function MembersList({ isLoading, members, count }: MembersListProps) {
+  const memberData = React.useMemo(
+    () =>
+      members
+        ?.filter((m): m is NonNullable<typeof m> => m != null)
+        .map((membership) => ({
+          id: membership.id,
+          name: membership.publicUserData?.firstName
+            ? `${membership.publicUserData.firstName} ${membership.publicUserData.lastName ?? ""}`.trim()
+            : (membership.publicUserData?.identifier ?? "Unknown"),
+          email: membership.publicUserData?.identifier ?? "Unknown",
+          role: membership.role,
+        })) ?? [],
+    [members],
+  );
+
+  const columns: Column<(typeof memberData)[number]>[] = [
+    {
+      key: "name",
+      label: "Member",
+      render: (row) => <MemberCell name={row.name} email={row.email} iconType="user" />,
+    },
+    {
+      key: "role",
+      label: "Role",
+      render: (row) => <RoleBadge role={row.role} />,
+    },
+  ];
+
+  return (
+    <MemberListCard
+      title="Members"
+      countLabel="member"
+      count={count}
+      data={memberData}
+      columns={columns}
+      isLoading={isLoading}
+      empty={{
+        icon: <UserIcon className="h-5 w-5" />,
+        title: "No members yet",
+        description: "Invite team members to join your organization",
+      }}
+      rowKey={(row) => row.id}
+    />
+  );
+}

--- a/packages/dashboard/src/components/dashboard/organizations/members/_members-skeleton.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_members-skeleton.tsx
@@ -1,0 +1,10 @@
+import { Surface } from "@cloudflare/kumo/components/surface";
+import { FormSkeleton } from "@/components/dashboard/loading-states";
+
+export function _MembersSkeleton() {
+  return (
+    <Surface className="flex flex-col gap-4 p-6">
+      <FormSkeleton fields={3} />
+    </Surface>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/organizations/members/_page-header.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_page-header.tsx
@@ -1,0 +1,32 @@
+import { Button } from "@cloudflare/kumo/components/button";
+import { ArrowLeftIcon } from "@phosphor-icons/react";
+import Link from "next/link";
+
+export interface _PageHeaderProps {
+  readonly organizationName?: string;
+  readonly isLoading?: boolean;
+}
+
+export function _PageHeader({ organizationName, isLoading }: _PageHeaderProps) {
+  return (
+    <header className="flex items-center gap-3 border-border border-b pb-5">
+      <Link href="/dashboard/settings/organizations">
+        <Button
+          variant="ghost"
+          shape="square"
+          size="sm"
+          disabled={isLoading}
+          aria-label="Back to organizations"
+        >
+          <ArrowLeftIcon aria-hidden="true" />
+        </Button>
+      </Link>
+      <div className="min-w-0 flex-1">
+        <h1 className="text-[26px] tracking-tight text-foreground">Members</h1>
+        <p className="text-[14.5px] leading-6 text-muted-foreground">
+          {organizationName ? `${organizationName} · ` : ""}Manage organization members
+        </p>
+      </div>
+    </header>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/organizations/members/_pending-invitations-list.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_pending-invitations-list.tsx
@@ -1,0 +1,69 @@
+import { Button } from "@cloudflare/kumo/components/button";
+import { EnvelopeIcon } from "@phosphor-icons/react";
+import type { Column } from "@/components/dashboard/data-table";
+import { MemberCell } from "./_member-cell";
+import { MemberListCard } from "./_member-list-card";
+
+export interface _PendingInvitationsListProps {
+  readonly isLoading: boolean;
+  readonly invitations: Array<{
+    readonly id: string;
+    readonly emailAddress: string;
+    readonly role: string;
+    readonly status: string;
+  }> | null;
+  readonly count?: number;
+  readonly onRevokeInvitation: (id: string) => void;
+}
+
+export function _PendingInvitationsList({
+  isLoading,
+  invitations,
+  count,
+  onRevokeInvitation,
+}: _PendingInvitationsListProps) {
+  type Invitation = NonNullable<typeof invitations>[number];
+
+  const formatRoleStatus = (role: string, status: string) =>
+    `${role === "org:admin" ? "Admin" : "Member"} · ${status}`;
+
+  const columns: Column<Invitation>[] = [
+    {
+      key: "emailAddress",
+      label: "Email",
+      render: (row) => (
+        <MemberCell
+          name={row.emailAddress}
+          email={row.emailAddress}
+          iconType="mail"
+          subtitle={formatRoleStatus(row.role, row.status)}
+        />
+      ),
+    },
+    {
+      key: "actions",
+      label: "",
+      render: (row) => (
+        <Button variant="ghost" size="sm" onClick={() => onRevokeInvitation(row.id)}>
+          Revoke
+        </Button>
+      ),
+    },
+  ];
+
+  return (
+    <MemberListCard
+      title="Pending Invitations"
+      countLabel="pending invitation"
+      count={count}
+      data={invitations ?? []}
+      columns={columns}
+      isLoading={isLoading}
+      empty={{
+        icon: <EnvelopeIcon className="h-5 w-5" aria-hidden="true" />,
+        title: "No pending invitations",
+      }}
+      rowKey={(row) => row.id}
+    />
+  );
+}

--- a/packages/dashboard/src/components/dashboard/organizations/members/_role-badge.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_role-badge.tsx
@@ -1,0 +1,10 @@
+import { Badge } from "@cloudflare/kumo/components/badge";
+
+export interface RoleBadgeProps {
+  readonly role: string;
+}
+
+export function RoleBadge({ role }: RoleBadgeProps) {
+  const isAdmin = role === "org:admin";
+  return <Badge variant={isAdmin ? "primary" : "secondary"}>{isAdmin ? "Admin" : "Member"}</Badge>;
+}

--- a/packages/dashboard/src/components/dashboard/organizations/members/_use-invite-member.ts
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_use-invite-member.ts
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { toast } from "sonner";
+import type { Role } from "./_components";
+
+interface ClerkError {
+  errors?: Array<{ message?: string }>;
+}
+
+export function useInviteMember(
+  organization:
+    | {
+        inviteMember: (params: { emailAddress: string; role: Role }) => Promise<unknown>;
+      }
+    | null
+    | undefined,
+  invitations:
+    | {
+        revalidate?: () => Promise<void>;
+      }
+    | null
+    | undefined,
+) {
+  const [isInviting, setIsInviting] = React.useState(false);
+
+  const inviteMember = React.useCallback(
+    async (emailAddress: string, role: Role) => {
+      if (!organization) return;
+
+      setIsInviting(true);
+      try {
+        await organization.inviteMember({ emailAddress, role });
+        await invitations?.revalidate?.();
+        toast.success("Invitation sent successfully");
+      } catch (err: unknown) {
+        const error = err as ClerkError;
+        const message = error?.errors?.[0]?.message ?? "Failed to send invitation";
+        toast.error(message);
+      } finally {
+        setIsInviting(false);
+      }
+    },
+    [organization, invitations],
+  );
+
+  return { inviteMember, isInviting };
+}

--- a/packages/dashboard/src/components/dashboard/organizations/members/members-content.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/members-content.tsx
@@ -1,0 +1,90 @@
+import { useOrganization, useOrganizationList, useUser } from "@clerk/react";
+import { LayerCard } from "@cloudflare/kumo/components/layer-card";
+import { Text } from "@cloudflare/kumo/components/text";
+import * as React from "react";
+import { toast } from "sonner";
+import {
+  _MembersSkeleton,
+  _PageHeader,
+  _PendingInvitationsList,
+  InviteMemberForm,
+  MembersList,
+} from "./_components";
+import { useInviteMember } from "./_use-invite-member";
+
+// =============================================================================
+// Main Page
+// =============================================================================
+
+export function MembersContent() {
+  const { isLoaded: isUserLoaded, isSignedIn } = useUser();
+  const { isLoaded: isOrgListLoaded } = useOrganizationList({
+    userMemberships: true,
+  });
+  const {
+    isLoaded: isOrgLoaded,
+    organization,
+    memberships,
+    invitations,
+  } = useOrganization({
+    memberships: {
+      pageSize: 10,
+      keepPreviousData: true,
+    },
+    invitations: {
+      pageSize: 10,
+      keepPreviousData: true,
+    },
+  });
+
+  const { inviteMember, isInviting } = useInviteMember(organization, invitations);
+
+  const handleRevokeInvitation = React.useCallback(async (_invitationId: string) => {
+    toast.info("To revoke invitations, use the Clerk Dashboard");
+  }, []);
+
+  // Loading state
+  if (!isUserLoaded || !isOrgListLoaded || !isOrgLoaded) {
+    return (
+      <div className="flex flex-col gap-6 px-4 lg:px-6">
+        <_PageHeader isLoading />
+        <_MembersSkeleton />
+      </div>
+    );
+  }
+
+  // Not signed in or no organization
+  if (!isSignedIn || !organization) {
+    return (
+      <div className="flex flex-col gap-6 px-4 lg:px-6">
+        <_PageHeader />
+        <LayerCard className="flex flex-col gap-1 p-6">
+          <Text variant="heading3" as="h2">
+            No organization selected
+          </Text>
+          <Text variant="secondary" as="p">
+            Select an organization to manage its members.
+          </Text>
+        </LayerCard>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 px-4 lg:px-6">
+      <_PageHeader organizationName={organization.name} />
+      <InviteMemberForm isInviting={isInviting} onInvite={inviteMember} />
+      <MembersList
+        isLoading={memberships?.isLoading ?? false}
+        members={memberships?.data ?? null}
+        count={memberships?.count}
+      />
+      <_PendingInvitationsList
+        isLoading={invitations?.isLoading ?? false}
+        invitations={invitations?.data ?? null}
+        count={invitations?.count}
+        onRevokeInvitation={handleRevokeInvitation}
+      />
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/organizations/members/members-page.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/members-page.tsx
@@ -1,0 +1,10 @@
+import { DashboardShell } from "@/components/dashboard-shell";
+import { MembersContent } from "./members-content";
+
+export function MembersPage() {
+  return (
+    <DashboardShell>
+      <MembersContent />
+    </DashboardShell>
+  );
+}

--- a/packages/dashboard/src/pages/dashboard/settings/organizations/create.astro
+++ b/packages/dashboard/src/pages/dashboard/settings/organizations/create.astro
@@ -1,0 +1,8 @@
+---
+import { CreateOrgPage } from "@/components/dashboard/organizations/create/create-org-page";
+import DashboardLayout from "@/layouts/DashboardLayout.astro";
+---
+
+<DashboardLayout>
+  <CreateOrgPage client:only="react" />
+</DashboardLayout>

--- a/packages/dashboard/src/pages/dashboard/settings/organizations/index.astro
+++ b/packages/dashboard/src/pages/dashboard/settings/organizations/index.astro
@@ -1,0 +1,8 @@
+---
+import { OrganizationsListPage } from "@/components/dashboard/organizations/list/organizations-list-page";
+import DashboardLayout from "@/layouts/DashboardLayout.astro";
+---
+
+<DashboardLayout>
+  <OrganizationsListPage client:only="react" />
+</DashboardLayout>

--- a/packages/dashboard/src/pages/dashboard/settings/organizations/members.astro
+++ b/packages/dashboard/src/pages/dashboard/settings/organizations/members.astro
@@ -1,0 +1,8 @@
+---
+import { MembersPage } from "@/components/dashboard/organizations/members/members-page";
+import DashboardLayout from "@/layouts/DashboardLayout.astro";
+---
+
+<DashboardLayout>
+  <MembersPage client:only="react" />
+</DashboardLayout>


### PR DESCRIPTION
Phase 2 of the Next.js → Astro dashboard migration. Ports the entire `/dashboard/settings/organizations` subtree — 3 routes sharing active-org context via `useOrganization`.

## Routes
- `/dashboard/settings/organizations` — list of orgs (active badge, create/members links)
- `/dashboard/settings/organizations/create` — create-org form with domain-already-exists warning
- `/dashboard/settings/organizations/members` — invite form + members table + pending invitations

## Pattern
Each route = one `client:only="react"` island wrapped in `<DashboardShell>`, matching the traces port (#144). Co-located components/hooks copied 1:1 into per-route dirs under `src/components/dashboard/organizations/{list,create,members}/` with relative imports intact and `'use client'` stripped.

## Logic preserved exactly
- `useOrganization` / `useOrganizationList` / `useOrganizationCreationDefaults` / `useUser`
- `organization.inviteMember` + `invitations.revalidate`
- `useOrganizationsList` hook (from `@/hooks`)
- Role badge (org:admin/org:member), pending-invitation revoke, domain advisory warning

`src/app/` left untouched. `next/link` + `next/navigation` resolve to existing shims via `astro.config.mjs` aliases — no import edits needed.

## Verify
- `bunx astro check` → 0 errors, 0 warnings (103 pre-existing hints)
- `bunx astro dev` → all 3 routes return 200
- `bunx biome check` → clean (only the same `.astro` false-positive `noUnusedImports` warnings present on the merged `traces.astro`)

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>