### PR TITLE
feat(dashboard): port /domains route to Astro

### DIFF
--- a/packages/dashboard/src/components/dashboard/domains/_components.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_components.tsx
@@ -1,0 +1,9 @@
+export {
+  _AddDomainForm,
+  _DomainsEmptyState,
+  _DomainsList,
+  _DomainsLoadingSkeleton,
+  type AddDomainFormProps,
+  type DomainsEmptyStateProps,
+  type DomainsListProps,
+} from "./_components/index";

--- a/packages/dashboard/src/components/dashboard/domains/_components/add-domain-form.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_components/add-domain-form.tsx
@@ -1,0 +1,55 @@
+import { Button } from "@cloudflare/kumo/components/button";
+import { Input } from "@cloudflare/kumo/components/input";
+import { LayerCard } from "@cloudflare/kumo/components/layer-card";
+import { XIcon } from "@phosphor-icons/react";
+
+export interface AddDomainFormProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+  adding: boolean;
+}
+
+export function _AddDomainForm({
+  value,
+  onChange,
+  onSubmit,
+  onCancel,
+  adding,
+}: AddDomainFormProps) {
+  const isSubmitDisabled = !value.trim() || adding;
+
+  return (
+    <LayerCard className="mb-6 flex flex-col gap-4 border border-border p-6">
+      <Input
+        id="domain-input"
+        label="Domain name"
+        placeholder="e.g. app.example.com"
+        value={value}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && !isSubmitDisabled) {
+            onSubmit();
+          }
+        }}
+        description="Enter your domain without the protocol (https://) or path."
+        autoFocus
+      />
+      <div className="flex gap-2">
+        <Button variant="primary" onClick={onSubmit} disabled={isSubmitDisabled} loading={adding}>
+          {adding ? "Adding..." : "Add"}
+        </Button>
+        <Button
+          variant="ghost"
+          shape="square"
+          size="sm"
+          onClick={onCancel}
+          aria-label="Cancel adding domain"
+        >
+          <XIcon aria-hidden="true" />
+        </Button>
+      </div>
+    </LayerCard>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/domains/_components/domains-empty-state.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_components/domains-empty-state.tsx
@@ -1,0 +1,20 @@
+import { LayerCard } from "@cloudflare/kumo/components/layer-card";
+import { GlobeIcon } from "@phosphor-icons/react";
+import { EmptyState } from "@/components/dashboard/empty-state";
+
+export interface DomainsEmptyStateProps {
+  onAddDomain: () => void;
+}
+
+export function _DomainsEmptyState({ onAddDomain }: DomainsEmptyStateProps) {
+  return (
+    <LayerCard className="border border-border">
+      <EmptyState
+        icon={<GlobeIcon aria-hidden="true" />}
+        title="No custom domains"
+        description="Add a custom domain to serve your project from your own domain with SSL."
+        action={{ label: "Add your first domain", onClick: onAddDomain }}
+      />
+    </LayerCard>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/domains/_components/domains-list.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_components/domains-list.tsx
@@ -1,0 +1,38 @@
+import type { CustomDomainResponse } from "@agentstate/shared";
+import { _DomainCard } from "../_domain-card";
+
+type CustomDomain = CustomDomainResponse;
+
+export interface DomainsListProps {
+  domains: CustomDomain[];
+  expandedDomains: Set<string>;
+  checkingVerification: string | null;
+  onToggle: (id: string) => void;
+  onVerify: (id: string, domain: string) => void;
+  onDelete: (id: string, domain: string) => void;
+}
+
+export function _DomainsList({
+  domains,
+  expandedDomains,
+  checkingVerification,
+  onToggle,
+  onVerify,
+  onDelete,
+}: DomainsListProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      {domains.map((domain) => (
+        <_DomainCard
+          key={domain.id}
+          domain={domain}
+          isExpanded={expandedDomains.has(domain.id)}
+          onToggle={onToggle}
+          onVerify={onVerify}
+          onDelete={onDelete}
+          isCheckingVerification={checkingVerification === domain.id}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/domains/_components/domains-loading-skeleton.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_components/domains-loading-skeleton.tsx
@@ -1,0 +1,10 @@
+import { CardListSkeleton, PageHeaderSkeleton } from "@/components/dashboard/loading-states";
+
+export function _DomainsLoadingSkeleton(): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-6">
+      <PageHeaderSkeleton hasAction />
+      <CardListSkeleton count={3} />
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/domains/_components/index.ts
+++ b/packages/dashboard/src/components/dashboard/domains/_components/index.ts
@@ -1,0 +1,4 @@
+export { _AddDomainForm, type AddDomainFormProps } from "./add-domain-form";
+export { _DomainsEmptyState, type DomainsEmptyStateProps } from "./domains-empty-state";
+export { _DomainsList, type DomainsListProps } from "./domains-list";
+export { _DomainsLoadingSkeleton } from "./domains-loading-skeleton";

--- a/packages/dashboard/src/components/dashboard/domains/_domain-card-actions.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_domain-card-actions.tsx
@@ -1,0 +1,51 @@
+import { Button } from "@cloudflare/kumo/components/button";
+import { TrashIcon } from "@phosphor-icons/react";
+
+interface DomainCardActionsProps {
+  verified: boolean;
+  isCheckingVerification: boolean;
+  onVerify: () => void;
+  onDelete: () => void;
+  domain: string;
+}
+
+export function _DomainCardActions({
+  verified,
+  isCheckingVerification,
+  onVerify,
+  onDelete,
+  domain,
+}: DomainCardActionsProps) {
+  return (
+    <div className="flex items-center gap-2">
+      {!verified && (
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={(e) => {
+            e.stopPropagation();
+            onVerify();
+          }}
+          disabled={isCheckingVerification}
+          loading={isCheckingVerification}
+          aria-label={`Verify ${domain}`}
+        >
+          {isCheckingVerification ? "Checking..." : "Verify"}
+        </Button>
+      )}
+      <Button
+        shape="square"
+        size="sm"
+        variant="ghost"
+        className="text-kumo-danger"
+        aria-label={`Delete ${domain}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onDelete();
+        }}
+      >
+        <TrashIcon aria-hidden="true" />
+      </Button>
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/domains/_domain-card-expanded.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_domain-card-expanded.tsx
@@ -1,0 +1,35 @@
+import type { CustomDomainResponse } from "@agentstate/shared";
+import { _DomainUnverifiedAlert } from "./_domain-card-unverified-alert";
+import { _DomainVerifiedAlert } from "./_domain-card-verified-alert";
+
+type CustomDomain = CustomDomainResponse;
+
+const isVerified = (status: CustomDomain["verification_status"]): boolean => status === "verified";
+
+interface DomainCardExpandedProps {
+  domain: CustomDomain;
+  isCheckingVerification: boolean;
+  onVerify: () => void;
+}
+
+export function _DomainCardExpanded({
+  domain,
+  isCheckingVerification,
+  onVerify,
+}: DomainCardExpandedProps) {
+  const verified = isVerified(domain.verification_status);
+
+  return (
+    <div className="border-border border-t p-4">
+      {verified ? (
+        <_DomainVerifiedAlert sslEnabled={domain.ssl_enabled} />
+      ) : (
+        <_DomainUnverifiedAlert
+          domain={domain}
+          isCheckingVerification={isCheckingVerification}
+          onVerify={onVerify}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/domains/_domain-card-status-badge.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_domain-card-status-badge.tsx
@@ -1,0 +1,16 @@
+import type { CustomDomainResponse } from "@agentstate/shared";
+import { Badge } from "@cloudflare/kumo/components/badge";
+
+const STATUS_VARIANTS = {
+  verified: "success" as const,
+  failed: "error" as const,
+  pending: "neutral" as const,
+} satisfies Record<CustomDomainResponse["verification_status"], "success" | "error" | "neutral">;
+
+interface DomainStatusBadgeProps {
+  status: CustomDomainResponse["verification_status"];
+}
+
+export function _DomainStatusBadge({ status }: DomainStatusBadgeProps) {
+  return <Badge variant={STATUS_VARIANTS[status]}>{status}</Badge>;
+}

--- a/packages/dashboard/src/components/dashboard/domains/_domain-card-unverified-alert.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_domain-card-unverified-alert.tsx
@@ -1,0 +1,86 @@
+import type { CustomDomainResponse } from "@agentstate/shared";
+import { Banner } from "@cloudflare/kumo/components/banner";
+import { Button } from "@cloudflare/kumo/components/button";
+import { WarningCircleIcon } from "@phosphor-icons/react";
+import { _VerificationMethod } from "./_verification-method";
+
+interface DomainUnverifiedAlertProps {
+  domain: CustomDomainResponse;
+  isCheckingVerification: boolean;
+  onVerify: () => void;
+}
+
+const getVerificationMethods = (
+  domain: string,
+  token: string,
+): Array<{
+  title: string;
+  description: string;
+  records: Array<{ label: string; value: string; copy: string }>;
+}> => [
+  {
+    title: "DNS TXT Record (Recommended)",
+    description: "Add a TXT record to your domain's DNS configuration.",
+    records: [
+      { label: "Name", value: `_agentstate.${domain}`, copy: `_agentstate.${domain}` },
+      { label: "Value", value: token, copy: token },
+    ],
+  },
+  {
+    title: "HTTP File",
+    description: `Create a file at https://${domain}/.well-known/agentstate-${token}`,
+    records: [
+      {
+        label: "URL",
+        value: `https://${domain}/.well-known/agentstate-${token}`,
+        copy: `/.well-known/agentstate-${token}`,
+      },
+      { label: "Content", value: token, copy: token },
+    ],
+  },
+  {
+    title: "Meta Tag",
+    description: "Add this meta tag to your site's HTML head section.",
+    records: [
+      {
+        label: "Tag",
+        value: `<meta name="agentstate-verification" content="${token}">`,
+        copy: `<meta name="agentstate-verification" content="${token}">`,
+      },
+    ],
+  },
+];
+
+export function _DomainUnverifiedAlert({
+  domain,
+  isCheckingVerification,
+  onVerify,
+}: DomainUnverifiedAlertProps) {
+  const verificationMethods = getVerificationMethods(domain.domain, domain.verification_token);
+
+  return (
+    <>
+      <Banner
+        variant="default"
+        icon={<WarningCircleIcon aria-hidden="true" weight="fill" />}
+        title="Verify your domain"
+        description={`Choose one of the following methods to verify ownership of ${domain.domain}. Verification may take a few minutes to propagate after making changes.`}
+      />
+      <div className="flex flex-col gap-4">
+        {verificationMethods.map((method) => (
+          <_VerificationMethod key={method.title} {...method} />
+        ))}
+      </div>
+      <Button
+        size="sm"
+        variant="primary"
+        onClick={onVerify}
+        disabled={isCheckingVerification}
+        loading={isCheckingVerification}
+        aria-label={`Check verification status for ${domain.domain}`}
+      >
+        {isCheckingVerification ? "Checking..." : "Check Verification"}
+      </Button>
+    </>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/domains/_domain-card-verified-alert.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_domain-card-verified-alert.tsx
@@ -1,0 +1,19 @@
+import { Banner } from "@cloudflare/kumo/components/banner";
+import { CheckCircleIcon } from "@phosphor-icons/react";
+
+interface DomainVerifiedAlertProps {
+  sslEnabled: boolean;
+}
+
+export function _DomainVerifiedAlert({ sslEnabled }: DomainVerifiedAlertProps) {
+  return (
+    <Banner
+      variant="secondary"
+      icon={<CheckCircleIcon aria-hidden="true" weight="fill" />}
+      title="Domain verified"
+      description={`Your domain is verified and ready to use. SSL is ${
+        sslEnabled ? "enabled" : "being provisioned"
+      }.`}
+    />
+  );
+}

--- a/packages/dashboard/src/components/dashboard/domains/_domain-card.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_domain-card.tsx
@@ -1,0 +1,98 @@
+import type { CustomDomainResponse } from "@agentstate/shared";
+import { LayerCard } from "@cloudflare/kumo/components/layer-card";
+import { CaretDownIcon, CaretRightIcon, GlobeIcon } from "@phosphor-icons/react";
+import { _DomainCardActions } from "./_domain-card-actions";
+import { _DomainCardExpanded } from "./_domain-card-expanded";
+import { _DomainStatusBadge } from "./_domain-card-status-badge";
+
+type CustomDomain = CustomDomainResponse;
+
+const isVerified = (status: CustomDomain["verification_status"]): boolean => status === "verified";
+
+interface DomainCardHeaderProps {
+  domain: string;
+  verificationStatus: CustomDomain["verification_status"];
+  isExpanded: boolean;
+  isCheckingVerification: boolean;
+  onToggle: () => void;
+  onVerify: () => void;
+  onDelete: () => void;
+}
+
+function _DomainCardHeader({
+  domain,
+  verificationStatus,
+  isExpanded,
+  isCheckingVerification,
+  onToggle,
+  onVerify,
+  onDelete,
+}: DomainCardHeaderProps) {
+  const ChevronIcon = isExpanded ? CaretDownIcon : CaretRightIcon;
+  const verified = isVerified(verificationStatus);
+
+  return (
+    <div className="flex w-full items-center justify-between gap-2 px-4 py-3">
+      <button
+        type="button"
+        className="flex min-w-0 flex-1 items-center gap-3 rounded-md text-left transition-colors hover:opacity-80"
+        onClick={onToggle}
+        aria-expanded={isExpanded}
+        aria-label={`Toggle details for ${domain}`}
+      >
+        <ChevronIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        <span className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border bg-muted text-muted-foreground">
+          <GlobeIcon className="size-4" aria-hidden="true" />
+        </span>
+        <span className="truncate text-sm font-semibold text-foreground">{domain}</span>
+        <_DomainStatusBadge status={verificationStatus} />
+      </button>
+      <_DomainCardActions
+        verified={verified}
+        isCheckingVerification={isCheckingVerification}
+        onVerify={onVerify}
+        onDelete={onDelete}
+        domain={domain}
+      />
+    </div>
+  );
+}
+
+export interface DomainCardProps {
+  domain: CustomDomain;
+  isExpanded: boolean;
+  onToggle: (id: string) => void;
+  onVerify: (id: string, domain: string) => void;
+  onDelete: (id: string, domain: string) => void;
+  isCheckingVerification: boolean;
+}
+
+export function _DomainCard({
+  domain,
+  isExpanded,
+  onToggle,
+  onVerify,
+  onDelete,
+  isCheckingVerification,
+}: DomainCardProps) {
+  return (
+    <LayerCard>
+      <_DomainCardHeader
+        domain={domain.domain}
+        verificationStatus={domain.verification_status}
+        isExpanded={isExpanded}
+        isCheckingVerification={isCheckingVerification}
+        onToggle={() => onToggle(domain.id)}
+        onVerify={() => onVerify(domain.id, domain.domain)}
+        onDelete={() => onDelete(domain.id, domain.domain)}
+      />
+      {isExpanded && (
+        <_DomainCardExpanded
+          domain={domain}
+          isCheckingVerification={isCheckingVerification}
+          onVerify={() => onVerify(domain.id, domain.domain)}
+        />
+      )}
+    </LayerCard>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/domains/_domains-service.ts
+++ b/packages/dashboard/src/components/dashboard/domains/_domains-service.ts
@@ -1,0 +1,33 @@
+import type { CreateCustomDomainResponse, CustomDomainResponse } from "@agentstate/shared";
+import { api } from "@/lib/api";
+
+type CustomDomain = CustomDomainResponse;
+
+export async function loadDomains(projectId: string): Promise<CustomDomain[]> {
+  const res = await api<{ data: CustomDomain[] }>(`/v1/projects/${projectId}/domains`);
+  return res.data ?? [];
+}
+
+export async function addDomain(
+  projectId: string,
+  domain: string,
+): Promise<CreateCustomDomainResponse> {
+  return api<CreateCustomDomainResponse>(`/v1/projects/${projectId}/domains`, {
+    method: "POST",
+    body: JSON.stringify({ domain: domain.trim().toLowerCase() }),
+  });
+}
+
+export async function deleteDomain(projectId: string, domainId: string): Promise<void> {
+  await api(`/v1/projects/${projectId}/domains/${domainId}`, { method: "DELETE" });
+}
+
+export async function checkDomainVerification(
+  projectId: string,
+  domainId: string,
+): Promise<{
+  verification_status: CustomDomain["verification_status"];
+  verified_at: number | null;
+}> {
+  return api(`/v1/projects/${projectId}/domains/${domainId}/verify`, { method: "POST" });
+}

--- a/packages/dashboard/src/components/dashboard/domains/_use-domain-actions.ts
+++ b/packages/dashboard/src/components/dashboard/domains/_use-domain-actions.ts
@@ -1,0 +1,91 @@
+import type { CustomDomainResponse } from "@agentstate/shared";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import { isValidDomain } from "@/lib/domain-validation";
+import { addDomain, checkDomainVerification, deleteDomain } from "./_domains-service";
+
+export function useDomainActions(
+  projectId: string | null,
+  setDomains: React.Dispatch<React.SetStateAction<CustomDomainResponse[]>>,
+  setExpandedDomains: React.Dispatch<React.SetStateAction<Set<string>>>,
+) {
+  const [adding, setAdding] = useState(false);
+  const [checkingVerification, setCheckingVerification] = useState<string | null>(null);
+
+  const handleAddDomain = useCallback(
+    async (newDomain: string, onSuccess?: () => void) => {
+      if (!newDomain.trim() || !projectId) return;
+      if (!isValidDomain(newDomain)) {
+        toast.error("Invalid domain format");
+        return;
+      }
+      setAdding(true);
+      try {
+        const res = await addDomain(projectId, newDomain);
+        setDomains((prev) => [...prev, res]);
+        setExpandedDomains((prev) => new Set([...prev, res.id]));
+        toast.success("Domain added. Follow the instructions to verify ownership.");
+        onSuccess?.();
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Failed to add domain");
+      } finally {
+        setAdding(false);
+      }
+    },
+    [projectId, setDomains, setExpandedDomains],
+  );
+
+  const handleDeleteDomain = useCallback(
+    async (domainId: string, domain: string) => {
+      if (!projectId || !confirm(`Are you sure you want to delete ${domain}?`)) return;
+      try {
+        await deleteDomain(projectId, domainId);
+        setDomains((prev) => prev.filter((d) => d.id !== domainId));
+        setExpandedDomains((prev) => {
+          const next = new Set(prev);
+          next.delete(domainId);
+          return next;
+        });
+        toast.success("Domain deleted");
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Failed to delete domain");
+      }
+    },
+    [projectId, setDomains, setExpandedDomains],
+  );
+
+  const handleCheckVerification = useCallback(
+    async (domainId: string, domain: string) => {
+      if (!projectId) return;
+      setCheckingVerification(domainId);
+      try {
+        const res = await checkDomainVerification(projectId, domainId);
+        if (res.verification_status === "verified") {
+          toast.success(`Domain ${domain} has been verified!`);
+          setDomains((prev) =>
+            prev.map((d) =>
+              d.id === domainId
+                ? { ...d, verification_status: "verified", verified_at: res.verified_at }
+                : d,
+            ),
+          );
+        } else {
+          toast.info("Verification not complete yet. Please wait a few minutes and try again.");
+        }
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Verification check failed");
+      } finally {
+        setCheckingVerification(null);
+      }
+    },
+    [projectId, setDomains],
+  );
+
+  return {
+    adding,
+    checkingVerification,
+    handleAddDomain,
+    handleDeleteDomain,
+    handleCheckVerification,
+  };
+}

--- a/packages/dashboard/src/components/dashboard/domains/_use-domains-list.ts
+++ b/packages/dashboard/src/components/dashboard/domains/_use-domains-list.ts
@@ -1,0 +1,27 @@
+import type { CustomDomainResponse } from "@agentstate/shared";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { loadDomains } from "./_domains-service";
+
+export function useDomainsList(projectId: string | null) {
+  const [domains, setDomains] = useState<CustomDomainResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadDomainsData = useCallback(async () => {
+    if (!projectId) return;
+    try {
+      const data = await loadDomains(projectId);
+      setDomains(data);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to load domains");
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    if (projectId) loadDomainsData();
+  }, [projectId, loadDomainsData]);
+
+  return { domains, loading, loadDomainsData, setDomains };
+}

--- a/packages/dashboard/src/components/dashboard/domains/_use-domains.ts
+++ b/packages/dashboard/src/components/dashboard/domains/_use-domains.ts
@@ -1,0 +1,40 @@
+import { useState } from "react";
+import { useDomainActions } from "./_use-domain-actions";
+import { useDomainsList } from "./_use-domains-list";
+import { useExpandedDomains } from "./_use-expanded-domains";
+
+export function useDomains(projectId: string | null) {
+  const [newDomain, setNewDomain] = useState("");
+
+  const { domains, loading, loadDomainsData, setDomains } = useDomainsList(projectId);
+  const { expandedDomains, setExpandedDomains, toggleDomain } = useExpandedDomains();
+  const {
+    adding,
+    checkingVerification,
+    handleAddDomain,
+    handleDeleteDomain,
+    handleCheckVerification,
+  } = useDomainActions(projectId, setDomains, setExpandedDomains);
+
+  const handleAddDomainWithReset = (onSuccess?: () => void) => {
+    handleAddDomain(newDomain, () => {
+      setNewDomain("");
+      onSuccess?.();
+    });
+  };
+
+  return {
+    domains,
+    loading,
+    adding,
+    checkingVerification,
+    expandedDomains,
+    newDomain,
+    setNewDomain,
+    handleAddDomain: handleAddDomainWithReset,
+    handleDeleteDomain,
+    handleCheckVerification,
+    toggleDomain,
+    loadDomainsData,
+  };
+}

--- a/packages/dashboard/src/components/dashboard/domains/_use-expanded-domains.ts
+++ b/packages/dashboard/src/components/dashboard/domains/_use-expanded-domains.ts
@@ -1,0 +1,19 @@
+import { useCallback, useState } from "react";
+
+export function useExpandedDomains() {
+  const [expandedDomains, setExpandedDomains] = useState<Set<string>>(new Set());
+
+  const toggleDomain = useCallback((domainId: string) => {
+    setExpandedDomains((prev) => {
+      const next = new Set(prev);
+      if (next.has(domainId)) {
+        next.delete(domainId);
+      } else {
+        next.add(domainId);
+      }
+      return next;
+    });
+  }, []);
+
+  return { expandedDomains, setExpandedDomains, toggleDomain };
+}

--- a/packages/dashboard/src/components/dashboard/domains/_use-project-id.ts
+++ b/packages/dashboard/src/components/dashboard/domains/_use-project-id.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+export function useProjectId(): string | null {
+  const [projectId, setProjectId] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const projects = await api<{ data: Array<{ project_id: string }> }>("/v1/projects");
+        if (projects.data?.[0]) setProjectId(projects.data[0].project_id);
+      } catch (e) {
+        console.error("Failed to load projects", e);
+      }
+    })();
+  }, []);
+
+  return projectId;
+}

--- a/packages/dashboard/src/components/dashboard/domains/_verification-method.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_verification-method.tsx
@@ -1,0 +1,23 @@
+import { VerificationRecord } from "./_verification-record";
+
+interface VerificationMethodProps {
+  title: string;
+  description: string;
+  records: Array<{ label: string; value: string; copy: string }>;
+}
+
+export function _VerificationMethod({ title, description, records }: VerificationMethodProps) {
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-border bg-kumo-base p-4 shadow-sm">
+      <div className="flex flex-col gap-1">
+        <h4 className="font-medium">{title}</h4>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+      <div className="flex flex-col gap-2">
+        {records.map((record) => (
+          <VerificationRecord key={record.label} {...record} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/domains/_verification-record.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_verification-record.tsx
@@ -1,0 +1,16 @@
+import { ClipboardText } from "@cloudflare/kumo/components/clipboard-text";
+
+interface VerificationRecordProps {
+  label: string;
+  value: string;
+  copy: string;
+}
+
+export function VerificationRecord({ label, value, copy }: VerificationRecordProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-16 shrink-0 text-sm text-muted-foreground">{label}:</span>
+      <ClipboardText className="flex-1" size="sm" text={value} textToCopy={copy} />
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/domains/domains-content.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/domains-content.tsx
@@ -1,0 +1,83 @@
+import { Button } from "@cloudflare/kumo/components/button";
+import { PlusIcon } from "@phosphor-icons/react";
+import { Suspense, useState } from "react";
+import { PageHeader } from "@/components/dashboard/page-header";
+import {
+  _AddDomainForm,
+  _DomainsEmptyState,
+  _DomainsList,
+  _DomainsLoadingSkeleton,
+} from "./_components";
+import { useDomains } from "./_use-domains";
+import { useProjectId } from "./_use-project-id";
+
+// ---------------------------------------------------------------------------
+// Domains Content (old page.tsx body)
+// ---------------------------------------------------------------------------
+
+export function DomainsContent() {
+  const projectId = useProjectId();
+  const [showAddForm, setShowAddForm] = useState(false);
+
+  const {
+    domains,
+    loading,
+    adding,
+    checkingVerification,
+    expandedDomains,
+    newDomain,
+    setNewDomain,
+    handleAddDomain,
+    handleDeleteDomain,
+    handleCheckVerification,
+    toggleDomain,
+  } = useDomains(projectId);
+
+  if (loading) {
+    return <_DomainsLoadingSkeleton />;
+  }
+
+  return (
+    <Suspense fallback={<div className="h-32 animate-pulse rounded-lg bg-muted" />}>
+      <div className="flex flex-col px-4 lg:px-6">
+        <PageHeader
+          title="Custom Domains"
+          description="Add a custom domain to serve your project from your own domain with SSL."
+          actions={
+            <Button
+              size="sm"
+              variant="outline"
+              icon={<PlusIcon aria-hidden="true" />}
+              onClick={() => setShowAddForm(!showAddForm)}
+            >
+              Add Domain
+            </Button>
+          }
+        />
+
+        {showAddForm && (
+          <_AddDomainForm
+            value={newDomain}
+            onChange={setNewDomain}
+            onSubmit={() => handleAddDomain(() => setShowAddForm(false))}
+            onCancel={() => setShowAddForm(false)}
+            adding={adding}
+          />
+        )}
+
+        {domains.length === 0 ? (
+          <_DomainsEmptyState onAddDomain={() => setShowAddForm(true)} />
+        ) : (
+          <_DomainsList
+            domains={domains}
+            expandedDomains={expandedDomains}
+            checkingVerification={checkingVerification}
+            onToggle={toggleDomain}
+            onVerify={handleCheckVerification}
+            onDelete={handleDeleteDomain}
+          />
+        )}
+      </div>
+    </Suspense>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/domains/domains-page.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/domains-page.tsx
@@ -1,0 +1,14 @@
+import { DashboardShell } from "@/components/dashboard-shell";
+import { DomainsContent } from "./domains-content";
+
+// ---------------------------------------------------------------------------
+// Page (wraps content in DashboardShell)
+// ---------------------------------------------------------------------------
+
+export function DomainsPage() {
+  return (
+    <DashboardShell>
+      <DomainsContent />
+    </DashboardShell>
+  );
+}

--- a/packages/dashboard/src/pages/dashboard/domains.astro
+++ b/packages/dashboard/src/pages/dashboard/domains.astro
@@ -1,0 +1,8 @@
+---
+import { DomainsPage } from "@/components/dashboard/domains/domains-page";
+import DashboardLayout from "@/layouts/DashboardLayout.astro";
+---
+
+<DashboardLayout>
+  <DomainsPage client:only="react" />
+</DashboardLayout>


### PR DESCRIPTION
## Summary

Phase 2 of the Next.js → Astro dashboard migration: ports the `/dashboard/domains` route to Astro, following the established `client:only` island pattern (same as the merged `/traces` port in #144).

## Changes

- **`src/pages/dashboard/domains.astro`** — Astro entry: renders `<DomainsPage client:only="react" />` inside `<DashboardLayout>`.
- **`src/components/dashboard/domains/domains-page.tsx`** — thin wrapper: `<DashboardShell><DomainsContent /></DashboardShell>`.
- **`src/components/dashboard/domains/domains-content.tsx`** — the old `page.tsx` body (`useProjectId` + `useDomains` + `<Suspense>` + `PageHeader` / `_AddDomainForm` / `_DomainsList`).
- **15 co-located files** copied 1:1 from `src/app/dashboard/domains/` into `src/components/dashboard/domains/`:
  - `_components/` (add-domain-form, domains-empty-state, domains-list, domains-loading-skeleton, index)
  - `_domain-card.tsx`, `_domain-card-actions.tsx`, `_domain-card-expanded.tsx`, `_domain-card-status-badge.tsx`, `_domain-card-unverified-alert.tsx`, `_domain-card-verified-alert.tsx`
  - `_domains-service.ts`
  - `_use-domain-actions.ts`, `_use-domains.ts`, `_use-domains-list.ts`, `_use-expanded-domains.ts`, `_use-project-id.ts`
  - `_verification-method.tsx`, `_verification-record.tsx`
  - `'use client'` directives stripped; relative imports kept intact; domain validation and add/delete/verify action logic preserved exactly.

Source `src/app/dashboard/domains/` is left untouched (copy-out, not move).

## Pattern

Each dashboard page = one `client:only="react"` island wrapped in `<DashboardShell>` (which provides Clerk `Providers` + auth gate + sidebar/header chrome). See `src/components/dashboard-shell.tsx`.

## Verification

- [x] `bunx biome check --write` on new files (2 warnings on `.astro` import are biome false positives — `DashboardLayout` IS used in the template; identical to `traces.astro`)
- [x] `bunx astro check` — **0 errors, 0 warnings** (92 hints are pre-existing deprecation hints in `nav-user.tsx`)
- [x] `bunx astro dev` + `curl http://localhost:4325/dashboard/domains/` → **HTTP 200**, HTML contains `astro-island` + `client:only` markers confirming island hydration
- [x] Source `src/app/` not modified

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>