### PR TITLE
feat(dashboard): port /project route to Astro

### DIFF
--- a/packages/dashboard/src/components/dashboard/project/_api-keys-table.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_api-keys-table.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import type { ApiKeyResponse } from "@agentstate/shared";
+import { Button } from "@cloudflare/kumo/components/button";
+import { LayerCard } from "@cloudflare/kumo/components/layer-card";
+import { Table } from "@cloudflare/kumo/components/table";
+import { Key, Trash } from "@phosphor-icons/react";
+import { EmptyState } from "@/components/dashboard/empty-state";
+import { formatDate } from "./_utils";
+
+interface ApiKeysTableProps {
+  keys: ApiKeyResponse[];
+  onRevoke: (keyId: string) => void;
+}
+
+export function ApiKeysTable({ keys, onRevoke }: ApiKeysTableProps) {
+  const activeKeys = keys.filter((k) => !k.revoked_at);
+
+  if (activeKeys.length === 0) {
+    return (
+      <LayerCard>
+        <EmptyState
+          icon={<Key aria-hidden />}
+          title="No active API keys"
+          description="Create a key to start using the API."
+        />
+      </LayerCard>
+    );
+  }
+
+  return (
+    <LayerCard className="overflow-hidden p-0">
+      <Table>
+        <Table.Header>
+          <Table.Row className="bg-muted hover:bg-muted">
+            <Table.Head>Name</Table.Head>
+            <Table.Head>Key</Table.Head>
+            <Table.Head className="hidden sm:table-cell">Last used</Table.Head>
+            <Table.Head className="w-10" />
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {activeKeys.map((key) => (
+            <Table.Row key={key.id}>
+              <Table.Cell className="py-3.5">
+                <div className="flex items-center gap-3">
+                  <span className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border bg-muted text-muted-foreground">
+                    <Key className="size-4" aria-hidden />
+                  </span>
+                  <span className="text-sm font-semibold text-foreground">{key.name}</span>
+                </div>
+              </Table.Cell>
+              <Table.Cell>
+                <code className="font-mono text-xs text-muted-foreground">{key.key_prefix}...</code>
+              </Table.Cell>
+              <Table.Cell className="hidden text-xs text-muted-foreground sm:table-cell">
+                {key.last_used_at ? formatDate(key.last_used_at) : "Never"}
+              </Table.Cell>
+              <Table.Cell>
+                <Button
+                  shape="square"
+                  size="sm"
+                  variant="ghost"
+                  className="text-muted-foreground hover:text-kumo-danger"
+                  aria-label={`Revoke key ${key.name}`}
+                  onClick={() => onRevoke(key.id)}
+                >
+                  <Trash aria-hidden />
+                </Button>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+    </LayerCard>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/project/_column-picker.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_column-picker.tsx
@@ -1,0 +1,37 @@
+import type { ColumnKey } from "./_types";
+
+interface ColumnDefinition {
+  key: ColumnKey;
+  label: string;
+}
+
+interface ColumnPickerProps {
+  allColumns: readonly ColumnDefinition[];
+  visible: ColumnKey[];
+  onChange: (columns: ColumnKey[]) => void;
+}
+
+export function ColumnPicker({ allColumns, visible, onChange }: ColumnPickerProps) {
+  const toggleCol = (key: ColumnKey) =>
+    onChange(visible.includes(key) ? visible.filter((c) => c !== key) : [...visible, key]);
+
+  return (
+    <fieldset className="absolute right-0 top-9 z-10 min-w-[160px] rounded-lg border border-border bg-kumo-base p-2 shadow-md">
+      <legend className="sr-only">Select visible columns</legend>
+      {allColumns.map((col) => (
+        <label
+          key={col.key}
+          className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted focus-within:bg-muted focus-within:ring-2 focus-within:ring-kumo-focus"
+        >
+          <input
+            type="checkbox"
+            checked={visible.includes(col.key)}
+            onChange={() => toggleCol(col.key)}
+            className="rounded"
+          />
+          <span className="flex-1">{col.label}</span>
+        </label>
+      ))}
+    </fieldset>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/project/_components.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_components.tsx
@@ -1,0 +1,27 @@
+// Re-export all project components
+
+export { CONVERSATION_COLUMNS } from "./_conversation-row";
+export { _ConversationsEmptyState } from "./_conversations-empty-state";
+export { _CreatedKeyDisplay } from "./_created-key-display";
+export { _DataTab } from "./_data-tab";
+export { useDataTabState } from "./_data-tab-state";
+// Re-export existing dependencies
+export { KeysTab as _KeysTab } from "./_keys-tab";
+export { useKeysTabState } from "./_keys-tab-state";
+// Re-export loading state component
+export { _ProjectLoadingState } from "./_loading-state";
+export { _PageHeader } from "./_page-header";
+export { _ProjectDetails } from "./_project-details";
+export { _ProjectSettings } from "./_project-settings";
+export { _QuickStartCode } from "./_quick-start-code";
+export { RetentionSettings } from "./_retention-settings";
+export { _StatsGrid } from "./_stats-grid";
+export { buildTabItem as _TabTrigger } from "./_tab-trigger";
+export type { ColumnKey } from "./_types";
+// Re-export hooks
+export { useComputedStats } from "./_use-computed-stats";
+export { useConversationActions } from "./_use-conversation-actions";
+export { useDeleteProject } from "./_use-delete-project";
+export { useKeyActions } from "./_use-key-actions";
+export { useNewKeyStorage } from "./_use-new-key-storage";
+export { useProjectData } from "./_use-project-data";

--- a/packages/dashboard/src/components/dashboard/project/_conversation-cell-renderers.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_conversation-cell-renderers.tsx
@@ -1,0 +1,61 @@
+import type { ConversationResponse } from "@agentstate/shared";
+import { formatCostMicrodollars } from "@/lib/format-cost";
+import type { ColumnKey } from "./_types";
+import { formatDate } from "./_utils";
+
+type Conversation = ConversationResponse;
+
+export function renderConversationCell(conv: Conversation, col: ColumnKey): React.ReactNode {
+  switch (col) {
+    case "title":
+      return (
+        <span className="text-sm font-medium text-foreground">{conv.title || "Untitled"}</span>
+      );
+    case "external_id":
+      return (
+        <code className="font-mono text-xs text-muted-foreground">{conv.external_id || "—"}</code>
+      );
+    case "message_count":
+      return (
+        <span className="font-mono text-xs tabular-nums text-muted-foreground">
+          {conv.message_count}
+        </span>
+      );
+    case "token_count":
+      return (
+        <span
+          suppressHydrationWarning
+          className="font-mono text-xs tabular-nums text-muted-foreground"
+        >
+          {conv.token_count.toLocaleString()}
+        </span>
+      );
+    case "total_cost":
+      return (
+        <span className="font-mono text-xs tabular-nums text-muted-foreground">
+          {formatCostMicrodollars(conv.total_cost_microdollars)}
+        </span>
+      );
+    case "total_tokens":
+      return (
+        <span
+          suppressHydrationWarning
+          className="font-mono text-xs tabular-nums text-muted-foreground"
+        >
+          {conv.total_tokens.toLocaleString()}
+        </span>
+      );
+    case "metadata":
+      return conv.metadata ? (
+        <code className="block max-w-[140px] truncate font-mono text-xs text-muted-foreground">
+          {JSON.stringify(conv.metadata)}
+        </code>
+      ) : (
+        "—"
+      );
+    case "created_at":
+      return <span className="text-xs text-muted-foreground">{formatDate(conv.created_at)}</span>;
+    case "updated_at":
+      return <span className="text-xs text-muted-foreground">{formatDate(conv.updated_at)}</span>;
+  }
+}

--- a/packages/dashboard/src/components/dashboard/project/_conversation-columns.ts
+++ b/packages/dashboard/src/components/dashboard/project/_conversation-columns.ts
@@ -1,0 +1,13 @@
+import type { ColumnKey } from "./_types";
+
+export const CONVERSATION_COLUMNS: readonly { key: ColumnKey; label: string }[] = [
+  { key: "title", label: "Title" },
+  { key: "external_id", label: "External ID" },
+  { key: "message_count", label: "Messages" },
+  { key: "token_count", label: "Tokens" },
+  { key: "total_cost", label: "Cost" },
+  { key: "total_tokens", label: "Total Tokens" },
+  { key: "metadata", label: "Metadata" },
+  { key: "created_at", label: "Created" },
+  { key: "updated_at", label: "Updated" },
+] as const;

--- a/packages/dashboard/src/components/dashboard/project/_conversation-message.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_conversation-message.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import type { MessageResponse } from "@agentstate/shared";
+import type { BadgeVariant } from "@cloudflare/kumo/components/badge";
+import { Badge } from "@cloudflare/kumo/components/badge";
+import { ROLE_BADGE_VARIANTS } from "@/lib/constants";
+import { formatDateTime } from "./_utils";
+
+type Message = MessageResponse;
+
+/**
+ * Maps shadcn Badge variant strings (from ROLE_BADGE_VARIANTS in lib/constants)
+ * to the Kumo Badge variant equivalents. lib/constants.ts is shared and cannot
+ * be edited here, so the shim translates at the call site.
+ */
+const SHADCN_TO_KUMO_BADGE: Record<string, BadgeVariant> = {
+  default: "primary",
+  secondary: "neutral",
+  outline: "outline",
+  destructive: "error",
+};
+
+interface ConversationMessageProps {
+  message: Message;
+}
+
+export function ConversationMessage({ message }: ConversationMessageProps) {
+  const shadcnVariant = ROLE_BADGE_VARIANTS[message.role] ?? ROLE_BADGE_VARIANTS.system;
+
+  return (
+    <div className="flex gap-3">
+      <Badge
+        variant={SHADCN_TO_KUMO_BADGE[shadcnVariant] ?? "neutral"}
+        className="shrink-0 font-mono text-xs"
+      >
+        {message.role}
+      </Badge>
+      <div className="min-w-0 flex-1">
+        <p className="whitespace-pre-wrap break-words text-sm leading-relaxed">{message.content}</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {formatDateTime(message.created_at)}
+          {message.token_count > 0 && ` · ${message.token_count} tokens`}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/project/_conversation-row.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_conversation-row.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import type { ConversationResponse, MessageResponse } from "@agentstate/shared";
+import { Table } from "@cloudflare/kumo";
+import { CaretDown, CaretRight } from "@phosphor-icons/react";
+import { MessageListSkeleton } from "@/components/dashboard/loading-states";
+import { renderConversationCell } from "./_conversation-cell-renderers";
+import { CONVERSATION_COLUMNS } from "./_conversation-columns";
+import { ConversationMessage } from "./_conversation-message";
+import type { ColumnKey } from "./_types";
+
+type Conversation = ConversationResponse;
+type Message = MessageResponse;
+
+interface ConversationRowProps {
+  conversation: Conversation;
+  isExpanded: boolean;
+  messages?: Message[];
+  isLoading: boolean;
+  visibleColumns: ColumnKey[];
+  allColumns: readonly { key: ColumnKey; label: string }[];
+  onToggle: () => void;
+}
+
+export function ConversationRow({
+  conversation,
+  isExpanded,
+  messages,
+  isLoading,
+  visibleColumns,
+  allColumns,
+  onToggle,
+}: ConversationRowProps) {
+  return (
+    <Table.Row>
+      <Table.Cell colSpan={visibleColumns.length + 1} className="p-0">
+        <button
+          type="button"
+          className="flex w-full cursor-pointer items-center border-b border-border bg-transparent text-left transition-colors hover:bg-muted"
+          onClick={onToggle}
+          aria-expanded={isExpanded}
+          aria-label={`Toggle ${conversation.title || "Untitled"} conversation`}
+        >
+          <div className="px-3 py-3 text-muted-foreground" aria-hidden="true">
+            {isExpanded ? <CaretDown aria-hidden /> : <CaretRight aria-hidden />}
+          </div>
+          {allColumns
+            .filter((c) => visibleColumns.includes(c.key))
+            .map((col) => (
+              <div key={col.key} className="px-4 py-3">
+                {renderConversationCell(conversation, col.key)}
+              </div>
+            ))}
+        </button>
+        {isExpanded && (
+          <section
+            className="border-b border-border bg-muted px-6 py-5"
+            aria-label="Conversation messages"
+          >
+            {isLoading ? (
+              <MessageListSkeleton lines={2} />
+            ) : messages?.length ? (
+              <div className="flex max-h-[500px] flex-col gap-4 overflow-y-auto">
+                {messages.map((msg) => (
+                  <ConversationMessage key={msg.id} message={msg} />
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">No messages</p>
+            )}
+          </section>
+        )}
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+export { CONVERSATION_COLUMNS };

--- a/packages/dashboard/src/components/dashboard/project/_conversations-empty-state.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_conversations-empty-state.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { LayerCard } from "@cloudflare/kumo/components/layer-card";
+import { ChatCentered } from "@phosphor-icons/react";
+import { MethodTag } from "@/components/brand/bits";
+import { EmptyState } from "@/components/dashboard/empty-state";
+
+export function _ConversationsEmptyState() {
+  return (
+    <LayerCard>
+      <div className="grid min-h-72 place-items-center px-4">
+        <div className="flex flex-col items-center gap-4 text-center">
+          <EmptyState
+            icon={<ChatCentered aria-hidden />}
+            title="No conversations yet"
+            description="Use your API key to start storing conversations."
+          />
+          <span className="inline-flex items-center gap-2">
+            <MethodTag>POST</MethodTag>
+            <code className="font-mono text-xs text-muted-foreground">/api/v1/conversations</code>
+          </span>
+        </div>
+      </div>
+    </LayerCard>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/project/_created-key-display.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_created-key-display.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Badge } from "@cloudflare/kumo/components/badge";
+import { Button } from "@cloudflare/kumo/components/button";
+import { LayerCard } from "@cloudflare/kumo/components/layer-card";
+import { Text } from "@cloudflare/kumo/components/text";
+import { Check, Copy } from "@phosphor-icons/react";
+
+interface CreatedKeyDisplayProps {
+  apiKey: string;
+  copied: boolean;
+  onCopy: (text: string) => void;
+}
+
+export function _CreatedKeyDisplay({ apiKey, copied, onCopy }: CreatedKeyDisplayProps) {
+  return (
+    <LayerCard className="mb-6 flex flex-col gap-4 p-6">
+      <div className="flex items-center justify-between gap-2">
+        <Text variant="heading3" as="h2">
+          Your API key
+        </Text>
+        <Badge variant="info">shown once</Badge>
+      </div>
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center gap-2">
+          <code className="flex-1 break-all rounded-lg border border-border bg-muted px-3 py-2 font-mono text-xs text-muted-foreground">
+            {apiKey}
+          </code>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => onCopy(apiKey)}
+            aria-label={copied ? "Copied!" : "Copy API key"}
+          >
+            {copied ? <Check className="text-emerald-600" aria-hidden /> : <Copy aria-hidden />}
+          </Button>
+        </div>
+        <Text variant="secondary" size="sm" as="p">
+          Copy this key now. It won&apos;t be shown again.
+        </Text>
+      </div>
+    </LayerCard>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/project/_data-tab-state.ts
+++ b/packages/dashboard/src/components/dashboard/project/_data-tab-state.ts
@@ -1,0 +1,23 @@
+import { useState } from "react";
+import type { ColumnKey } from "./_components";
+
+const DEFAULT_COLUMNS: ColumnKey[] = [
+  "title",
+  "message_count",
+  "token_count",
+  "total_cost",
+  "updated_at",
+];
+
+export function useDataTabState() {
+  const [visibleCols, setVisibleCols] = useState<ColumnKey[]>(DEFAULT_COLUMNS);
+  const [showColPicker, setShowColPicker] = useState(false);
+
+  return {
+    visibleCols,
+    showColPicker,
+    setVisibleCols,
+    setShowColPicker,
+    toggleColPicker: () => setShowColPicker((prev) => !prev),
+  };
+}

--- a/packages/dashboard/src/components/dashboard/project/_data-tab.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_data-tab.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import type { ConversationResponse, MessageResponse } from "@agentstate/shared";
+import { ColumnPicker } from "./_column-picker";
+import type { ColumnKey } from "./_types";
+import { ConversationsContent, ConversationsHeader } from "./data-tab";
+
+type Conversation = ConversationResponse;
+type Message = MessageResponse;
+
+interface DataTabProps {
+  totalConvs: number;
+  convsLoading: boolean;
+  conversations: Conversation[];
+  expandedConv: string | null;
+  messagesCache: Record<string, Message[]>;
+  loadingMessages: Record<string, boolean>;
+  visibleCols: ColumnKey[];
+  showColPicker: boolean;
+  allColumns: readonly { key: ColumnKey; label: string }[];
+  onToggleConversation: (convId: string) => void;
+  onToggleColPicker: () => void;
+  onChangeColumns: (columns: ColumnKey[]) => void;
+}
+
+export function _DataTab({
+  totalConvs,
+  convsLoading,
+  conversations,
+  expandedConv,
+  messagesCache,
+  loadingMessages,
+  visibleCols,
+  showColPicker,
+  allColumns,
+  onToggleConversation,
+  onToggleColPicker,
+  onChangeColumns,
+}: DataTabProps) {
+  const columns: Array<{ key: ColumnKey | "expand"; label: string }> = [
+    { key: "expand" as const, label: "" },
+    ...allColumns
+      .filter((c) => visibleCols.includes(c.key))
+      .map((col) => ({ key: col.key, label: col.label })),
+  ];
+
+  return (
+    <div className="flex flex-col gap-3">
+      <ConversationsHeader
+        totalConvs={totalConvs}
+        showColPicker={showColPicker}
+        onToggleColPicker={onToggleColPicker}
+      />
+      {showColPicker && (
+        <ColumnPicker allColumns={allColumns} visible={visibleCols} onChange={onChangeColumns} />
+      )}
+      <ConversationsContent
+        loading={convsLoading}
+        conversations={conversations}
+        columns={columns}
+        expandedConv={expandedConv}
+        messagesCache={messagesCache}
+        loadingMessages={loadingMessages}
+        visibleCols={visibleCols}
+        allColumns={allColumns}
+        onToggleConversation={onToggleConversation}
+      />
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/project/_delete-confirmation.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_delete-confirmation.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Button } from "@cloudflare/kumo/components/button";
+import { Dialog } from "@cloudflare/kumo/components/dialog";
+import { Input } from "@cloudflare/kumo/components/input";
+import { LayerCard } from "@cloudflare/kumo/components/layer-card";
+import { Text } from "@cloudflare/kumo/components/text";
+import { Trash } from "@phosphor-icons/react";
+
+interface DeleteConfirmationProps {
+  projectName: string;
+  projectSlug: string;
+  confirmSlug: string;
+  deleting: boolean;
+  onConfirmChange: (slug: string) => void;
+  onDelete: () => void;
+}
+
+export function DeleteConfirmation({
+  projectName,
+  projectSlug,
+  confirmSlug,
+  deleting,
+  onConfirmChange,
+  onDelete,
+}: DeleteConfirmationProps) {
+  return (
+    <LayerCard className="p-6 ring-kumo-danger/30">
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <Text variant="heading3" as="h3">
+            Danger zone
+          </Text>
+          <Text variant="secondary" size="sm" as="p">
+            Permanently delete this project and all its data including conversations, messages, and
+            API keys.
+          </Text>
+        </div>
+        <Dialog.Root role="alertdialog" onOpenChange={(open) => !open && onConfirmChange("")}>
+          <Dialog.Trigger
+            render={(props) => (
+              <Button variant="destructive" size="sm" {...props}>
+                <Trash aria-hidden />
+                Delete project
+              </Button>
+            )}
+          />
+          <Dialog className="p-6">
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-2">
+                <Dialog.Title className="text-lg font-semibold text-foreground">
+                  Delete {projectName}?
+                </Dialog.Title>
+                <Dialog.Description className="text-sm text-muted-foreground">
+                  This action cannot be undone. This will permanently delete the project and all
+                  associated conversations, messages, and API keys.
+                </Dialog.Description>
+              </div>
+              <Input
+                label={
+                  <>
+                    Type{" "}
+                    <code className="font-mono font-semibold text-foreground">{projectSlug}</code>{" "}
+                    to confirm
+                  </>
+                }
+                placeholder={projectSlug}
+                value={confirmSlug}
+                onChange={(e) => onConfirmChange(e.target.value)}
+                className="font-mono"
+              />
+              <div className="flex justify-end gap-2">
+                <Dialog.Close
+                  render={(props) => (
+                    <Button variant="ghost" size="sm" {...props}>
+                      Cancel
+                    </Button>
+                  )}
+                />
+                <Dialog.Close
+                  render={(props) => (
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      {...props}
+                      onClick={onDelete}
+                      disabled={confirmSlug !== projectSlug || deleting}
+                    >
+                      {deleting ? "Deleting..." : "Delete project"}
+                    </Button>
+                  )}
+                />
+              </div>
+            </div>
+          </Dialog>
+        </Dialog.Root>
+      </div>
+    </LayerCard>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/project/_keys-tab-state.ts
+++ b/packages/dashboard/src/components/dashboard/project/_keys-tab-state.ts
@@ -1,0 +1,17 @@
+import { useState } from "react";
+
+export function useKeysTabState() {
+  const [showCreateKey, setShowCreateKey] = useState(false);
+  const [newKeyName, setNewKeyName] = useState("");
+
+  return {
+    showCreateKey,
+    newKeyName,
+    setShowCreateKey,
+    setNewKeyName,
+    resetKeyForm: () => {
+      setShowCreateKey(false);
+      setNewKeyName("");
+    },
+  };
+}

--- a/packages/dashboard/src/components/dashboard/project/_keys-tab.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_keys-tab.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import type { ApiKeyResponse } from "@agentstate/shared";
+import { Button } from "@cloudflare/kumo/components/button";
+import { Plus } from "@phosphor-icons/react";
+import { InlineForm } from "@/components/dashboard/inline-form";
+import { ApiKeysTable } from "./_api-keys-table";
+
+interface KeysTabProps {
+  showCreateKey: boolean;
+  newKeyName: string;
+  apiKeys: ApiKeyResponse[];
+  onCreateKey: () => void;
+  onChangeKeyName: (value: string) => void;
+  onShowCreateKey: () => void;
+  onCancelCreateKey: () => void;
+  onRevokeKey: (keyId: string) => void;
+}
+
+export function KeysTab({
+  showCreateKey,
+  newKeyName,
+  apiKeys,
+  onCreateKey,
+  onChangeKeyName,
+  onShowCreateKey,
+  onCancelCreateKey,
+  onRevokeKey,
+}: KeysTabProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="text-sm text-muted-foreground">Manage API keys for this project.</p>
+        <Button size="sm" variant="outline" icon={<Plus aria-hidden />} onClick={onShowCreateKey}>
+          New Key
+        </Button>
+      </div>
+      {showCreateKey && (
+        <InlineForm
+          value={newKeyName}
+          onChange={onChangeKeyName}
+          onSubmit={onCreateKey}
+          onCancel={onCancelCreateKey}
+          placeholder="e.g. Production"
+          label="Key name"
+          submitLabel="Create"
+          inputId="key-name"
+        />
+      )}
+      <ApiKeysTable keys={apiKeys} onRevoke={onRevokeKey} />
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/project/_loading-state.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_loading-state.tsx
@@ -1,0 +1,14 @@
+import { PageHeaderSkeleton, StatsCardsSkeleton } from "@/components/dashboard/loading-states";
+
+export function _ProjectLoadingState() {
+  return (
+    <div className="flex flex-col gap-6">
+      <PageHeaderSkeleton />
+      <StatsCardsSkeleton count={4} />
+      <div className="flex flex-col gap-3">
+        <div className="h-10 w-48 animate-pulse rounded bg-muted" />
+        <div className="h-64 animate-pulse rounded-lg bg-muted" />
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/project/_page-header.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_page-header.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Badge } from "@cloudflare/kumo/components/badge";
+import { buttonVariants } from "@cloudflare/kumo/components/button";
+import { ArrowLeft, Database, Globe } from "@phosphor-icons/react";
+import Link from "next/link";
+
+interface PageHeaderProps {
+  name: string;
+  slug: string;
+}
+
+export function _PageHeader({ name, slug }: PageHeaderProps) {
+  return (
+    <header className="mb-5 overflow-hidden rounded-lg border border-border bg-kumo-base shadow-sm">
+      <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-start sm:justify-between sm:p-5">
+        <div className="flex min-w-0 gap-3">
+          <Link
+            href="/dashboard"
+            aria-label="Back to projects"
+            className={buttonVariants({
+              variant: "outline",
+              size: "sm",
+              shape: "square",
+            })}
+          >
+            <ArrowLeft aria-hidden />
+          </Link>
+          <div className="min-w-0 space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant="outline">Project</Badge>
+              <span className="font-mono text-xs text-muted-foreground">{slug}</span>
+            </div>
+            <h1 className="truncate text-[26px] font-semibold tracking-tight text-foreground">
+              {name}
+            </h1>
+          </div>
+        </div>
+        <div className="grid gap-2 text-xs text-muted-foreground sm:min-w-64">
+          <div className="flex items-center gap-2 rounded-lg border border-border bg-muted px-2.5 py-2">
+            <Database className="size-3.5" aria-hidden />
+            <span className="font-mono">durable conversation history</span>
+          </div>
+          <div className="flex items-center gap-2 rounded-lg border border-border bg-muted px-2.5 py-2">
+            <Globe className="size-3.5" aria-hidden />
+            <span className="truncate font-mono">https://agentstate.app/api</span>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/project/_project-details.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_project-details.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import type { ProjectDetailResponse } from "@agentstate/shared";
+import { LayerCard } from "@cloudflare/kumo/components/layer-card";
+import { Text } from "@cloudflare/kumo/components/text";
+
+interface ProjectDetailsProps {
+  project: ProjectDetailResponse;
+}
+
+export function _ProjectDetails({ project }: ProjectDetailsProps) {
+  return (
+    <LayerCard className="flex flex-col gap-4 p-6">
+      <Text variant="heading3" as="h2">
+        Project details
+      </Text>
+      <div className="flex flex-col gap-1.5 text-sm text-muted-foreground">
+        <p>
+          ID: <code className="font-mono text-muted-foreground">{project.id}</code>
+        </p>
+        <p suppressHydrationWarning>Created: {new Date(project.created_at).toLocaleString()}</p>
+        <p>
+          Base URL:{" "}
+          <code className="font-mono text-muted-foreground">https://agentstate.app/api</code>
+        </p>
+      </div>
+    </LayerCard>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/project/_project-settings.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_project-settings.tsx
@@ -1,0 +1,39 @@
+import type { ProjectDetailResponse } from "@agentstate/shared";
+import { DeleteConfirmation } from "./_delete-confirmation";
+import { _ProjectDetails } from "./_project-details";
+import { _QuickStartCode } from "./_quick-start-code";
+import { RetentionSettings } from "./_retention-settings";
+
+interface ProjectSettingsProps {
+  project: ProjectDetailResponse;
+  deleteConfirmSlug: string;
+  deleting: boolean;
+  onDeleteConfirm: (slug: string) => void;
+  onDelete: () => void;
+  onProjectUpdated: (updated: ProjectDetailResponse) => void;
+}
+
+export function _ProjectSettings({
+  project,
+  deleteConfirmSlug,
+  deleting,
+  onDeleteConfirm,
+  onDelete,
+  onProjectUpdated,
+}: ProjectSettingsProps) {
+  return (
+    <div className="flex flex-col gap-6">
+      <_QuickStartCode />
+      <_ProjectDetails project={project} />
+      <RetentionSettings project={project} onUpdated={onProjectUpdated} />
+      <DeleteConfirmation
+        projectName={project.name}
+        projectSlug={project.slug}
+        confirmSlug={deleteConfirmSlug}
+        deleting={deleting}
+        onConfirmChange={onDeleteConfirm}
+        onDelete={onDelete}
+      />
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/project/_quick-start-code.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_quick-start-code.tsx
@@ -1,0 +1,15 @@
+import { CodeBlock } from "@/components/brand/code-block";
+
+const QUICK_START_SNIPPET = `curl -X POST https://agentstate.app/api/v1/conversations \\
+  -H "Authorization: Bearer <your-key>" \\
+  -H "Content-Type: application/json" \\
+  -d '{"messages": [{"role": "user", "content": "Hello"}]}'`;
+
+export function _QuickStartCode() {
+  return (
+    <div className="flex flex-col gap-3">
+      <h3 className="font-medium text-foreground">Quick start</h3>
+      <CodeBlock code={QUICK_START_SNIPPET} title="terminal" />
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/project/_retention-settings.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_retention-settings.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import type { ProjectDetailResponse } from "@agentstate/shared";
+import { Button } from "@cloudflare/kumo/components/button";
+import { Input } from "@cloudflare/kumo/components/input";
+import { LayerCard } from "@cloudflare/kumo/components/layer-card";
+import { Text } from "@cloudflare/kumo/components/text";
+import { useState } from "react";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+
+interface RetentionSettingsProps {
+  project: ProjectDetailResponse;
+  onUpdated: (updated: ProjectDetailResponse) => void;
+}
+
+export function RetentionSettings({ project, onUpdated }: RetentionSettingsProps) {
+  const [retentionDays, setRetentionDays] = useState<string>(
+    project.retention_days != null ? String(project.retention_days) : "",
+  );
+  const [saving, setSaving] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const currentDisplay =
+    project.retention_days != null ? `${project.retention_days} days` : "Forever (no retention)";
+
+  async function handleSave() {
+    const trimmed = retentionDays.trim();
+    const value = trimmed === "" ? null : Number(trimmed);
+
+    if (
+      value !== null &&
+      (Number.isNaN(value) || !Number.isInteger(value) || value < 1 || value > 3650)
+    ) {
+      toast.error("Retention must be between 1 and 3650 days, or empty for infinite.");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const updated = await api<ProjectDetailResponse>(`/v2/projects/${project.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ retention_days: value }),
+      });
+      onUpdated(updated);
+      setShowConfirm(false);
+      toast.success("Retention setting saved");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to save retention setting");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <LayerCard className="flex flex-col gap-4 p-6">
+      <div className="flex flex-col gap-1">
+        <Text variant="heading3" as="h2">
+          Data retention
+        </Text>
+        <Text variant="secondary" size="sm" as="p">
+          Automatically delete conversations older than a specified number of days. Leave empty for
+          infinite retention.
+        </Text>
+      </div>
+      {showConfirm ? (
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-3">
+            <Input
+              type="number"
+              min={1}
+              max={3650}
+              placeholder="Leave empty for infinite"
+              value={retentionDays}
+              onChange={(e) => setRetentionDays(e.target.value)}
+              aria-label="Retention days"
+              className="max-w-[200px]"
+            />
+            <span className="text-sm text-muted-foreground">days</span>
+          </div>
+          <Text variant="secondary" size="sm" as="p">
+            Conversations older than this will be permanently deleted daily at 3 AM UTC.
+          </Text>
+          <div className="flex gap-2">
+            <Button size="sm" variant="primary" onClick={handleSave} disabled={saving}>
+              {saving ? "Saving..." : "Confirm"}
+            </Button>
+            <Button size="sm" variant="outline" onClick={() => setShowConfirm(false)}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-muted-foreground">Current: {currentDisplay}</span>
+          <Button size="sm" variant="outline" onClick={() => setShowConfirm(true)}>
+            Change
+          </Button>
+        </div>
+      )}
+    </LayerCard>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/project/_stats-grid.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_stats-grid.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Badge } from "@cloudflare/kumo/components/badge";
+import { LayerCard } from "@cloudflare/kumo/components/layer-card";
+import { Text } from "@cloudflare/kumo/components/text";
+import { ChartLineUp, ChatCentered, Coins, Hash, Key } from "@phosphor-icons/react";
+
+interface StatsGridProps {
+  totalConversations: number;
+  totalMessages: number;
+  totalTokens: number;
+  activeKeyCount: number;
+}
+
+export function _StatsGrid({
+  totalConversations,
+  totalMessages,
+  totalTokens,
+  activeKeyCount,
+}: StatsGridProps) {
+  const stats = [
+    { label: "Conversations", value: totalConversations.toLocaleString(), icon: ChatCentered },
+    { label: "Messages", value: totalMessages.toLocaleString(), icon: Hash },
+    { label: "Tokens", value: totalTokens.toLocaleString(), icon: Coins },
+    { label: "API Keys", value: activeKeyCount.toLocaleString(), icon: Key },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 gap-4 @xl/main:grid-cols-2 @5xl/main:grid-cols-4">
+      {stats.map((s) => (
+        <LayerCard key={s.label} className="flex flex-col gap-3 p-5">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex flex-col gap-1">
+              <Text variant="secondary" size="sm" as="p">
+                {s.label}
+              </Text>
+              <Text variant="heading2" as="h2">
+                {s.value}
+              </Text>
+            </div>
+            <Badge variant="outline">
+              <s.icon className="size-3" aria-hidden />
+              active
+            </Badge>
+          </div>
+          <div className="flex items-center gap-2 text-sm">
+            <span className="font-medium text-foreground">Project stats</span>
+            <ChartLineUp className="size-4 text-muted-foreground" aria-hidden />
+          </div>
+          <Text variant="secondary" size="xs" as="p">
+            {s.label.toLowerCase()} count
+          </Text>
+        </LayerCard>
+      ))}
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/project/_tab-trigger.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_tab-trigger.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Badge } from "@cloudflare/kumo/components/badge";
+import type { TabsItem } from "@cloudflare/kumo/components/tabs";
+import type { Icon } from "@phosphor-icons/react";
+
+interface TabItemProps {
+  value: string;
+  icon: Icon;
+  label: string;
+  count?: number;
+}
+
+/**
+ * Builds a Kumo TabsItem with an icon, label, and optional count badge.
+ * The Kumo Tabs API takes a `tabs` array rather than compound triggers,
+ * so the parent owns active-tab state and renders content panels itself.
+ */
+export function buildTabItem({ value, icon: Icon, label, count }: TabItemProps): TabsItem {
+  return {
+    value,
+    label: (
+      <span className="flex items-center justify-center gap-1.5">
+        <Icon aria-hidden />
+        {label}
+        {count !== undefined && (
+          <Badge variant="neutral" className="tabular-nums">
+            {count}
+          </Badge>
+        )}
+      </span>
+    ),
+  };
+}

--- a/packages/dashboard/src/components/dashboard/project/_types.ts
+++ b/packages/dashboard/src/components/dashboard/project/_types.ts
@@ -1,0 +1,10 @@
+export type ColumnKey =
+  | "title"
+  | "external_id"
+  | "message_count"
+  | "token_count"
+  | "total_cost"
+  | "total_tokens"
+  | "metadata"
+  | "created_at"
+  | "updated_at";

--- a/packages/dashboard/src/components/dashboard/project/_use-computed-stats.ts
+++ b/packages/dashboard/src/components/dashboard/project/_use-computed-stats.ts
@@ -1,0 +1,36 @@
+import type { ConversationResponse, ProjectDetailResponse } from "@agentstate/shared";
+import { useMemo } from "react";
+
+type Conversation = ConversationResponse;
+type ProjectDetail = ProjectDetailResponse;
+
+interface UseComputedStatsResult {
+  activeKeys: ProjectDetail["api_keys"];
+  totalConvs: number;
+  totalMessages: number;
+  totalTokens: number;
+}
+
+export function useComputedStats(
+  project: ProjectDetail | null,
+  conversations: Conversation[],
+): UseComputedStatsResult {
+  const activeKeys = useMemo(
+    () => project?.api_keys.filter((k) => !k.revoked_at) ?? [],
+    [project?.api_keys],
+  );
+
+  const totalConvs = conversations.length;
+
+  const totalMessages = useMemo(
+    () => conversations.reduce((s, c) => s + c.message_count, 0),
+    [conversations],
+  );
+
+  const totalTokens = useMemo(
+    () => conversations.reduce((s, c) => s + c.token_count, 0),
+    [conversations],
+  );
+
+  return { activeKeys, totalConvs, totalMessages, totalTokens };
+}

--- a/packages/dashboard/src/components/dashboard/project/_use-conversation-actions.ts
+++ b/packages/dashboard/src/components/dashboard/project/_use-conversation-actions.ts
@@ -1,0 +1,39 @@
+import type { MessageResponse, ProjectDetailResponse } from "@agentstate/shared";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+
+type ProjectDetail = ProjectDetailResponse;
+type Message = MessageResponse;
+
+export function useConversationActions(project: ProjectDetail | null) {
+  const [expandedConv, setExpandedConv] = useState<string | null>(null);
+  const [messagesCache, setMessagesCache] = useState<Record<string, Message[]>>({});
+  const [loadingMessages, setLoadingMessages] = useState<Record<string, boolean>>({});
+
+  const toggleConversation = useCallback(
+    async (convId: string) => {
+      if (expandedConv === convId) {
+        setExpandedConv(null);
+        return;
+      }
+      setExpandedConv(convId);
+      if (!messagesCache[convId] && project) {
+        setLoadingMessages((prev) => ({ ...prev, [convId]: true }));
+        try {
+          const res = await api<{ data: Message[] }>(
+            `/v1/projects/${project.id}/conversations/${convId}/messages`,
+          );
+          setMessagesCache((prev) => ({ ...prev, [convId]: res.data }));
+        } catch (e) {
+          toast.error(e instanceof Error ? e.message : "Failed to load messages");
+        } finally {
+          setLoadingMessages((prev) => ({ ...prev, [convId]: false }));
+        }
+      }
+    },
+    [expandedConv, messagesCache, project],
+  );
+
+  return { expandedConv, messagesCache, loadingMessages, toggleConversation };
+}

--- a/packages/dashboard/src/components/dashboard/project/_use-delete-project.ts
+++ b/packages/dashboard/src/components/dashboard/project/_use-delete-project.ts
@@ -1,0 +1,28 @@
+import type { ProjectDetailResponse } from "@agentstate/shared";
+import { useRouter } from "next/navigation";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+
+type ProjectDetail = ProjectDetailResponse;
+
+export function useDeleteProject(project: ProjectDetail | null) {
+  const router = useRouter();
+  const [deleteConfirmSlug, setDeleteConfirmSlug] = useState("");
+  const [deleting, setDeleting] = useState(false);
+
+  const handleDeleteProject = useCallback(async () => {
+    if (!project || deleteConfirmSlug !== project.slug) return;
+    setDeleting(true);
+    try {
+      await api(`/v1/projects/${project.id}`, { method: "DELETE" });
+      toast.success(`Project "${project.name}" deleted`);
+      router.push("/dashboard");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to delete project");
+      setDeleting(false);
+    }
+  }, [project, deleteConfirmSlug, router]);
+
+  return { deleteConfirmSlug, deleting, setDeleteConfirmSlug, handleDeleteProject };
+}

--- a/packages/dashboard/src/components/dashboard/project/_use-key-actions.ts
+++ b/packages/dashboard/src/components/dashboard/project/_use-key-actions.ts
@@ -1,0 +1,38 @@
+import type { ProjectDetailResponse } from "@agentstate/shared";
+import { useCallback } from "react";
+import { api } from "@/lib/api";
+
+type ProjectDetail = ProjectDetailResponse;
+
+interface UseKeyActionsProps {
+  project: ProjectDetail | null;
+  onKeyCreated: (key: string) => void;
+  onProjectRefresh: () => Promise<void>;
+}
+
+export function useKeyActions({ project, onKeyCreated, onProjectRefresh }: UseKeyActionsProps) {
+  const handleCreateKey = useCallback(
+    async (keyName: string) => {
+      if (!keyName.trim() || !project) return false;
+      const res = await api<{ id: string; key: string }>(`/v1/projects/${project.id}/keys`, {
+        method: "POST",
+        body: JSON.stringify({ name: keyName.trim() }),
+      });
+      onKeyCreated(res.key);
+      await onProjectRefresh();
+      return true;
+    },
+    [project, onKeyCreated, onProjectRefresh],
+  );
+
+  const handleRevokeKey = useCallback(
+    async (keyId: string) => {
+      if (!project) return;
+      await api(`/v1/projects/${project.id}/keys/${keyId}`, { method: "DELETE" });
+      await onProjectRefresh();
+    },
+    [project, onProjectRefresh],
+  );
+
+  return { handleCreateKey, handleRevokeKey };
+}

--- a/packages/dashboard/src/components/dashboard/project/_use-new-key-storage.ts
+++ b/packages/dashboard/src/components/dashboard/project/_use-new-key-storage.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+
+export function useNewKeyStorage(slug: string | null) {
+  const [createdKey, setCreatedKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!slug) return;
+    const storedKey = sessionStorage.getItem(`new_key_${slug}`);
+    if (storedKey) {
+      setCreatedKey(storedKey);
+      sessionStorage.removeItem(`new_key_${slug}`);
+    }
+  }, [slug]);
+
+  return { createdKey, setCreatedKey };
+}

--- a/packages/dashboard/src/components/dashboard/project/_use-project-data.ts
+++ b/packages/dashboard/src/components/dashboard/project/_use-project-data.ts
@@ -1,0 +1,56 @@
+import type { ConversationResponse, ProjectDetailResponse } from "@agentstate/shared";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+
+type ProjectDetail = ProjectDetailResponse;
+type Conversation = ConversationResponse;
+
+interface UseProjectDataResult {
+  project: ProjectDetail | null;
+  loading: boolean;
+  conversations: Conversation[];
+  convsLoading: boolean;
+  setProject: (p: ProjectDetail | null) => void;
+  setConversations: (c: Conversation[]) => void;
+  refreshProject: () => Promise<void>;
+}
+
+export function useProjectData(slug: string | null): UseProjectDataResult {
+  const [project, setProject] = useState<ProjectDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [convsLoading, setConvsLoading] = useState(false);
+
+  const refreshProject = async () => {
+    if (!slug) return;
+    const p = await api<ProjectDetail>(`/v1/projects/by-slug/${slug}`);
+    setProject(p);
+  };
+
+  useEffect(() => {
+    if (!slug) return;
+    api<ProjectDetail>(`/v1/projects/by-slug/${slug}`)
+      .then((p) => {
+        setProject(p);
+        setConvsLoading(true);
+        return api<{ data: Conversation[] }>(`/v1/projects/${p.id}/conversations?limit=100`);
+      })
+      .then((res) => setConversations(res.data))
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load data"))
+      .finally(() => {
+        setLoading(false);
+        setConvsLoading(false);
+      });
+  }, [slug]);
+
+  return {
+    project,
+    loading,
+    conversations,
+    convsLoading,
+    setProject,
+    setConversations,
+    refreshProject,
+  };
+}

--- a/packages/dashboard/src/components/dashboard/project/_utils.ts
+++ b/packages/dashboard/src/components/dashboard/project/_utils.ts
@@ -1,0 +1,7 @@
+export function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleDateString();
+}
+
+export function formatDateTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleString();
+}

--- a/packages/dashboard/src/components/dashboard/project/data-tab/conversations-content.tsx
+++ b/packages/dashboard/src/components/dashboard/project/data-tab/conversations-content.tsx
@@ -1,0 +1,61 @@
+import type { ConversationResponse, MessageResponse } from "@agentstate/shared";
+import { DataTable } from "@/components/dashboard/data-table";
+import { ConversationRowSkeleton } from "@/components/dashboard/loading-states";
+import { ConversationRow } from "../_conversation-row";
+import { _ConversationsEmptyState } from "../_conversations-empty-state";
+import type { ColumnKey } from "../_types";
+
+type Conversation = ConversationResponse;
+type Message = MessageResponse;
+
+interface ConversationsContentProps {
+  loading: boolean;
+  conversations: Conversation[];
+  columns: Array<{ key: ColumnKey | "expand"; label: string }>;
+  expandedConv: string | null;
+  messagesCache: Record<string, Message[]>;
+  loadingMessages: Record<string, boolean>;
+  visibleCols: ColumnKey[];
+  allColumns: readonly { key: ColumnKey; label: string }[];
+  onToggleConversation: (convId: string) => void;
+}
+
+export function ConversationsContent({
+  loading,
+  conversations,
+  columns,
+  expandedConv,
+  messagesCache,
+  loadingMessages,
+  visibleCols,
+  allColumns,
+  onToggleConversation,
+}: ConversationsContentProps) {
+  if (loading) {
+    return <ConversationRowSkeleton rows={3} />;
+  }
+
+  if (conversations.length === 0) {
+    return <_ConversationsEmptyState />;
+  }
+
+  return (
+    <DataTable
+      data={conversations}
+      columns={columns}
+      rowKey={(conv) => conv.id}
+      renderRow={(conv) => (
+        <ConversationRow
+          key={conv.id}
+          conversation={conv}
+          isExpanded={expandedConv === conv.id}
+          messages={messagesCache[conv.id]}
+          isLoading={loadingMessages[conv.id] || false}
+          visibleColumns={visibleCols}
+          allColumns={allColumns}
+          onToggle={() => onToggleConversation(conv.id)}
+        />
+      )}
+    />
+  );
+}

--- a/packages/dashboard/src/components/dashboard/project/data-tab/conversations-header.tsx
+++ b/packages/dashboard/src/components/dashboard/project/data-tab/conversations-header.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Button } from "@cloudflare/kumo/components/button";
+import { SlidersHorizontal } from "@phosphor-icons/react";
+
+interface ConversationsHeaderProps {
+  totalConvs: number;
+  showColPicker: boolean;
+  onToggleColPicker: () => void;
+}
+
+interface ColumnPickerTriggerProps {
+  show: boolean;
+  onToggle: () => void;
+}
+
+export function ConversationsHeader({
+  totalConvs,
+  showColPicker,
+  onToggleColPicker,
+}: ConversationsHeaderProps) {
+  return (
+    <div className="mb-3 flex items-center justify-between rounded-lg border border-border bg-kumo-base px-3 py-2 shadow-sm">
+      <div>
+        <p className="text-sm font-medium text-foreground">Conversation data</p>
+        <ConversationsCount count={totalConvs} />
+      </div>
+      <ColumnPickerTrigger show={showColPicker} onToggle={onToggleColPicker} />
+    </div>
+  );
+}
+
+function ConversationsCount({ count }: { count: number }) {
+  return (
+    <p className="text-xs text-muted-foreground">
+      {count} conversation{count !== 1 ? "s" : ""}
+    </p>
+  );
+}
+
+function ColumnPickerTrigger({ show, onToggle }: ColumnPickerTriggerProps) {
+  return (
+    <div className="relative">
+      <Button
+        size="sm"
+        variant="outline"
+        icon={<SlidersHorizontal aria-hidden />}
+        type="button"
+        onClick={onToggle}
+        aria-expanded={show}
+        aria-haspopup="menu"
+      >
+        Columns
+      </Button>
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/project/data-tab/index.ts
+++ b/packages/dashboard/src/components/dashboard/project/data-tab/index.ts
@@ -1,0 +1,2 @@
+export { ConversationsContent } from "./conversations-content";
+export { ConversationsHeader } from "./conversations-header";

--- a/packages/dashboard/src/components/dashboard/project/project-content.tsx
+++ b/packages/dashboard/src/components/dashboard/project/project-content.tsx
@@ -1,0 +1,144 @@
+import { Tabs } from "@cloudflare/kumo/components/tabs";
+import { ChatCentered, GearSix, Key } from "@phosphor-icons/react";
+import { useSearchParams } from "next/navigation";
+import { Suspense, useState } from "react";
+import { useCopiedText } from "@/lib/hooks/use-copied-text";
+import {
+  _CreatedKeyDisplay,
+  _DataTab,
+  _KeysTab,
+  _PageHeader,
+  _ProjectSettings,
+  _StatsGrid,
+  _TabTrigger,
+  CONVERSATION_COLUMNS,
+} from "./_components";
+import { useDataTabState } from "./_data-tab-state";
+import { useKeysTabState } from "./_keys-tab-state";
+import { _ProjectLoadingState } from "./_loading-state";
+import { useComputedStats } from "./_use-computed-stats";
+import { useConversationActions } from "./_use-conversation-actions";
+import { useDeleteProject } from "./_use-delete-project";
+import { useKeyActions } from "./_use-key-actions";
+import { useNewKeyStorage } from "./_use-new-key-storage";
+import { useProjectData } from "./_use-project-data";
+
+function ProjectContent() {
+  const params = useSearchParams();
+  const slug = params.get("slug");
+  const { copied, copy } = useCopiedText();
+
+  // Data fetching
+  const { project, loading, conversations, convsLoading, setProject, refreshProject } =
+    useProjectData(slug);
+
+  // UI state
+  const { createdKey, setCreatedKey } = useNewKeyStorage(slug);
+  const keysTab = useKeysTabState();
+  const dataTab = useDataTabState();
+  const [activeTab, setActiveTab] = useState<string>(createdKey ? "keys" : "data");
+
+  // Actions
+  const keyActions = useKeyActions({
+    project,
+    onKeyCreated: (key) => {
+      setCreatedKey(key);
+      keysTab.resetKeyForm();
+    },
+    onProjectRefresh: refreshProject,
+  });
+  const { expandedConv, messagesCache, loadingMessages, toggleConversation } =
+    useConversationActions(project);
+  const { deleteConfirmSlug, deleting, setDeleteConfirmSlug, handleDeleteProject } =
+    useDeleteProject(project);
+
+  // Computed stats
+  const { activeKeys, totalConvs, totalMessages, totalTokens } = useComputedStats(
+    project,
+    conversations,
+  );
+
+  // Early returns after all hooks
+  if (loading) return <_ProjectLoadingState />;
+  if (!project) return <p className="text-muted-foreground">Project not found.</p>;
+
+  const tabs = [
+    _TabTrigger({ value: "data", icon: ChatCentered, label: "Data", count: totalConvs }),
+    _TabTrigger({ value: "keys", icon: Key, label: "API Keys", count: activeKeys.length }),
+    _TabTrigger({ value: "settings", icon: GearSix, label: "Settings" }),
+  ];
+
+  return (
+    <div className="flex flex-col gap-6 px-4 lg:px-6">
+      <_PageHeader name={project.name} slug={project.slug} />
+
+      {createdKey && <_CreatedKeyDisplay apiKey={createdKey} copied={copied} onCopy={copy} />}
+
+      <_StatsGrid
+        totalConversations={totalConvs}
+        totalMessages={totalMessages}
+        totalTokens={totalTokens}
+        activeKeyCount={activeKeys.length}
+      />
+
+      <div className="flex flex-col gap-4">
+        <Tabs
+          variant="segmented"
+          tabs={tabs}
+          value={activeTab}
+          onValueChange={setActiveTab}
+          className="w-full"
+        />
+
+        {activeTab === "settings" && (
+          <_ProjectSettings
+            project={project}
+            deleteConfirmSlug={deleteConfirmSlug}
+            deleting={deleting}
+            onDeleteConfirm={setDeleteConfirmSlug}
+            onDelete={handleDeleteProject}
+            onProjectUpdated={(updated) => setProject(updated)}
+          />
+        )}
+
+        {activeTab === "keys" && (
+          <_KeysTab
+            showCreateKey={keysTab.showCreateKey}
+            newKeyName={keysTab.newKeyName}
+            apiKeys={project.api_keys}
+            onCreateKey={async () => keyActions.handleCreateKey(keysTab.newKeyName)}
+            onChangeKeyName={keysTab.setNewKeyName}
+            onShowCreateKey={() => keysTab.setShowCreateKey(true)}
+            onCancelCreateKey={keysTab.resetKeyForm}
+            onRevokeKey={keyActions.handleRevokeKey}
+          />
+        )}
+
+        {activeTab === "data" && (
+          <_DataTab
+            totalConvs={totalConvs}
+            convsLoading={convsLoading}
+            conversations={conversations}
+            expandedConv={expandedConv}
+            messagesCache={messagesCache}
+            loadingMessages={loadingMessages}
+            visibleCols={dataTab.visibleCols}
+            showColPicker={dataTab.showColPicker}
+            allColumns={CONVERSATION_COLUMNS}
+            onToggleConversation={toggleConversation}
+            onToggleColPicker={dataTab.toggleColPicker}
+            onChangeColumns={dataTab.setVisibleCols}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function ProjectPageContent() {
+  return (
+    <Suspense fallback={<div className="h-32 animate-pulse rounded-lg bg-muted" />}>
+      <ProjectContent />
+    </Suspense>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/project/project-page.tsx
+++ b/packages/dashboard/src/components/dashboard/project/project-page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from "react";
+import { DashboardShell } from "@/components/dashboard-shell";
+import ProjectPageContent from "./project-content";
+
+/**
+ * Astro entry for the /dashboard/project route.
+ * Wraps the ported Next page body in the shared auth-gated dashboard shell.
+ * <Suspense> is required because the body reads `useSearchParams` (shimmed).
+ */
+export function ProjectPage() {
+  return (
+    <DashboardShell>
+      <Suspense>
+        <ProjectPageContent />
+      </Suspense>
+    </DashboardShell>
+  );
+}

--- a/packages/dashboard/src/pages/dashboard/project.astro
+++ b/packages/dashboard/src/pages/dashboard/project.astro
@@ -1,0 +1,8 @@
+---
+import { ProjectPage } from "@/components/dashboard/project/project-page";
+import DashboardLayout from "@/layouts/DashboardLayout.astro";
+---
+
+<DashboardLayout>
+  <ProjectPage client:only="react" />
+</DashboardLayout>


### PR DESCRIPTION
Phase 2 of the Next.js → Astro dashboard migration. Largest route (34 files incl. `data-tab/` subdir).

- `src/pages/dashboard/project.astro`
- `src/components/dashboard/project/project-page.tsx` (DashboardShell wrapper, `<Suspense>` for `useSearchParams`)
- `src/components/dashboard/project/project-content.tsx` (ported body) + 32 co-located files copied 1:1 (relative imports intact, `data-tab/` preserved)

Verified: `astro check` 0 errors, `biome check` clean. Legacy `src/app/` untouched (Phase 3 deletes it).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added a comprehensive project dashboard with dedicated pages for managing settings, API keys, and conversation data.
* Implemented an API keys management interface allowing users to view active keys, display key prefixes, track last-used dates, and revoke keys as needed.
* Introduced a conversation data viewer with expandable rows to display individual messages, customizable column visibility, and filtering options.
* Added data retention settings to configure conversation history retention periods.
* Included project deletion with slug confirmation to prevent accidental removal.
* Provided quick-start code examples and project statistics overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->