### PR TITLE
feat(dashboard): new design system + Vercel-style landing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,8 @@
         "@agentstate/shared": "workspace:*",
         "@clerk/react": "^6.6.6",
         "@cloudflare/kumo": "^2.5.2",
+        "@fontsource-variable/geist": "^5.2.9",
+        "@fontsource-variable/geist-mono": "^5.2.8",
         "@fontsource-variable/hanken-grotesk": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.6",
         "@fontsource-variable/space-grotesk": "^5.2.8",
@@ -322,6 +324,10 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
+    "@fontsource-variable/geist": ["@fontsource-variable/geist@5.2.9", "", {}, "sha512-TP+QSBG3wxKGPE33CbMy/L0Nu3qvJ6Fy81Yc4LnQ95xH+i+cfEp8fyU8/kfV14YwszxIFPhnoMTbjL71waVpyQ=="],
+
+    "@fontsource-variable/geist-mono": ["@fontsource-variable/geist-mono@5.2.8", "", {}, "sha512-KI5bj+hkkRiHttYHmccotUZ80ZuZyai+RwI1d7UId0clkx/jXxlo8qYK8j54WzmpBjtMoEMPyllV7faDcj+6RA=="],
 
     "@fontsource-variable/hanken-grotesk": ["@fontsource-variable/hanken-grotesk@5.2.8", "", {}, "sha512-K7hu09ZKReBc7EifRLeM4K94NZBrxFEg0nGcISmVwlFQOJo4EmYkLXTWEwr5JcNW4z2hr5zy8vLS2sxC8JDmrQ=="],
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -13,6 +13,8 @@
     "@agentstate/shared": "workspace:*",
     "@clerk/react": "^6.6.6",
     "@cloudflare/kumo": "^2.5.2",
+    "@fontsource-variable/geist": "^5.2.9",
+    "@fontsource-variable/geist-mono": "^5.2.8",
     "@fontsource-variable/hanken-grotesk": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.6",
     "@fontsource-variable/space-grotesk": "^5.2.8",

--- a/packages/dashboard/src/components/logo.astro
+++ b/packages/dashboard/src/components/logo.astro
@@ -1,0 +1,14 @@
+---
+/** AgentState mark — three stacked "state layers" with ascending weight.
+ *  Original geometric mark; works at any size, inherits currentColor. */
+interface Props {
+  size?: number;
+  class?: string;
+}
+const { size = 20, class: cls = "" } = Astro.props;
+---
+<svg width={size} height={size} viewBox="0 0 24 24" class={cls} aria-hidden="true" focusable="false">
+  <rect x="3" y="4"  width="18" height="4" rx="2" fill="currentColor" fill-opacity="0.35" />
+  <rect x="3" y="10" width="18" height="4" rx="2" fill="currentColor" fill-opacity="0.65" />
+  <rect x="3" y="16" width="18" height="4" rx="2" fill="currentColor" />
+</svg>

--- a/packages/dashboard/src/components/ui/badge.astro
+++ b/packages/dashboard/src/components/ui/badge.astro
@@ -1,0 +1,25 @@
+---
+interface Props {
+  tone?: "default" | "live" | "warn" | "idle";
+  dot?: boolean;
+  class?: string;
+}
+const { tone = "default", dot = false, class: cls = "" } = Astro.props;
+
+const tones: Record<NonNullable<Props["tone"]>, string> = {
+  default: "border-edge text-fg-3",
+  live: "border-pos/40 bg-pos/10 text-pos",
+  warn: "border-warn/40 bg-warn/10 text-warn",
+  idle: "border-edge text-fg-4",
+};
+const dotColor: Record<NonNullable<Props["tone"]>, string> = {
+  default: "bg-fg-4",
+  live: "bg-pos",
+  warn: "bg-warn",
+  idle: "bg-fg-4",
+};
+---
+<span class={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 font-mono text-[11px] ${tones[tone]} ${cls}`}>
+  {dot && <span class={`size-1.5 rounded-full ${dotColor[tone]}`}></span>}
+  <slot />
+</span>

--- a/packages/dashboard/src/components/ui/button.astro
+++ b/packages/dashboard/src/components/ui/button.astro
@@ -1,0 +1,28 @@
+---
+import type { HTMLAttributes } from "astro/types";
+
+interface Props extends HTMLAttributes<"button"> {
+  variant?: "primary" | "secondary" | "ghost" | "danger";
+  href?: string;
+  class?: string;
+}
+const { variant = "secondary", href, class: cls = "", ...rest } = Astro.props;
+
+const base =
+  "inline-flex items-center justify-center gap-1.5 rounded-[var(--radius)] px-3.5 py-2 text-[13px] font-medium transition-colors disabled:opacity-50 disabled:pointer-events-none";
+const variants: Record<NonNullable<Props["variant"]>, string> = {
+  primary: "bg-white text-black hover:bg-zinc-200",
+  secondary: "border border-edge text-fg hover:bg-panel2",
+  ghost: "text-fg-3 hover:text-fg hover:bg-panel2",
+  danger: "border border-neg/40 bg-neg/10 text-neg hover:bg-neg/20",
+};
+const Tag = href ? "a" : "button";
+const className = `${base} ${variants[variant]} ${cls}`;
+---
+<Tag
+  href={href}
+  class={className}
+  {...(href ? {} : (rest as object))}
+>
+  <slot />
+</Tag>

--- a/packages/dashboard/src/components/ui/card.astro
+++ b/packages/dashboard/src/components/ui/card.astro
@@ -1,0 +1,9 @@
+---
+interface Props {
+  class?: string;
+}
+const { class: cls = "" } = Astro.props;
+---
+<div class={`rounded-[var(--radius-lg)] border border-edge bg-panel ${cls}`}>
+  <slot />
+</div>

--- a/packages/dashboard/src/layouts/MarketingLayout.astro
+++ b/packages/dashboard/src/layouts/MarketingLayout.astro
@@ -1,0 +1,49 @@
+---
+import "../styles/tokens.css";
+import "@fontsource-variable/geist";
+import "@fontsource-variable/geist-mono";
+import Logo from "../components/logo.astro";
+
+interface Props {
+  title?: string;
+  description?: string;
+}
+const {
+  title = "AgentState — the state layer for AI agents",
+  description = "Store conversations, UI messages and graph state behind one API. Drop-in adapters for every framework you already use.",
+} = Astro.props;
+---
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <meta name="color-scheme" content="dark" />
+  </head>
+  <body class="min-h-screen bg-base text-fg-2">
+    <!-- top nav -->
+    <header class="sticky top-0 z-40 border-b border-edge-soft bg-base/85 backdrop-blur">
+      <div class="mx-auto flex h-14 max-w-[1040px] items-center gap-2.5 px-5">
+        <a href="/" class="flex items-center gap-2 text-fg"><Logo size={20} /><span class="text-[15px] font-semibold tracking-tight">AgentState</span></a>
+        <nav class="ml-8 hidden items-center gap-6 text-[13.5px] text-fg-3 sm:flex">
+          <a href="/docs" class="hover:text-fg">Docs</a>
+          <a href="/dashboard" class="hover:text-fg">Dashboard</a>
+          <a href="https://github.com/duyet/agentstate" class="hover:text-fg">GitHub</a>
+        </nav>
+        <div class="ml-auto flex items-center gap-2">
+          <a href="/dashboard" class="rounded-[var(--radius)] border border-edge px-3.5 py-1.5 text-[13px] text-fg hover:bg-panel2">Sign in</a>
+          <a href="/dashboard" class="rounded-[var(--radius)] bg-white px-3.5 py-1.5 text-[13px] font-medium text-black hover:bg-zinc-200">Open dashboard</a>
+        </div>
+      </div>
+    </header>
+    <slot />
+    <footer class="border-t border-edge-soft">
+      <div class="mx-auto flex max-w-[1040px] flex-col items-center gap-2 px-5 py-8 text-center font-mono text-[11px] text-fg-4">
+        <a href="/" class="flex items-center gap-1.5 text-fg-3"><Logo size={14} /> AgentState</a>
+        <span>© 2026 AgentState · MIT · built on Cloudflare D1</span>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/packages/dashboard/src/pages/index.astro
+++ b/packages/dashboard/src/pages/index.astro
@@ -1,8 +1,138 @@
 ---
-import { LandingPage } from "../components/marketing/landing-page";
-import RootLayout from "../layouts/RootLayout.astro";
----
+import Card from "../components/ui/card.astro";
+import MarketingLayout from "../layouts/MarketingLayout.astro";
 
-<RootLayout>
-  <LandingPage client:only="react" />
-</RootLayout>
+const adapters = [
+  ["AI SDK", "@ai-sdk"],
+  ["TanStack", "@tanstack/ai"],
+  ["LangGraph", "@langchain"],
+  ["CF Agents", "agents"],
+  ["Workers AI", "env.AI"],
+  ["OpenAI", "openai"],
+  ["REST", "fetch()"],
+];
+const endpoints: [string, string, string, "pos" | "accent"][] = [
+  ["POST", "/conversations", "Create conversation or state", "pos"],
+  ["GET", "/conversations/:id", "Get, include=messages", "accent"],
+  ["GET", "/analytics/summary", "Usage summary", "accent"],
+  ["POST", "/conversations/:id/messages", "Append messages", "pos"],
+];
+const code = `// any framework — one persistent state layer
+import { AgentState } from "@agentstate/sdk";
+import { createAISDKChatStore } from "@agentstate/sdk/ai-sdk";
+
+const state = new AgentState({ apiKey: AS_KEY });
+const store  = createAISDKChatStore(state);
+
+const chatId = await store.createChat();
+await store.saveChat({ chatId, messages });`;
+---
+<MarketingLayout>
+  <main>
+    <!-- hero -->
+    <section class="mx-auto max-w-[1040px] px-5 pt-24 pb-16 sm:pt-32">
+      <div class="max-w-[820px]">
+        <span class="inline-flex items-center gap-2 rounded-full border border-edge px-3 py-1 text-[12.5px] text-fg-3"><span class="size-1.5 rounded-full bg-accent"></span>v2 state API · graph checkpoints &amp; tracing</span>
+        <h1 class="mt-7 text-[44px] font-semibold leading-[0.98] tracking-[-0.04em] text-fg sm:text-[68px]">
+          The state layer<br />for AI agents.
+        </h1>
+        <p class="mt-7 max-w-[580px] text-[18px] leading-[1.55] text-fg-3 sm:text-[20px]">
+          Store conversations, UI messages and graph state behind one API. Drop-in adapters for every framework you already use — stop rebuilding the memory backend.
+        </p>
+        <div class="mt-9 flex flex-wrap items-center gap-3">
+          <a href="/dashboard" class="inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-white px-5 py-2.5 text-[14px] font-medium text-black hover:bg-zinc-200">Open dashboard →</a>
+          <a href="/docs" class="inline-flex items-center gap-1.5 rounded-[var(--radius)] border border-edge px-5 py-2.5 text-[14px] text-fg hover:bg-panel2">Read the docs</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- code -->
+    <section class="mx-auto max-w-[1040px] px-5 pb-24">
+      <Card class="overflow-hidden p-0">
+        <div class="flex h-10 items-center gap-2 border-b border-edge-soft px-4">
+          <span class="size-2.5 rounded-full bg-fg-4/60"></span>
+          <span class="size-2.5 rounded-full bg-fg-4/60"></span>
+          <span class="size-2.5 rounded-full bg-fg-4/60"></span>
+          <span class="ml-2 font-mono text-[11px] text-fg-4">app.ts</span>
+        </div>
+        <pre class="overflow-auto bg-[#0c0c0e] p-4 font-mono text-[12.5px] leading-[1.75] text-zinc-300"><code>{code}</code></pre>
+      </Card>
+    </section>
+
+    <!-- adapters -->
+    <section class="mx-auto max-w-[1040px] px-5 pb-24">
+      <div class="mb-6 font-mono text-[11px] uppercase tracking-[0.15em] text-fg-4">Works with your stack</div>
+      <div class="grid grid-cols-2 gap-px overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-edge sm:grid-cols-4 lg:grid-cols-7">
+        {adapters.map(([name, pkg]) => (
+          <div class="bg-panel p-4 text-center">
+            <div class="text-[13px] font-medium text-fg">{name}</div>
+            <div class="font-mono text-[10.5px] text-fg-4">{pkg}</div>
+          </div>
+        ))}
+      </div>
+    </section>
+
+    <!-- features -->
+    <section class="mx-auto max-w-[1040px] px-5 pb-24">
+      <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <Card class="p-6">
+          <div class="mb-3 font-mono text-[11px] uppercase tracking-wider text-fg-4">State</div>
+          <div class="text-[16px] font-medium text-fg">Any state, typed</div>
+          <p class="mt-2 text-[14px] leading-relaxed text-fg-3">Threads, UI messages, RSC payloads, graph checkpoints — stored as typed v2 state under any key.</p>
+        </Card>
+        <Card class="p-6">
+          <div class="mb-3 font-mono text-[11px] uppercase tracking-wider text-fg-4">Adapt</div>
+          <div class="text-[16px] font-medium text-fg">Drop-in adapters</div>
+          <p class="mt-2 text-[14px] leading-relaxed text-fg-3">First-class stores for AI SDK, TanStack, LangGraph and Cloudflare Agents. Or raw REST.</p>
+        </Card>
+        <Card class="p-6">
+          <div class="mb-3 font-mono text-[11px] uppercase tracking-wider text-fg-4">Ops</div>
+          <div class="text-[16px] font-medium text-fg">Usage &amp; tracing</div>
+          <p class="mt-2 text-[14px] leading-relaxed text-fg-3">Volume, tokens, cost and active projects — tracked per key, with request-level traces.</p>
+        </Card>
+      </div>
+    </section>
+
+    <!-- API -->
+    <section class="border-t border-edge-soft">
+      <div class="mx-auto max-w-[1040px] px-5 py-24">
+        <div class="mb-3 font-mono text-[11px] uppercase tracking-wider text-fg-4">API surface</div>
+        <h2 class="max-w-[620px] text-[34px] font-semibold leading-[1.05] tracking-[-0.03em] text-fg sm:text-[40px]">
+          Small enough for agents and humans to keep in context.
+        </h2>
+        <Card class="mt-10 overflow-hidden p-0">
+          <table class="w-full text-left text-[13.5px]">
+            <thead>
+              <tr class="border-b border-edge-soft font-mono text-[11px] uppercase text-fg-4">
+                <th class="w-24 px-5 py-3 font-medium">Method</th>
+                <th class="px-5 py-3 font-medium">Endpoint</th>
+                <th class="px-5 py-3 font-medium">Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {endpoints.map(([m, path, desc, tone]) => (
+                <tr class="border-b border-edge-soft last:border-0 hover:bg-panel2">
+                  <td class={`px-5 py-3.5 font-mono ${tone === "pos" ? "text-pos" : "text-accent"}`}>{m}</td>
+                  <td class="px-5 py-3.5 font-mono text-fg">{path}</td>
+                  <td class="px-5 py-3.5 text-fg-3">{desc}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div class="border-t border-edge-soft px-5 py-3 font-mono text-[12px] text-fg-4">
+            base <span class="text-fg-3">https://agentstate.app/api/v1</span> · bearer auth · cursor pagination
+          </div>
+        </Card>
+      </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="border-t border-edge-soft py-24 text-center">
+      <div class="mx-auto max-w-[680px] px-5">
+        <h2 class="text-[30px] font-semibold tracking-[-0.03em] text-fg sm:text-[36px]">Ship the agent,<br />not the backend.</h2>
+        <p class="mx-auto mt-4 max-w-[460px] text-fg-3">Spin up a project, grab a key, and persist your first session in two minutes.</p>
+        <a href="/dashboard" class="mt-8 inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-white px-5 py-2.5 text-[14px] font-medium text-black hover:bg-zinc-200">Open dashboard →</a>
+      </div>
+    </section>
+  </main>
+</MarketingLayout>

--- a/packages/dashboard/src/pages/index.astro
+++ b/packages/dashboard/src/pages/index.astro
@@ -26,6 +26,11 @@ const store  = createAISDKChatStore(state);
 
 const chatId = await store.createChat();
 await store.saveChat({ chatId, messages });`;
+const features: [string, string, string][] = [
+  ["State", "Any state, typed", "Threads, UI messages, RSC payloads, graph checkpoints — stored as typed v2 state under any key."],
+  ["Adapt", "Drop-in adapters", "First-class stores for AI SDK, TanStack, LangGraph and Cloudflare Agents. Or raw REST."],
+  ["Ops", "Usage & tracing", "Volume, tokens, cost and active projects — tracked per key, with request-level traces."],
+];
 ---
 <MarketingLayout>
   <main>
@@ -72,25 +77,20 @@ await store.saveChat({ chatId, messages });`;
       </div>
     </section>
 
-    <!-- features -->
+    <!-- features: editorial list (not 3-equal cards) -->
     <section class="mx-auto max-w-[1040px] px-5 pb-24">
-      <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
-        <Card class="p-6">
-          <div class="mb-3 font-mono text-[11px] uppercase tracking-wider text-fg-4">State</div>
-          <div class="text-[16px] font-medium text-fg">Any state, typed</div>
-          <p class="mt-2 text-[14px] leading-relaxed text-fg-3">Threads, UI messages, RSC payloads, graph checkpoints — stored as typed v2 state under any key.</p>
-        </Card>
-        <Card class="p-6">
-          <div class="mb-3 font-mono text-[11px] uppercase tracking-wider text-fg-4">Adapt</div>
-          <div class="text-[16px] font-medium text-fg">Drop-in adapters</div>
-          <p class="mt-2 text-[14px] leading-relaxed text-fg-3">First-class stores for AI SDK, TanStack, LangGraph and Cloudflare Agents. Or raw REST.</p>
-        </Card>
-        <Card class="p-6">
-          <div class="mb-3 font-mono text-[11px] uppercase tracking-wider text-fg-4">Ops</div>
-          <div class="text-[16px] font-medium text-fg">Usage &amp; tracing</div>
-          <p class="mt-2 text-[14px] leading-relaxed text-fg-3">Volume, tokens, cost and active projects — tracked per key, with request-level traces.</p>
-        </Card>
-      </div>
+      <div class="mb-6 font-mono text-[11px] uppercase tracking-[0.15em] text-fg-4">What it does</div>
+      <ul class="divide-y divide-edge-soft border-y border-edge-soft">
+        {features.map(([tag, title, desc]) => (
+          <li class="grid grid-cols-1 gap-2 py-7 md:grid-cols-[140px_1fr] md:gap-6">
+            <div class="font-mono text-[11px] uppercase tracking-wider text-fg-4">{tag}</div>
+            <div>
+              <div class="text-[17px] font-medium text-fg">{title}</div>
+              <p class="mt-1.5 max-w-[62ch] text-[14px] leading-relaxed text-fg-3">{desc}</p>
+            </div>
+          </li>
+        ))}
+      </ul>
     </section>
 
     <!-- API -->

--- a/packages/dashboard/src/styles/tokens.css
+++ b/packages/dashboard/src/styles/tokens.css
@@ -1,0 +1,57 @@
+/*
+ * AgentState design tokens — "state console" (dark-first, Geist, restrained).
+ * Centralized so a redesign is a one-file change. Imported by global.css.
+ */
+@import "tailwindcss";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  /* type */
+  --font-sans: "Geist", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "Geist Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+  /* surfaces (dark-first) */
+  --color-base: #09090b; /* app canvas (zinc-950) */
+  --color-panel: #111113; /* cards, table head bg */
+  --color-panel2: #161618; /* hover / elevated */
+  --color-edge: #262629; /* primary borders */
+  --color-edge-soft: #1f1f22; /* subtle borders */
+
+  /* text */
+  --color-fg: #fafafa; /* headings / strong (zinc-50) */
+  --color-fg-2: #d4d4d8; /* body (zinc-300) */
+  --color-fg-3: #a1a1aa; /* muted (zinc-400) */
+  --color-fg-4: #71717a; /* faint (zinc-500) */
+
+  /* accents (restrained: one blue + functional) */
+  --color-accent: #3b82f6; /* primary interactive (blue-500) */
+  --color-accent-fg: #ffffff;
+  --color-pos: #34d399; /* positive / live (emerald-400) */
+  --color-warn: #f59e0b; /* warn / rate-limited (amber-500) */
+  --color-neg: #f87171; /* negative / over-budget (red-400) */
+
+  /* shape */
+  --radius-sm: 6px;
+  --radius: 8px;
+  --radius-lg: 12px;
+}
+
+/* base */
+html {
+  color-scheme: dark;
+}
+html,
+body {
+  background: var(--color-base);
+  color: var(--color-fg-2);
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: "ss01", "cv11";
+}
+::selection {
+  background: color-mix(in srgb, var(--color-accent) 30%, transparent);
+}
+.num {
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
Redesign milestone 1 of N. New plain-Tailwind design system (tokens + logo + Button/Card/Badge primitives, no library) and a fully redesigned static landing in the new dark direction.

Self-contained on the new tokens, so it deploys without breaking the still-Kumo dashboard pages — those migrate next (dashboard shell + pages, then docs).

Verified: astro check 0 errors, build 13 pages, preview clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned marketing landing page with hero section, code preview, adapter showcase, feature highlights, API reference table, and call-to-action buttons
  * Added new UI components including badge, button, and card elements

* **Style**
  * Established centralized design tokens and Tailwind CSS styling system with font and color variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->