### PR TITLE
docs: correct dashboard stack to Astro + Tailwind v4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Conversation history database-as-a-service for AI agents.
 packages/
   api/          Hono API on Cloudflare Workers + D1
   shared/       Shared TypeScript types (public API contract)
-  dashboard/    Next.js + Clerk + shadcn/ui (served as static assets by API Worker)
+  dashboard/    Astro + React islands + Clerk + Tailwind v4 (served as static assets by API Worker)
 docs/           Integration guides
 scripts/        Setup and deployment scripts
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Conversation history database-as-a-service for AI agents.
 packages/
   api/          Hono API on Cloudflare Workers + D1
   shared/       Shared TypeScript types (public API contract)
-  dashboard/    Astro + React islands + Clerk + Cloudflare Kumo (served as static assets by API Worker)
+  dashboard/    Astro + React islands + Clerk + Tailwind v4 (served as static assets by API Worker)
 docs/           Integration guides
 scripts/        Setup and deployment scripts
 ```

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ curl https://agentstate.app/api/v2/conversations/:id \
 - **Database**: Cloudflare D1 (SQLite at edge)
 - **API Framework**: Hono
 - **ORM**: Drizzle ORM
-- **Dashboard**: Next.js + Clerk + shadcn/ui
+- **Dashboard**: Astro + React islands + Clerk + Tailwind v4
 - **Package Manager**: Bun
 - **Linter**: Biome
 - **Tests**: Vitest (276 tests)


### PR DESCRIPTION
Rewires repo docs to the current stack: `Next.js + shadcn`/`Kumo` → `Astro + React islands + Clerk + Tailwind v4` in README, CLAUDE.md, AGENTS.md, agents.md. Served `llms.txt`/`agents.md` (packages/api/src/content) and `docs/` were already accurate — the API itself is unchanged by the dashboard framework swap, so the API docs stand.