### PR TITLE
feat(dashboard): rebuild /conversations in new design system (no Kumo)

### DIFF
--- a/packages/dashboard/src/components/dashboard/conversations/_components.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/_components.tsx
@@ -1,18 +1,18 @@
-// Re-export all conversation components for convenience
+// Re-export conversation components for convenience.
 export type { Conversation } from "./_conversation-row";
 export { ConversationRow } from "./_conversation-row";
 
 export type { _ConversationsTableProps } from "./_conversations-table";
 export { _ConversationsTable } from "./_conversations-table";
+
 export type {
   MessagesPanel as MessagesPanelType,
   RoleBadge as RoleBadgeType,
 } from "./_messages-panel";
 export { MessageRow, MessagesPanel, RoleBadge } from "./_messages-panel";
+
 export type { _EmptyProjectsProps, _ProjectSelectorProps } from "./_project-selectors";
 export { _EmptyProjects, _ProjectSelector } from "./_project-selectors";
+
 export { CONVERSATIONS_EMPTY_STATE, getConversationsColumns } from "./_table-columns";
 export type { Message } from "./_use-messages";
-
-import { DataTableLoadMore } from "@/components/dashboard/data-table";
-export const _LoadMoreButton = DataTableLoadMore;

--- a/packages/dashboard/src/components/dashboard/conversations/_conversation-row.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/_conversation-row.tsx
@@ -1,6 +1,5 @@
 import type { ConversationResponse } from "@agentstate/shared";
-import { Table } from "@cloudflare/kumo";
-import { CaretRightIcon } from "@phosphor-icons/react";
+import { CaretRight } from "@phosphor-icons/react";
 import { useState } from "react";
 import { formatDateShort } from "@/lib/format";
 import { formatCostMicrodollars } from "@/lib/format-cost";
@@ -9,14 +8,18 @@ import { MessagesPanel } from "./_messages-panel";
 
 export type Conversation = ConversationResponse & { project_id: string };
 
+/**
+ * ConversationRow - one clickable table row that expands to reveal the
+ * conversation's messages. Plain <tr>/<td> on top of design tokens.
+ */
 export function ConversationRow({ conv }: { conv: Conversation }) {
   const [open, setOpen] = useState(false);
   const title = conv.title ?? "Untitled";
 
   return (
     <>
-      <Table.Row
-        className="cursor-pointer focus-visible:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+      <tr
+        className="cursor-pointer border-b border-edge-soft transition-colors hover:bg-panel2 focus-visible:bg-panel2 focus-visible:outline-none"
         onClick={() => setOpen((v) => !v)}
         tabIndex={0}
         role="button"
@@ -29,49 +32,55 @@ export function ConversationRow({ conv }: { conv: Conversation }) {
           }
         }}
       >
-        <Table.Cell className="py-3.5">
+        <td className="py-3.5 pr-4">
           <div className="flex items-center gap-2.5">
-            <CaretRightIcon
+            <CaretRight
               className={cn(
-                "size-3.5 shrink-0 text-muted-foreground transition-transform duration-150",
+                "size-3.5 shrink-0 text-fg-4 transition-transform duration-150",
                 open && "rotate-90",
               )}
               aria-hidden="true"
             />
-            <span className="max-w-[200px] truncate text-sm font-medium text-foreground sm:max-w-xs">
+            <span className="max-w-[200px] truncate text-[14px] font-medium text-fg sm:max-w-xs">
               {title}
             </span>
           </div>
-        </Table.Cell>
-        <Table.Cell
+        </td>
+        <td
           suppressHydrationWarning
-          className="hidden font-mono text-xs text-muted-foreground sm:table-cell"
+          className="hidden py-3.5 pr-4 text-right font-mono text-[12px] text-fg-3 num sm:table-cell"
         >
           {conv.message_count.toLocaleString()}
-        </Table.Cell>
-        <Table.Cell
+        </td>
+        <td
           suppressHydrationWarning
-          className="hidden font-mono text-xs text-muted-foreground sm:table-cell"
+          className="hidden py-3.5 pr-4 text-right font-mono text-[12px] text-fg-3 num sm:table-cell"
         >
           {conv.token_count.toLocaleString()}
-        </Table.Cell>
-        <Table.Cell className="hidden font-mono text-xs text-muted-foreground tabular-nums sm:table-cell">
+        </td>
+        <td className="hidden py-3.5 pr-4 text-right font-mono text-[12px] text-fg-3 num sm:table-cell">
           {formatCostMicrodollars(conv.total_cost_microdollars)}
-        </Table.Cell>
-        <Table.Cell className="hidden text-xs text-muted-foreground md:table-cell">
+        </td>
+        <td
+          suppressHydrationWarning
+          className="hidden py-3.5 pr-4 font-mono text-[12px] text-fg-3 num md:table-cell"
+        >
           {formatDateShort(conv.created_at)}
-        </Table.Cell>
-        <Table.Cell className="hidden text-xs text-muted-foreground md:table-cell">
+        </td>
+        <td
+          suppressHydrationWarning
+          className="hidden py-3.5 pr-4 font-mono text-[12px] text-fg-3 num md:table-cell"
+        >
           {formatDateShort(conv.updated_at)}
-        </Table.Cell>
-      </Table.Row>
+        </td>
+      </tr>
 
       {open && (
-        <Table.Row className="bg-muted hover:bg-muted" id={`messages-${conv.id}`}>
-          <Table.Cell colSpan={6} className="bg-muted px-6 py-3">
+        <tr className="bg-panel2" id={`messages-${conv.id}`}>
+          <td colSpan={6} className="border-b border-edge-soft px-6 py-3">
             <MessagesPanel projectId={conv.project_id} conversationId={conv.id} />
-          </Table.Cell>
-        </Table.Row>
+          </td>
+        </tr>
       )}
     </>
   );

--- a/packages/dashboard/src/components/dashboard/conversations/_conversations-table.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/_conversations-table.tsx
@@ -1,6 +1,7 @@
 import type { ProjectResponse } from "@agentstate/shared";
-import { ChatCircleIcon } from "@phosphor-icons/react";
-import { DataTable } from "@/components/dashboard/data-table";
+import { ChatCircle } from "@phosphor-icons/react";
+import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 import { type Conversation, ConversationRow } from "./_conversation-row";
 import { CONVERSATIONS_EMPTY_STATE, getConversationsColumns } from "./_table-columns";
 
@@ -10,23 +11,83 @@ export interface _ConversationsTableProps {
   conversations: Conversation[];
 }
 
+const SKELETON_ROWS = 5;
+
+/**
+ * Conversations table — plain <table> on design tokens. Handles loading
+ * (skeleton rows) and empty state inline; no shared DataTable/Kumo dependency.
+ * Cursor pagination is preserved verbatim by the parent (see conversations-page).
+ */
 export function _ConversationsTable({
   selectedProject,
   loading,
   conversations,
 }: _ConversationsTableProps) {
+  const columns = getConversationsColumns(selectedProject);
+
   return (
-    <DataTable
-      data={conversations}
-      columns={getConversationsColumns(selectedProject)}
-      loading={loading}
-      loadingRows={5}
-      empty={{
-        ...CONVERSATIONS_EMPTY_STATE,
-        icon: <ChatCircleIcon className="h-6 w-6 text-muted-foreground" />,
-      }}
-      rowKey={(conv) => conv.id}
-      renderRow={(conv) => <ConversationRow key={conv.id} conv={conv} />}
-    />
+    <Card className="overflow-hidden p-0">
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-left">
+          <thead>
+            <tr className="border-b border-edge bg-panel">
+              {columns.map((col) => (
+                <th
+                  key={col.key}
+                  className={cn(
+                    "px-4 py-2.5 font-mono text-[10.5px] font-normal uppercase tracking-[0.12em] text-fg-4",
+                    col.className,
+                    col.align === "right" && "text-right",
+                  )}
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {loading &&
+              Array.from({ length: SKELETON_ROWS }).map((_, i) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton rows
+                <tr key={`skeleton-${i}`} className="border-b border-edge-soft">
+                  <td className="py-3.5 pr-4">
+                    <div className="h-3.5 w-40 animate-pulse rounded bg-edge" />
+                  </td>
+                  {[0, 1, 2, 3, 4].map((c) => (
+                    // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton cells
+                    <td key={c} className="hidden py-3.5 pr-4 sm:table-cell">
+                      <div className="ml-auto h-3.5 w-12 animate-pulse rounded bg-edge" />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+
+            {!loading && conversations.length === 0 && (
+              <tr className="border-b border-edge-soft">
+                <td colSpan={columns.length} className="px-4 py-16">
+                  <div className="flex flex-col items-center justify-center gap-3 text-center">
+                    <div className="flex size-12 items-center justify-center rounded-[var(--radius)] border border-edge bg-panel2 text-fg-4">
+                      <ChatCircle className="size-6" aria-hidden />
+                    </div>
+                    <div className="flex max-w-xs flex-col gap-1">
+                      <p className="text-[14px] font-medium text-fg">
+                        {CONVERSATIONS_EMPTY_STATE.title}
+                      </p>
+                      <p className="text-[12.5px] leading-5 text-fg-4">
+                        {CONVERSATIONS_EMPTY_STATE.description}
+                      </p>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            )}
+
+            {!loading &&
+              conversations.length > 0 &&
+              conversations.map((conv) => <ConversationRow key={conv.id} conv={conv} />)}
+          </tbody>
+        </table>
+      </div>
+    </Card>
   );
 }

--- a/packages/dashboard/src/components/dashboard/conversations/_messages-panel.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/_messages-panel.tsx
@@ -1,12 +1,11 @@
-import { Badge } from "@cloudflare/kumo";
 import { useState } from "react";
-import { MessageListSkeleton } from "@/components/dashboard/loading-states";
+import { Badge } from "@/components/ui/badge";
 import { formatDate } from "@/lib/format";
 import { type Message, useMessages } from "./_use-messages";
 
 export function RoleBadge({ role }: { role: string }) {
   return (
-    <Badge variant="secondary" className="font-mono text-[10px] uppercase tracking-wide!">
+    <Badge tone="default" className="uppercase tracking-wide">
       {role}
     </Badge>
   );
@@ -19,18 +18,18 @@ export function MessageRow({ msg }: { msg: Message }) {
   const displayed = expanded || !truncated ? msg.content : `${msg.content.slice(0, limit)}…`;
 
   return (
-    <div className="flex gap-3 border-b border-border/50 py-2.5 last:border-b-0">
+    <div className="flex gap-3 border-b border-edge-soft py-2.5 last:border-b-0">
       <div className="pt-0.5">
         <RoleBadge role={msg.role} />
       </div>
-      <div className="flex-1 min-w-0">
-        <p className="text-xs text-foreground whitespace-pre-wrap break-words leading-relaxed">
+      <div className="min-w-0 flex-1">
+        <p className="whitespace-pre-wrap break-words text-[12.5px] leading-relaxed text-fg-2">
           {displayed}
         </p>
         {truncated && (
           <button
             type="button"
-            className="mt-1 text-[11px] text-muted-foreground hover:text-foreground hover:underline"
+            className="mt-1 text-[11px] text-fg-4 hover:text-fg hover:underline"
             onClick={() => setExpanded((v) => !v)}
             aria-expanded={expanded}
             aria-label={expanded ? "Show less of this message" : "Show more of this message"}
@@ -39,7 +38,7 @@ export function MessageRow({ msg }: { msg: Message }) {
           </button>
         )}
       </div>
-      <span className="shrink-0 pt-0.5 text-[11px] text-muted-foreground">
+      <span className="shrink-0 pt-0.5 font-mono text-[11px] text-fg-4 num">
         {formatDate(msg.created_at)}
       </span>
     </div>
@@ -56,14 +55,20 @@ export function MessagesPanel({ projectId, conversationId }: MessagesPanelProps)
 
   return (
     <section aria-live="polite" aria-busy={loading}>
-      {loading && <MessageListSkeleton lines={3} />}
+      {loading && (
+        <div className="flex flex-col gap-2 py-1">
+          {["60%", "70%", "80%"].map((w) => (
+            <div key={w} className="h-3 animate-pulse rounded bg-edge" style={{ width: w }} />
+          ))}
+        </div>
+      )}
       {error && (
-        <p className="py-2 text-xs text-destructive" role="alert">
+        <p className="py-2 text-[12px] text-neg" role="alert">
           {error}
         </p>
       )}
       {messages !== null && messages.length === 0 && (
-        <p className="text-xs text-muted-foreground py-2">No messages in this conversation.</p>
+        <p className="py-2 text-[12px] text-fg-4">No messages in this conversation.</p>
       )}
       {messages !== null && messages.length > 0 && (
         <div>

--- a/packages/dashboard/src/components/dashboard/conversations/_project-selectors.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/_project-selectors.tsx
@@ -1,7 +1,7 @@
 import type { ProjectResponse } from "@agentstate/shared";
-import { Label, LayerCard, Select } from "@cloudflare/kumo";
-import { ChatCircleIcon } from "@phosphor-icons/react";
-import { EmptyState } from "@/components/dashboard/empty-state";
+import { ChatCircle } from "@phosphor-icons/react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 
 export interface _ProjectSelectorProps {
   projects: ProjectResponse[];
@@ -16,21 +16,27 @@ export function _ProjectSelector({
 }: _ProjectSelectorProps) {
   if (projects.length <= 1) return null;
 
-  const projectItems = Object.fromEntries(projects.map((p) => [p.id, p.name]));
-
   return (
     <div className="flex items-center gap-2.5">
-      <Label htmlFor="project-select" className="shrink-0">
+      <label
+        htmlFor="project-select"
+        className="shrink-0 font-mono text-[10.5px] uppercase tracking-[0.12em] text-fg-4"
+      >
         Project
-      </Label>
-      <Select
+      </label>
+      <select
+        id="project-select"
         aria-label="Select project"
-        size="sm"
-        className="w-[200px] font-mono text-xs"
         value={selectedProjectId}
-        onValueChange={(v) => onSelectProject(v ?? "")}
-        items={projectItems}
-      />
+        onChange={(e) => onSelectProject(e.target.value)}
+        className="h-[36px] w-[200px] rounded-[var(--radius)] border border-edge bg-panel px-3 font-mono text-[12px] text-fg transition-colors hover:bg-panel2 focus-visible:bg-panel2 focus-visible:outline-none"
+      >
+        {projects.map((p) => (
+          <option key={p.id} value={p.id}>
+            {p.name}
+          </option>
+        ))}
+      </select>
     </div>
   );
 }
@@ -41,16 +47,21 @@ export interface _EmptyProjectsProps {
 
 export function _EmptyProjects({ onCreateProject }: _EmptyProjectsProps) {
   return (
-    <LayerCard>
-      <EmptyState
-        icon={<ChatCircleIcon aria-hidden="true" />}
-        title="No projects yet"
-        description="Create a project first, then conversations will appear here."
-        action={{
-          label: "Create your first project",
-          onClick: onCreateProject,
-        }}
-      />
-    </LayerCard>
+    <Card className="flex items-center justify-center">
+      <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+        <div className="flex size-12 items-center justify-center rounded-[var(--radius)] border border-edge bg-panel2 text-fg-4">
+          <ChatCircle className="size-6" aria-hidden />
+        </div>
+        <div className="flex max-w-xs flex-col gap-1">
+          <p className="text-[14px] font-medium text-fg">No projects yet</p>
+          <p className="text-[12.5px] leading-5 text-fg-4">
+            Create a project first, then conversations will appear here.
+          </p>
+        </div>
+        <Button variant="secondary" onClick={onCreateProject}>
+          Create your first project
+        </Button>
+      </div>
+    </Card>
   );
 }

--- a/packages/dashboard/src/components/dashboard/conversations/_table-columns.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/_table-columns.tsx
@@ -1,29 +1,37 @@
 import type { ProjectResponse } from "@agentstate/shared";
-import type { Column } from "@/components/dashboard/data-table";
-import type { Conversation } from "./_conversation-row";
+import type { ReactNode } from "react";
+
+/**
+ * Column header config for the conversations table. The table itself is a
+ * hand-built <table>; this just describes header label + responsive class.
+ */
+export interface ConversationColumn {
+  key: string;
+  label: ReactNode;
+  className?: string;
+  align?: "left" | "right";
+}
 
 export function getConversationsColumns(
   selectedProject: ProjectResponse | undefined,
-): Column<Conversation>[] {
+): ConversationColumn[] {
   return [
     {
       key: "title",
       label: selectedProject ? (
         <span>
           Title
-          <span className="ml-1.5 text-muted-foreground/60 font-normal">
-            — {selectedProject.name}
-          </span>
+          <span className="ml-1.5 font-normal text-fg-4">— {selectedProject.name}</span>
         </span>
       ) : (
         "Title"
       ),
     },
-    { key: "messages", label: "Messages", className: "hidden sm:table-cell" },
-    { key: "tokens", label: "Tokens", className: "hidden sm:table-cell" },
-    { key: "cost", label: "Cost", className: "hidden sm:table-cell" },
-    { key: "created", label: "Created", className: "hidden md:table-cell" },
-    { key: "updated", label: "Updated", className: "hidden md:table-cell" },
+    { key: "messages", label: "Messages", className: "hidden sm:table-cell", align: "right" },
+    { key: "tokens", label: "Tokens", className: "hidden sm:table-cell", align: "right" },
+    { key: "cost", label: "Cost", className: "hidden sm:table-cell", align: "right" },
+    { key: "created", label: "Created", className: "hidden md:table-cell", align: "right" },
+    { key: "updated", label: "Updated", className: "hidden md:table-cell", align: "right" },
   ];
 }
 

--- a/packages/dashboard/src/components/dashboard/conversations/conversations-page.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/conversations-page.tsx
@@ -1,19 +1,31 @@
-import { useRouter } from "next/navigation";
 import { useCallback } from "react";
-import { CardListSkeleton } from "@/components/dashboard/loading-states";
-import { PageHeader } from "@/components/dashboard/page-header";
-import { DashboardShell } from "@/components/dashboard-shell";
-import {
-  _ConversationsTable,
-  _EmptyProjects,
-  _LoadMoreButton,
-  _ProjectSelector,
-} from "./_components";
+import { AppShell } from "@/components/app-shell";
+import { Providers } from "@/components/providers";
+import { Button } from "@/components/ui/button";
+import { _ConversationsTable, _EmptyProjects, _ProjectSelector } from "./_components";
 import { useConversationsData, useConversationsPagination } from "./_hooks";
 
-function ConversationsContent() {
-  const router = useRouter();
+function PageHeader({
+  title,
+  description,
+  actions,
+}: {
+  title: string;
+  description: string;
+  actions?: React.ReactNode;
+}) {
+  return (
+    <header className="mb-[22px] flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <div className="flex max-w-2xl flex-col gap-1.5">
+        <h1 className="text-[26px] tracking-tight text-fg">{title}</h1>
+        <p className="text-[14.5px] leading-6 text-fg-3">{description}</p>
+      </div>
+      {actions && <div className="flex flex-wrap items-center gap-2 sm:justify-end">{actions}</div>}
+    </header>
+  );
+}
 
+function ConversationsContent() {
   const {
     projects,
     selectedProjectId,
@@ -35,11 +47,15 @@ function ConversationsContent() {
   );
 
   const selectedProject = projects.find((p) => p.id === selectedProjectId);
-  const handleCreateProject = useCallback(() => router.push("/dashboard"), [router]);
+  const handleCreateProject = useCallback(() => {
+    window.location.assign("/dashboard");
+  }, []);
   const handleSelectProject = useCallback(
     (id: string) => setSelectedProjectId(id),
     [setSelectedProjectId],
   );
+
+  const showLoadMore = hasMore && conversations.length > 0;
 
   return (
     <div className="px-4 lg:px-6">
@@ -55,7 +71,23 @@ function ConversationsContent() {
         }
       />
 
-      {loadingProjects && <CardListSkeleton count={3} />}
+      {loadingProjects && (
+        <div className="flex flex-col gap-3">
+          {[0, 1, 2].map((i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton cards
+            <div
+              key={i}
+              className="flex items-center gap-4 rounded-[var(--radius-lg)] border border-edge bg-panel p-4"
+            >
+              <div className="size-10 shrink-0 animate-pulse rounded-[var(--radius)] bg-edge" />
+              <div className="flex flex-1 flex-col gap-2">
+                <div className="h-4 w-32 animate-pulse rounded bg-edge" />
+                <div className="h-3 w-24 animate-pulse rounded bg-edge" />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
 
       {!loadingProjects && projects.length === 0 && (
         <_EmptyProjects onCreateProject={handleCreateProject} />
@@ -68,21 +100,29 @@ function ConversationsContent() {
             loading={loadingConversations}
             conversations={conversations}
           />
-          <_LoadMoreButton
-            hasNext={hasMore && conversations.length > 0}
-            loading={isLoadingMore}
-            onLoadMore={loadMore}
-          />
+          {showLoadMore && (
+            <div className="mt-4 flex justify-center">
+              <Button variant="secondary" disabled={isLoadingMore} onClick={loadMore}>
+                {isLoadingMore ? "Loading…" : "Load more"}
+              </Button>
+            </div>
+          )}
         </>
       )}
     </div>
   );
 }
 
+/**
+ * ConversationsPage — client:only island for /dashboard/conversations.
+ * Wraps content in Providers (Clerk) + AppShell (sidebar/topbar + auth gate).
+ */
 export function ConversationsPage() {
   return (
-    <DashboardShell>
-      <ConversationsContent />
-    </DashboardShell>
+    <Providers>
+      <AppShell>
+        <ConversationsContent />
+      </AppShell>
+    </Providers>
   );
 }


### PR DESCRIPTION
## Summary

Rebuilds the `/dashboard/conversations` route on plain Tailwind v4 + design tokens (`tokens.css`), removing every `@cloudflare/kumo` import from the route. Behavior is preserved 1:1 — all data fetching, cursor pagination, message loading, and expand/collapse a11y are untouched.

## Changes

- **`conversations-page.tsx`** — wraps content in `<Providers><AppShell>` (per the new self-contained shell). Inlines `PageHeader`, the loading-card skeleton, and the **Load more** button (`@/components/ui/button`). Drops `next/navigation` `useRouter` (only use was `router.push("/dashboard")` for the empty-projects action → `window.location.assign`). All hooks and pagination wiring unchanged.
- **`_conversations-table.tsx`** — hand-built `<table>` with `border-edge`/`bg-panel` header and inline loading-skeleton rows + empty state. Removes the dependency on the shared (Kumo-backed) `DataTable`.
- **`_conversation-row.tsx`** — plain `<tr>`/`<td>` on tokens. Mono `font-mono` + `num` (tabular-nums) on counts/tokens/cost/timestamps. Expand-to-messages, keyboard activation, `aria-expanded`/`aria-controls`, and `suppressHydrationWarning` preserved exactly.
- **`_messages-panel.tsx`** — `@/components/ui/badge` + tokens; truncate/expand (`Show more`/`Show less`) unchanged.
- **`_project-selectors.tsx`** — native `<select>` + `Card` tokens; drops Kumo `Label`/`Select`/`LayerCard` and the shared `EmptyState`.
- **`_table-columns.tsx`** — simplified column descriptor (drops the shared `Column<T>` type dependency).
- **`_components.tsx`** — drops the `DataTableLoadMore` re-export (Kumo-derived); no longer used by this route.

No cursor/pagination logic was changed. `useSearchParams` is not used, so no `<Suspense>` wrap is required.

## Verification

- `bunx biome check --write` — clean (auto-fixed import ordering).
- `bunx astro check` — **0 errors**, 0 warnings.
- `bunx astro dev --port 4324` → `curl http://localhost:4324/dashboard/conversations/` → **200**.

## Out of scope

The shared `DataTable`, `EmptyState`, `DataTableLoadMore`, and `providers.tsx` still reference `@cloudflare/kumo` — those are used by other not-yet-rebuilt routes and are intentionally left untouched here.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>