### PR TITLE
feat(dashboard): rebuild /analytics in new design system (no Kumo)

### DIFF
--- a/packages/dashboard/src/components/analytics/area-chart.tsx
+++ b/packages/dashboard/src/components/analytics/area-chart.tsx
@@ -1,22 +1,16 @@
 "use client";
 
-import { LayerCard, Select, Text } from "@cloudflare/kumo";
 import type { EChartsType, TooltipComponentFormatterCallbackParams } from "echarts";
 import * as echarts from "echarts";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { Card } from "@/components/ui/card";
 import type { DataPoint } from "./chart-utils";
 import { fillDateGaps } from "./chart-utils";
-
-function cssVar(name: string, fallback: string): string {
-  if (typeof window === "undefined") return fallback;
-  const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-  return v || fallback;
-}
 
 interface AreaChartCardProps {
   title: string;
   data: DataPoint[];
-  /** CSS color value for the stroke/fill. Defaults to a Kumo-friendly blue. */
+  /** CSS color value for the stroke/fill. Defaults to accent blue. */
   color?: string;
   valueLabel?: string;
   formatValue?: (value: number) => string;
@@ -35,14 +29,15 @@ const TIME_RANGE_ITEMS = {
 type TimeRangeKey = keyof typeof TIME_RANGE_ITEMS;
 
 /**
- * Time-series area chart rendered with echarts (Kumo has no Chart component;
- * echarts is a peer dep). Preserves the prior recharts behavior: date-gap
+ * Time-series area chart rendered with echarts (the design-system primitives have
+ * no Chart component; echarts is a peer dep). Preserves the prior behavior: date-gap
  * filling, 7d/30d/90d filtering, gradient area, and a value total in the header.
+ * Recolored to the AgentState token palette.
  */
 export function AreaChartCard({
   title,
   data,
-  color = "#1a80e6",
+  color = "#3b82f6",
   valueLabel = "value",
   formatValue,
   showTimeRange = false,
@@ -76,9 +71,10 @@ export function AreaChartCard({
       grid: { left: 8, right: 8, top: 8, bottom: 0, containLabel: true },
       tooltip: {
         trigger: "axis",
-        backgroundColor: cssVar("--popover", "rgba(17,17,23,0.92)"),
-        borderWidth: 0,
-        textStyle: { color: cssVar("--popover-foreground", "#fff"), fontSize: 12 },
+        backgroundColor: "rgba(9,9,11,0.92)",
+        borderWidth: 1,
+        borderColor: "#262629",
+        textStyle: { color: "#fafafa", fontSize: 12 },
         formatter: (params: TooltipComponentFormatterCallbackParams) => {
           const p = Array.isArray(params) ? params[0] : params;
           if (!p) return "";
@@ -103,7 +99,7 @@ export function AreaChartCard({
         axisLine: { show: false },
         axisTick: { show: false },
         axisLabel: {
-          color: cssVar("--muted-foreground", "#71717a"),
+          color: "#a1a1aa",
           fontSize: 11,
           margin: 8,
           hideOverlap: true,
@@ -113,9 +109,9 @@ export function AreaChartCard({
       },
       yAxis: {
         type: "value",
-        splitLine: { lineStyle: { color: cssVar("--border", "rgba(255,255,255,0.08)") } },
+        splitLine: { lineStyle: { color: "rgba(255,255,255,0.08)" } },
         axisLabel: {
-          color: cssVar("--muted-foreground", "#71717a"),
+          color: "#a1a1aa",
           fontSize: 11,
           hideOverlap: true,
         },
@@ -154,36 +150,30 @@ export function AreaChartCard({
   }, []);
 
   return (
-    <LayerCard className="flex flex-col gap-4 p-5">
+    <Card className="flex flex-col gap-4 p-5">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="flex flex-col gap-1">
-          <Text variant="secondary" as="p">
-            {title}
-          </Text>
-          <Text variant="heading2" as="p">
-            {totalLabel}
-          </Text>
-          {description && (
-            <Text variant="secondary" as="p" size="sm">
-              {description}
-            </Text>
-          )}
+          <p className="font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4">{title}</p>
+          <p className="num text-[26px] font-semibold text-fg">{totalLabel}</p>
+          {description && <p className="text-[12px] text-fg-3">{description}</p>}
         </div>
         {showTimeRange && (
-          <Select
+          <select
             aria-label="Select time range"
-            size="sm"
-            className="w-[150px]"
             value={timeRange}
-            onValueChange={(v) => {
-              if (v) setTimeRange(v as TimeRangeKey);
-            }}
-            items={TIME_RANGE_ITEMS}
-          />
+            onChange={(e) => setTimeRange(e.target.value as TimeRangeKey)}
+            className="min-h-[34px] w-[150px] rounded-[var(--radius)] border border-edge bg-panel px-2.5 text-[12px] text-fg outline-none transition-colors hover:bg-panel2 focus-visible:border-accent"
+          >
+            {(Object.keys(TIME_RANGE_ITEMS) as TimeRangeKey[]).map((k) => (
+              <option key={k} value={k}>
+                {TIME_RANGE_ITEMS[k]}
+              </option>
+            ))}
+          </select>
         )}
       </div>
       <div ref={chartRef} className="h-[250px] w-full" />
-    </LayerCard>
+    </Card>
   );
 }
 

--- a/packages/dashboard/src/components/analytics/recent-activity.tsx
+++ b/packages/dashboard/src/components/analytics/recent-activity.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { LayerCard, Table } from "@cloudflare/kumo";
 import { ChatCircleIcon } from "@phosphor-icons/react";
-import { EmptyState } from "@/components/dashboard/empty-state";
+import { Card } from "@/components/ui/card";
 import { timeAgo } from "@/lib/format";
 
 interface RecentConversation {
@@ -20,44 +19,56 @@ interface RecentActivityProps {
 export function RecentActivity({ conversations }: RecentActivityProps) {
   if (conversations.length === 0) {
     return (
-      <LayerCard>
-        <EmptyState
-          icon={<ChatCircleIcon aria-hidden="true" />}
-          title="No recent conversations"
-          description="Conversation activity will appear here after your project receives messages."
-        />
-      </LayerCard>
+      <Card className="flex flex-col items-center justify-center gap-3 p-6 text-center">
+        <div className="flex size-10 items-center justify-center rounded-[var(--radius)] border border-edge bg-panel2 text-fg-4">
+          <ChatCircleIcon className="size-5" aria-hidden="true" />
+        </div>
+        <div className="flex flex-col gap-1">
+          <p className="text-[13px] font-medium text-fg">No recent conversations</p>
+          <p className="text-[12px] text-fg-3">
+            Conversation activity will appear here after your project receives messages.
+          </p>
+        </div>
+      </Card>
     );
   }
 
   return (
-    <LayerCard className="overflow-hidden p-0">
-      <Table>
-        <Table.Header>
-          <Table.Row>
-            <Table.Head>Title</Table.Head>
-            <Table.Head className="hidden sm:table-cell">Messages</Table.Head>
-            <Table.Head className="hidden sm:table-cell">Tokens</Table.Head>
-            <Table.Head className="text-right">Updated</Table.Head>
-          </Table.Row>
-        </Table.Header>
-        <Table.Body>
+    <Card className="overflow-hidden p-0">
+      <table className="w-full border-collapse text-[13px]">
+        <thead>
+          <tr className="border-b border-edge bg-panel2/50">
+            <th className="px-4 py-2.5 text-left font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4">
+              Title
+            </th>
+            <th className="hidden px-4 py-2.5 text-left font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4 sm:table-cell">
+              Messages
+            </th>
+            <th className="hidden px-4 py-2.5 text-left font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4 sm:table-cell">
+              Tokens
+            </th>
+            <th className="px-4 py-2.5 text-right font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4">
+              Updated
+            </th>
+          </tr>
+        </thead>
+        <tbody>
           {conversations.map((conv) => (
-            <Table.Row key={conv.id}>
-              <Table.Cell className="max-w-[200px] truncate">{conv.title || "Untitled"}</Table.Cell>
-              <Table.Cell className="hidden tabular-nums text-muted-foreground sm:table-cell">
+            <tr key={conv.id} className="border-b border-edge-soft last:border-0">
+              <td className="max-w-[200px] truncate px-4 py-2.5 text-fg">
+                {conv.title || "Untitled"}
+              </td>
+              <td className="num hidden px-4 py-2.5 text-fg-3 sm:table-cell">
                 {conv.message_count}
-              </Table.Cell>
-              <Table.Cell className="hidden tabular-nums text-muted-foreground sm:table-cell">
+              </td>
+              <td className="num hidden px-4 py-2.5 text-fg-3 sm:table-cell">
                 {conv.token_count.toLocaleString()}
-              </Table.Cell>
-              <Table.Cell className="text-right text-muted-foreground">
-                {timeAgo(conv.updated_at)}
-              </Table.Cell>
-            </Table.Row>
+              </td>
+              <td className="num px-4 py-2.5 text-right text-fg-3">{timeAgo(conv.updated_at)}</td>
+            </tr>
           ))}
-        </Table.Body>
-      </Table>
-    </LayerCard>
+        </tbody>
+      </table>
+    </Card>
   );
 }

--- a/packages/dashboard/src/components/analytics/summary-cards.tsx
+++ b/packages/dashboard/src/components/analytics/summary-cards.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Badge, LayerCard, Text } from "@cloudflare/kumo";
 import type { Icon } from "@phosphor-icons/react";
 import {
   ChartLineUpIcon,
@@ -10,6 +9,8 @@ import {
   KeyIcon,
   PulseIcon,
 } from "@phosphor-icons/react";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
 import { formatCostMicrodollars } from "@/lib/format-cost";
 
 interface SummaryCardsProps {
@@ -82,35 +83,33 @@ export function SummaryCards({
       {stats.map((s) => {
         const IconComp = s.icon;
         return (
-          <LayerCard key={s.label} className="flex flex-col gap-4 p-5">
+          <Card key={s.label} className="flex flex-col gap-4 p-5">
             <div className="flex items-start justify-between gap-2">
-              <div className="flex flex-col gap-1">
-                <Text variant="secondary" as="p">
+              <div className="flex flex-col gap-1.5">
+                <p className="font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4">
                   {s.label}
-                </Text>
-                <Text variant="heading2" as="p">
-                  {s.value}
-                </Text>
+                </p>
+                <p className="num text-[26px] font-semibold text-fg">{s.value}</p>
               </div>
-              <Badge variant="neutral">
+              <Badge tone="default">
                 <IconComp size={12} aria-hidden="true" />
                 {s.trend}
               </Badge>
             </div>
             <div className="flex flex-col gap-1">
-              <div className="flex items-center gap-2 text-sm font-medium">
+              <div className="flex items-center gap-2 text-[13px] font-medium text-fg-2">
                 <span className="line-clamp-1">{s.footer}</span>
                 <ChartLineUpIcon size={16} aria-hidden="true" />
               </div>
-              <Text variant="secondary" as="p" size="sm">
+              <p className="text-[12px] text-fg-3">
                 {s.trend === "growing"
                   ? "Growing steadily"
                   : s.trend === "spend"
                     ? "Cost tracking"
                     : `${s.trend} count`}
-              </Text>
+              </p>
             </div>
-          </LayerCard>
+          </Card>
         );
       })}
     </div>

--- a/packages/dashboard/src/components/analytics/time-range-select.tsx
+++ b/packages/dashboard/src/components/analytics/time-range-select.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { cn } from "@/lib/utils";
-
 const RANGES = [
   { label: "7d", value: "7d" },
   { label: "30d", value: "30d" },
@@ -17,7 +15,7 @@ interface TimeRangeSelectProps {
 
 export function TimeRangeSelect({ value, onChange }: TimeRangeSelectProps) {
   return (
-    <fieldset className="flex overflow-hidden rounded-lg border border-border">
+    <fieldset className="flex overflow-hidden rounded-[var(--radius)] border border-edge">
       <legend className="sr-only">Select time range</legend>
       {RANGES.map((r) => (
         <button
@@ -25,12 +23,11 @@ export function TimeRangeSelect({ value, onChange }: TimeRangeSelectProps) {
           type="button"
           aria-pressed={value === r.value}
           onClick={() => onChange(r.value)}
-          className={cn(
-            "px-3 py-[7px] font-mono text-xs transition-colors",
+          className={`min-h-[34px] px-3 font-mono text-[12px] transition-colors ${
             value === r.value
-              ? "bg-foreground text-background"
-              : "bg-card text-muted-foreground hover:text-foreground",
-          )}
+              ? "bg-fg text-base"
+              : "bg-panel text-fg-3 hover:bg-panel2 hover:text-fg"
+          }`}
         >
           {r.label}
         </button>

--- a/packages/dashboard/src/components/dashboard/analytics/_analytics-content.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_analytics-content.tsx
@@ -1,5 +1,4 @@
 import type { AnalyticsResponse } from "@agentstate/shared";
-import { Text } from "@cloudflare/kumo";
 import { AreaChartCard } from "@/components/analytics/area-chart";
 import { RecentActivity } from "@/components/analytics/recent-activity";
 import { SummaryCards } from "@/components/analytics/summary-cards";
@@ -33,13 +32,13 @@ export function AnalyticsContent({ data }: AnalyticsContentProps) {
         <AreaChartCard
           title="Conversations"
           data={data.conversations_per_day.map((d) => ({ date: d.date, value: d.count }))}
-          color="var(--chart-1)"
+          color="#3b82f6"
           valueLabel="Conversations"
         />
         <AreaChartCard
           title="Messages"
           data={data.messages_per_day.map((d) => ({ date: d.date, value: d.count }))}
-          color="var(--chart-2)"
+          color="#34d399"
           valueLabel="Messages"
         />
       </div>
@@ -48,7 +47,7 @@ export function AnalyticsContent({ data }: AnalyticsContentProps) {
       <AreaChartCard
         title="Token usage"
         data={data.tokens_per_day.map((d) => ({ date: d.date, value: d.total }))}
-        color="var(--chart-3)"
+        color="#f59e0b"
         valueLabel="Tokens"
         showTimeRange
       />
@@ -60,7 +59,7 @@ export function AnalyticsContent({ data }: AnalyticsContentProps) {
             date: d.date,
             value: d.total_cost_microdollars / 1_000_000,
           }))}
-          color="var(--chart-4)"
+          color="#f87171"
           valueLabel="Cost ($)"
           formatValue={(v) => formatCostMicrodollars(v * 1_000_000)}
           showTimeRange
@@ -79,15 +78,11 @@ export function AnalyticsContent({ data }: AnalyticsContentProps) {
 
       <div className="grid gap-4 lg:grid-cols-2">
         <div className="flex flex-col gap-3">
-          <Text variant="heading3" as="h3">
-            Recent activity
-          </Text>
+          <h3 className="text-[14px] font-medium text-fg">Recent activity</h3>
           <RecentActivity conversations={data.recent_conversations} />
         </div>
         <div className="flex flex-col gap-3">
-          <Text variant="heading3" as="h3">
-            Top conversations
-          </Text>
+          <h3 className="text-[14px] font-medium text-fg">Top conversations</h3>
           <TopConversations conversations={data.recent_conversations} />
         </div>
       </div>

--- a/packages/dashboard/src/components/dashboard/analytics/_analytics-empty.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_analytics-empty.tsx
@@ -1,24 +1,25 @@
-import { Button, LayerCard, Text } from "@cloudflare/kumo";
 import { ChartLineIcon } from "@phosphor-icons/react";
 import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 
 export function AnalyticsEmpty() {
   const router = useRouter();
 
   return (
-    <LayerCard className="flex flex-col items-center justify-center p-12 text-center">
-      <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-muted/60">
-        <ChartLineIcon className="h-6 w-6 text-muted-foreground" aria-hidden="true" />
+    <Card className="flex flex-col items-center justify-center gap-4 p-12 text-center">
+      <div className="flex size-12 items-center justify-center rounded-full border border-edge bg-panel2">
+        <ChartLineIcon className="size-5 text-fg-3" aria-hidden="true" />
       </div>
-      <Text variant="heading3" as="h3">
-        No projects yet
-      </Text>
-      <Text variant="secondary" as="p" size="sm">
-        Create a project to start tracking conversations, messages, and token usage.
-      </Text>
-      <Button size="sm" variant="outline" onClick={() => router.push("/dashboard")}>
+      <div className="flex flex-col gap-1">
+        <h3 className="text-[15px] font-medium text-fg">No projects yet</h3>
+        <p className="text-[13px] text-fg-3">
+          Create a project to start tracking conversations, messages, and token usage.
+        </p>
+      </div>
+      <Button variant="primary" onClick={() => router.push("/dashboard")}>
         Create your first project
       </Button>
-    </LayerCard>
+    </Card>
   );
 }

--- a/packages/dashboard/src/components/dashboard/analytics/_analytics-header.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_analytics-header.tsx
@@ -1,5 +1,4 @@
 import type { ProjectResponse } from "@agentstate/shared";
-import { Select } from "@cloudflare/kumo";
 import { type TimeRange, TimeRangeSelect } from "@/components/analytics/time-range-select";
 import { PageHeader } from "@/components/dashboard/page-header";
 
@@ -18,8 +17,6 @@ export function AnalyticsHeader({
   range,
   onRangeChange,
 }: AnalyticsHeaderProps) {
-  const projectItems = Object.fromEntries(projects.map((p) => [p.id, p.name]));
-
   return (
     <PageHeader
       title="Analytics"
@@ -27,17 +24,18 @@ export function AnalyticsHeader({
       actions={
         <>
           {projects.length > 1 && (
-            <Select
+            <select
               aria-label="Select project"
-              className="w-[180px]"
               value={selectedProjectId}
-              onValueChange={(value) => {
-                if (value) {
-                  onProjectChange(value);
-                }
-              }}
-              items={projectItems}
-            />
+              onChange={(e) => onProjectChange(e.target.value)}
+              className="min-h-[40px] w-[180px] rounded-[var(--radius)] border border-edge bg-panel px-3 text-[13px] text-fg outline-none transition-colors hover:bg-panel2 focus-visible:border-accent"
+            >
+              {projects.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
           )}
           <TimeRangeSelect value={range} onChange={onRangeChange} />
         </>

--- a/packages/dashboard/src/components/dashboard/analytics/_analytics-loading.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_analytics-loading.tsx
@@ -1,4 +1,3 @@
-import { Loader } from "@cloudflare/kumo";
 import { ChartCardSkeleton, StatsCardsSkeleton } from "@/components/dashboard/loading-states";
 
 interface AnalyticsLoadingProps {
@@ -8,8 +7,11 @@ interface AnalyticsLoadingProps {
 export function AnalyticsLoading({ hasData }: AnalyticsLoadingProps) {
   if (hasData) {
     return (
-      <div className="flex items-center gap-2 text-xs text-muted-foreground">
-        <Loader size="sm" aria-hidden="true" />
+      <div className="flex items-center gap-2 text-[12px] text-fg-3">
+        <span
+          className="size-3.5 animate-spin rounded-full border-2 border-edge border-t-fg-3"
+          aria-hidden="true"
+        />
         <span>Refreshing...</span>
       </div>
     );

--- a/packages/dashboard/src/components/dashboard/analytics/_empty-card.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_empty-card.tsx
@@ -1,6 +1,5 @@
-import { LayerCard } from "@cloudflare/kumo";
 import type { Icon } from "@phosphor-icons/react";
-import { cn } from "@/lib/utils";
+import { Card } from "@/components/ui/card";
 
 interface EmptyCardProps {
   icon: Icon;
@@ -10,11 +9,11 @@ interface EmptyCardProps {
 
 export function EmptyCard({ icon: Icon, message, minHeight = "min-h-[140px]" }: EmptyCardProps) {
   return (
-    <LayerCard
-      className={cn("flex flex-col items-center justify-center p-6 text-center", minHeight)}
+    <Card
+      className={`flex h-full flex-col items-center justify-center p-6 text-center ${minHeight}`}
     >
-      <Icon className="h-6 w-6 text-muted-foreground mb-2" />
-      <p className="text-sm text-muted-foreground">{message}</p>
-    </LayerCard>
+      <Icon className="mb-2 size-5 text-fg-4" aria-hidden="true" />
+      <p className="text-[13px] text-fg-3">{message}</p>
+    </Card>
   );
 }

--- a/packages/dashboard/src/components/dashboard/analytics/_metric-card.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_metric-card.tsx
@@ -1,6 +1,5 @@
-import { LayerCard, Text } from "@cloudflare/kumo";
 import type { Icon } from "@phosphor-icons/react";
-import { cn } from "@/lib/utils";
+import { Card } from "@/components/ui/card";
 
 interface MetricCardProps {
   title: string;
@@ -20,33 +19,31 @@ export function MetricCard({
   unit,
   footnote,
   icon: Icon,
-  iconBg = "bg-primary/10",
-  iconColor = "text-primary",
+  iconBg = "bg-accent/10",
+  iconColor = "text-accent",
 }: MetricCardProps) {
   return (
-    <LayerCard className="flex flex-col gap-4 p-5">
+    <Card className="flex h-full flex-col gap-4 p-5">
       <div className="flex items-start justify-between gap-2">
         <div className="flex flex-col gap-1">
-          <Text variant="heading3" as="h3">
-            {title}
-          </Text>
-          <Text variant="secondary" as="p">
-            {subtitle}
-          </Text>
+          <h3 className="text-[14px] font-medium text-fg">{title}</h3>
+          <p className="font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4">{subtitle}</p>
         </div>
-        <div className={cn("flex size-8 items-center justify-center rounded-lg", iconBg)}>
+        <div
+          className={`flex size-8 items-center justify-center rounded-[var(--radius)] ${iconBg}`}
+        >
           <Icon className={iconColor} aria-hidden="true" />
         </div>
       </div>
       <div className="flex flex-col gap-2">
         <div className="flex items-baseline gap-2">
-          <span className="text-3xl font-semibold tabular-nums">
+          <span className="num text-[28px] font-semibold text-fg">
             {typeof value === "number" ? value.toLocaleString() : value}
           </span>
-          <span className="text-sm text-muted-foreground">{unit}</span>
+          <span className="text-[13px] text-fg-3">{unit}</span>
         </div>
-        {footnote && <p className="text-xs text-muted-foreground">{footnote}</p>}
+        {footnote && <p className="text-[12px] text-fg-3">{footnote}</p>}
       </div>
-    </LayerCard>
+    </Card>
   );
 }

--- a/packages/dashboard/src/components/dashboard/analytics/_peak-usage.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_peak-usage.tsx
@@ -31,7 +31,7 @@ export function PeakUsage({ messagesPerDay }: PeakUsageProps) {
       footnote={
         <>
           Average: {average.toLocaleString()}/day
-          <span className="ml-2 text-rose-500">(+{aboveAverage}% above avg)</span>
+          <span className="ml-2 text-neg">(+{aboveAverage}% above avg)</span>
         </>
       }
       icon={ChartLineUpIcon}

--- a/packages/dashboard/src/components/dashboard/analytics/_token-trend-summary.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_token-trend-summary.tsx
@@ -1,6 +1,5 @@
 import { ArrowDownIcon, ArrowUpIcon, HashIcon } from "@phosphor-icons/react";
 
-import { cn } from "@/lib/utils";
 import { EmptyCard } from "./_empty-card";
 import { MetricCard } from "./_metric-card";
 
@@ -39,15 +38,15 @@ export function TokenTrendSummary({ tokensPerDay }: TokenTrendSummaryProps) {
       footnote={
         <>
           Was {earlierAvg.toLocaleString()}/day
-          <span className={cn("ml-2", isUp ? "text-emerald-600" : "text-rose-500")}>
+          <span className={`ml-2 ${isUp ? "text-pos" : "text-neg"}`}>
             ({isUp ? "+" : ""}
             {change}%)
           </span>
         </>
       }
       icon={isUp ? ArrowUpIcon : ArrowDownIcon}
-      iconBg={isUp ? "bg-emerald-500/10" : "bg-rose-500/10"}
-      iconColor={isUp ? "text-emerald-600" : "text-rose-500"}
+      iconBg={isUp ? "bg-pos/10" : "bg-neg/10"}
+      iconColor={isUp ? "text-pos" : "text-neg"}
     />
   );
 }

--- a/packages/dashboard/src/components/dashboard/analytics/_top-conversations.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_top-conversations.tsx
@@ -1,6 +1,5 @@
-import { LayerCard, Text } from "@cloudflare/kumo";
 import { ChatCircleIcon } from "@phosphor-icons/react";
-import { EmptyState } from "@/components/dashboard/empty-state";
+import { Card } from "@/components/ui/card";
 
 interface ConversationData {
   id: string;
@@ -22,39 +21,41 @@ export function TopConversations({ conversations, limit = 5 }: TopConversationsP
 
   if (sorted.length === 0) {
     return (
-      <LayerCard className="h-full min-h-[200px]">
-        <EmptyState
-          icon={<ChatCircleIcon aria-hidden="true" />}
-          title="No conversations yet"
-          description="Top conversations will appear after messages are stored."
-        />
-      </LayerCard>
+      <Card className="flex h-full min-h-[200px] flex-col items-center justify-center gap-3 p-6 text-center">
+        <div className="flex size-10 items-center justify-center rounded-[var(--radius)] border border-edge bg-panel2 text-fg-4">
+          <ChatCircleIcon className="size-5" aria-hidden="true" />
+        </div>
+        <div className="flex flex-col gap-1">
+          <p className="text-[13px] font-medium text-fg">No conversations yet</p>
+          <p className="text-[12px] text-fg-3">
+            Top conversations will appear after messages are stored.
+          </p>
+        </div>
+      </Card>
     );
   }
 
   return (
-    <LayerCard className="h-full p-5">
+    <Card className="h-full p-5">
       <div className="flex flex-col gap-1">
-        <Text variant="heading3" as="h3">
-          Top Conversations
-        </Text>
-        <Text variant="secondary" as="p">
+        <h3 className="text-[14px] font-medium text-fg">Top Conversations</h3>
+        <p className="font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4">
           By message count
-        </Text>
+        </p>
       </div>
       <div className="mt-4 flex flex-col gap-3">
         {sorted.map((conv, index) => (
           <div key={conv.id} className="flex items-center gap-3">
-            <span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-muted text-xs font-medium tabular-nums">
+            <span className="num flex size-6 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-panel2 text-[11px] font-medium text-fg-2">
               {index + 1}
             </span>
             <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium truncate">{conv.title || "Untitled"}</p>
-              <p className="text-xs text-muted-foreground">{conv.message_count} messages</p>
+              <p className="truncate text-[13px] font-medium text-fg">{conv.title || "Untitled"}</p>
+              <p className="num text-[11px] text-fg-3">{conv.message_count} messages</p>
             </div>
           </div>
         ))}
       </div>
-    </LayerCard>
+    </Card>
   );
 }

--- a/packages/dashboard/src/components/dashboard/analytics/analytics-page.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/analytics-page.tsx
@@ -1,17 +1,20 @@
-import { DashboardShell } from "@/components/dashboard-shell";
+import { AppShell } from "@/components/app-shell";
+import { Providers } from "@/components/providers";
 import { AnalyticsPageContent } from "./analytics-page-content";
 
 /**
  * Astro client:only island for /dashboard/analytics.
  *
- * Wraps the ported Next.js page body in <DashboardShell> (Clerk Providers +
- * auth gate + sidebar/header). The page uses local state only — no
+ * Mounts the analytics body in the new design system shell (Clerk Providers +
+ * AppShell auth gate + sidebar/header). The page uses local state only — no
  * useSearchParams — so no <Suspense> boundary is required.
  */
 export function AnalyticsPage() {
   return (
-    <DashboardShell>
-      <AnalyticsPageContent />
-    </DashboardShell>
+    <Providers>
+      <AppShell>
+        <AnalyticsPageContent />
+      </AppShell>
+    </Providers>
   );
 }


### PR DESCRIPTION
Rebuilds the `/dashboard/analytics` route on the new design system (plain Tailwind + AgentState tokens), dropping every `@cloudflare/kumo` import. Behavior is 1:1 — only presentation changes.

## Changes

**Shell mount** — the Astro island now wraps content in `<Providers><AppShell>` (same pattern as the migrated `/integrate` route) instead of `<DashboardShell>`.

**Rebuilt components** (all Kumo removed):
- `_metric-card.tsx`, `_empty-card.tsx` — `Card` primitive + token colors
- `_analytics-empty.tsx` — `Card` + `Button`; router.push kept
- `_analytics-loading.tsx` — inline spinner (was Kumo `Loader`)
- `_analytics-header.tsx` — native `<select>` for project picker (was Kumo `Select`); `PageHeader` retained
- `_analytics-content.tsx` — plain heading elements (was Kumo `Text`)
- `_top-conversations.tsx` — `Card` + mono ranked list
- `_peak-usage.tsx`, `_token-trend-summary.tsx` — recolored emerald/rose → `pos`/`neg` tokens

**Shared analytics components** (only used by this route):
- `area-chart.tsx` — `Card` container; echarts option logic unchanged but recolored to the token palette (accent `#3b82f6`, pos `#34d399`, warn `#f59e0b`, neg `#f87171`; gridlines `rgba(255,255,255,.08)`; axis text fg-3); native `<select>` for the time-range filter
- `summary-cards.tsx` — `Card` + `Badge`; mono labels with `num` (tabular-nums) metrics
- `recent-activity.tsx` — `Card` + plain `<table>` with `border-edge`, mono numbers
- `time-range-select.tsx` — restyled with tokens (`bg-fg text-base` active, panel/panel2 idle)

## Data logic unchanged
All `@/lib/api`, hooks, fetch effects, `formatCostMicrodollars`, `timeAgo`, and chart data-shaping (`fillDateGaps`) are preserved exactly.

## Verification
- `bunx astro check` — 0 errors
- `bunx astro dev --port 4323` → `curl /dashboard/analytics/` returns **200**

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>