### PR TITLE
feat(dashboard): rebuild /domains in new design system (no Kumo)

### DIFF
--- a/packages/dashboard/src/components/dashboard/domains/_components/add-domain-form.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_components/add-domain-form.tsx
@@ -1,7 +1,6 @@
-import { Button } from "@cloudflare/kumo/components/button";
-import { Input } from "@cloudflare/kumo/components/input";
-import { LayerCard } from "@cloudflare/kumo/components/layer-card";
 import { XIcon } from "@phosphor-icons/react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 
 export interface AddDomainFormProps {
   value: string;
@@ -21,35 +20,43 @@ export function _AddDomainForm({
   const isSubmitDisabled = !value.trim() || adding;
 
   return (
-    <LayerCard className="mb-6 flex flex-col gap-4 border border-border p-6">
-      <Input
-        id="domain-input"
-        label="Domain name"
-        placeholder="e.g. app.example.com"
-        value={value}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" && !isSubmitDisabled) {
-            onSubmit();
-          }
-        }}
-        description="Enter your domain without the protocol (https://) or path."
-        autoFocus
-      />
+    <Card className="flex flex-col gap-4 p-5">
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="domain-input" className="text-[13px] font-medium text-fg-2">
+          Domain name
+        </label>
+        <input
+          id="domain-input"
+          type="text"
+          placeholder="e.g. app.example.com"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !isSubmitDisabled) {
+              onSubmit();
+            }
+          }}
+          // biome-ignore lint/a11y/noAutofocus: intentional — focuses the domain field when the add form opens (matches prior behavior)
+          autoFocus
+          className="min-h-[40px] rounded-[var(--radius)] border border-edge bg-panel2 px-3 py-2 font-mono text-[13px] text-fg outline-none transition-[border-color] placeholder:text-fg-4 focus:border-accent"
+        />
+        <p className="text-[12px] leading-5 text-fg-4">
+          Enter your domain without the protocol (https://) or path.
+        </p>
+      </div>
       <div className="flex gap-2">
-        <Button variant="primary" onClick={onSubmit} disabled={isSubmitDisabled} loading={adding}>
+        <Button variant="primary" onClick={onSubmit} disabled={isSubmitDisabled}>
           {adding ? "Adding..." : "Add"}
         </Button>
         <Button
           variant="ghost"
-          shape="square"
-          size="sm"
           onClick={onCancel}
           aria-label="Cancel adding domain"
+          className="min-h-[40px]"
         >
-          <XIcon aria-hidden="true" />
+          <XIcon size={16} aria-hidden="true" />
         </Button>
       </div>
-    </LayerCard>
+    </Card>
   );
 }

--- a/packages/dashboard/src/components/dashboard/domains/_components/domains-empty-state.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_components/domains-empty-state.tsx
@@ -1,6 +1,6 @@
-import { LayerCard } from "@cloudflare/kumo/components/layer-card";
 import { GlobeIcon } from "@phosphor-icons/react";
-import { EmptyState } from "@/components/dashboard/empty-state";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 
 export interface DomainsEmptyStateProps {
   onAddDomain: () => void;
@@ -8,13 +8,21 @@ export interface DomainsEmptyStateProps {
 
 export function _DomainsEmptyState({ onAddDomain }: DomainsEmptyStateProps) {
   return (
-    <LayerCard className="border border-border">
-      <EmptyState
-        icon={<GlobeIcon aria-hidden="true" />}
-        title="No custom domains"
-        description="Add a custom domain to serve your project from your own domain with SSL."
-        action={{ label: "Add your first domain", onClick: onAddDomain }}
-      />
-    </LayerCard>
+    <Card>
+      <div className="flex flex-col items-center justify-center gap-3 px-6 py-16 text-center">
+        <div className="flex size-11 items-center justify-center rounded-[var(--radius)] border border-edge bg-panel2 text-fg-3">
+          <GlobeIcon size={20} aria-hidden="true" />
+        </div>
+        <div className="flex max-w-xs flex-col gap-1">
+          <p className="text-[13px] font-medium text-fg">No custom domains</p>
+          <p className="text-[12px] leading-5 text-fg-4">
+            Add a custom domain to serve your project from your own domain with SSL.
+          </p>
+        </div>
+        <Button variant="secondary" onClick={onAddDomain} className="min-h-[36px]">
+          Add your first domain
+        </Button>
+      </div>
+    </Card>
   );
 }

--- a/packages/dashboard/src/components/dashboard/domains/_domain-card-actions.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_domain-card-actions.tsx
@@ -1,5 +1,5 @@
-import { Button } from "@cloudflare/kumo/components/button";
 import { TrashIcon } from "@phosphor-icons/react";
+import { Button } from "@/components/ui/button";
 
 interface DomainCardActionsProps {
   verified: boolean;
@@ -20,31 +20,28 @@ export function _DomainCardActions({
     <div className="flex items-center gap-2">
       {!verified && (
         <Button
-          size="sm"
-          variant="outline"
+          variant="secondary"
           onClick={(e) => {
             e.stopPropagation();
             onVerify();
           }}
           disabled={isCheckingVerification}
-          loading={isCheckingVerification}
           aria-label={`Verify ${domain}`}
+          className="min-h-[32px] px-3 py-1.5 text-[12px]"
         >
           {isCheckingVerification ? "Checking..." : "Verify"}
         </Button>
       )}
       <Button
-        shape="square"
-        size="sm"
         variant="ghost"
-        className="text-kumo-danger"
         aria-label={`Delete ${domain}`}
         onClick={(e) => {
           e.stopPropagation();
           onDelete();
         }}
+        className="min-h-[32px] px-2.5 text-neg hover:bg-neg/10 hover:text-neg"
       >
-        <TrashIcon aria-hidden="true" />
+        <TrashIcon size={15} aria-hidden="true" />
       </Button>
     </div>
   );

--- a/packages/dashboard/src/components/dashboard/domains/_domain-card-expanded.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_domain-card-expanded.tsx
@@ -20,7 +20,7 @@ export function _DomainCardExpanded({
   const verified = isVerified(domain.verification_status);
 
   return (
-    <div className="border-border border-t p-4">
+    <div className="border-edge-soft border-t p-4">
       {verified ? (
         <_DomainVerifiedAlert sslEnabled={domain.ssl_enabled} />
       ) : (

--- a/packages/dashboard/src/components/dashboard/domains/_domain-card-status-badge.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_domain-card-status-badge.tsx
@@ -1,16 +1,20 @@
 import type { CustomDomainResponse } from "@agentstate/shared";
-import { Badge } from "@cloudflare/kumo/components/badge";
+import { Badge } from "@/components/ui/badge";
 
-const STATUS_VARIANTS = {
-  verified: "success" as const,
-  failed: "error" as const,
-  pending: "neutral" as const,
-} satisfies Record<CustomDomainResponse["verification_status"], "success" | "error" | "neutral">;
+const STATUS_TONES = {
+  verified: "live" as const,
+  failed: "warn" as const,
+  pending: "idle" as const,
+} satisfies Record<CustomDomainResponse["verification_status"], "live" | "warn" | "idle">;
 
 interface DomainStatusBadgeProps {
   status: CustomDomainResponse["verification_status"];
 }
 
 export function _DomainStatusBadge({ status }: DomainStatusBadgeProps) {
-  return <Badge variant={STATUS_VARIANTS[status]}>{status}</Badge>;
+  return (
+    <Badge tone={STATUS_TONES[status]} dot>
+      {status}
+    </Badge>
+  );
 }

--- a/packages/dashboard/src/components/dashboard/domains/_domain-card-unverified-alert.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_domain-card-unverified-alert.tsx
@@ -1,7 +1,6 @@
 import type { CustomDomainResponse } from "@agentstate/shared";
-import { Banner } from "@cloudflare/kumo/components/banner";
-import { Button } from "@cloudflare/kumo/components/button";
 import { WarningCircleIcon } from "@phosphor-icons/react";
+import { Button } from "@/components/ui/button";
 import { _VerificationMethod } from "./_verification-method";
 
 interface DomainUnverifiedAlertProps {
@@ -60,24 +59,31 @@ export function _DomainUnverifiedAlert({
 
   return (
     <>
-      <Banner
-        variant="default"
-        icon={<WarningCircleIcon aria-hidden="true" weight="fill" />}
-        title="Verify your domain"
-        description={`Choose one of the following methods to verify ownership of ${domain.domain}. Verification may take a few minutes to propagate after making changes.`}
-      />
-      <div className="flex flex-col gap-4">
+      <div className="flex items-start gap-2.5 rounded-[var(--radius)] border border-warn/40 bg-warn/10 px-3 py-2.5">
+        <WarningCircleIcon
+          className="mt-0.5 size-4 shrink-0 text-warn"
+          aria-hidden="true"
+          weight="fill"
+        />
+        <div className="flex flex-col gap-0.5">
+          <span className="text-[13px] font-medium text-fg">Verify your domain</span>
+          <span className="text-[12px] leading-5 text-fg-3">
+            Choose one of the following methods to verify ownership of {domain.domain}. Verification
+            may take a few minutes to propagate after making changes.
+          </span>
+        </div>
+      </div>
+      <div className="flex flex-col gap-3">
         {verificationMethods.map((method) => (
           <_VerificationMethod key={method.title} {...method} />
         ))}
       </div>
       <Button
-        size="sm"
         variant="primary"
         onClick={onVerify}
         disabled={isCheckingVerification}
-        loading={isCheckingVerification}
         aria-label={`Check verification status for ${domain.domain}`}
+        className="self-start"
       >
         {isCheckingVerification ? "Checking..." : "Check Verification"}
       </Button>

--- a/packages/dashboard/src/components/dashboard/domains/_domain-card-verified-alert.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_domain-card-verified-alert.tsx
@@ -1,4 +1,3 @@
-import { Banner } from "@cloudflare/kumo/components/banner";
 import { CheckCircleIcon } from "@phosphor-icons/react";
 
 interface DomainVerifiedAlertProps {
@@ -7,13 +6,19 @@ interface DomainVerifiedAlertProps {
 
 export function _DomainVerifiedAlert({ sslEnabled }: DomainVerifiedAlertProps) {
   return (
-    <Banner
-      variant="secondary"
-      icon={<CheckCircleIcon aria-hidden="true" weight="fill" />}
-      title="Domain verified"
-      description={`Your domain is verified and ready to use. SSL is ${
-        sslEnabled ? "enabled" : "being provisioned"
-      }.`}
-    />
+    <div className="flex items-start gap-2.5 rounded-[var(--radius)] border border-pos/40 bg-pos/10 px-3 py-2.5">
+      <CheckCircleIcon
+        className="mt-0.5 size-4 shrink-0 text-pos"
+        aria-hidden="true"
+        weight="fill"
+      />
+      <div className="flex flex-col gap-0.5">
+        <span className="text-[13px] font-medium text-fg">Domain verified</span>
+        <span className="text-[12px] leading-5 text-fg-3">
+          Your domain is verified and ready to use. SSL is{" "}
+          {sslEnabled ? "enabled" : "being provisioned"}.
+        </span>
+      </div>
+    </div>
   );
 }

--- a/packages/dashboard/src/components/dashboard/domains/_domain-card.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_domain-card.tsx
@@ -1,6 +1,6 @@
 import type { CustomDomainResponse } from "@agentstate/shared";
-import { LayerCard } from "@cloudflare/kumo/components/layer-card";
 import { CaretDownIcon, CaretRightIcon, GlobeIcon } from "@phosphor-icons/react";
+import { Card } from "@/components/ui/card";
 import { _DomainCardActions } from "./_domain-card-actions";
 import { _DomainCardExpanded } from "./_domain-card-expanded";
 import { _DomainStatusBadge } from "./_domain-card-status-badge";
@@ -35,16 +35,16 @@ function _DomainCardHeader({
     <div className="flex w-full items-center justify-between gap-2 px-4 py-3">
       <button
         type="button"
-        className="flex min-w-0 flex-1 items-center gap-3 rounded-md text-left transition-colors hover:opacity-80"
+        className="flex min-w-0 flex-1 items-center gap-3 rounded-[var(--radius)] text-left transition-[background-color] hover:bg-panel2"
         onClick={onToggle}
         aria-expanded={isExpanded}
         aria-label={`Toggle details for ${domain}`}
       >
-        <ChevronIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-        <span className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border bg-muted text-muted-foreground">
+        <ChevronIcon className="size-4 shrink-0 text-fg-4" aria-hidden="true" />
+        <span className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius)] border border-edge bg-panel2 text-fg-3">
           <GlobeIcon className="size-4" aria-hidden="true" />
         </span>
-        <span className="truncate text-sm font-semibold text-foreground">{domain}</span>
+        <span className="truncate font-mono text-[13.5px] font-medium text-fg">{domain}</span>
         <_DomainStatusBadge status={verificationStatus} />
       </button>
       <_DomainCardActions
@@ -76,7 +76,7 @@ export function _DomainCard({
   isCheckingVerification,
 }: DomainCardProps) {
   return (
-    <LayerCard>
+    <Card>
       <_DomainCardHeader
         domain={domain.domain}
         verificationStatus={domain.verification_status}
@@ -93,6 +93,6 @@ export function _DomainCard({
           onVerify={() => onVerify(domain.id, domain.domain)}
         />
       )}
-    </LayerCard>
+    </Card>
   );
 }

--- a/packages/dashboard/src/components/dashboard/domains/_verification-method.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_verification-method.tsx
@@ -8,10 +8,10 @@ interface VerificationMethodProps {
 
 export function _VerificationMethod({ title, description, records }: VerificationMethodProps) {
   return (
-    <div className="flex flex-col gap-3 rounded-lg border border-border bg-kumo-base p-4 shadow-sm">
+    <div className="flex flex-col gap-3 rounded-[var(--radius)] border border-edge-soft bg-panel2 p-4">
       <div className="flex flex-col gap-1">
-        <h4 className="font-medium">{title}</h4>
-        <p className="text-sm text-muted-foreground">{description}</p>
+        <h4 className="text-[13px] font-medium text-fg">{title}</h4>
+        <p className="text-[12px] leading-5 text-fg-3">{description}</p>
       </div>
       <div className="flex flex-col gap-2">
         {records.map((record) => (

--- a/packages/dashboard/src/components/dashboard/domains/_verification-record.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/_verification-record.tsx
@@ -1,4 +1,5 @@
-import { ClipboardText } from "@cloudflare/kumo/components/clipboard-text";
+import { ClipboardIcon } from "@phosphor-icons/react";
+import { useCopiedText } from "@/lib/hooks/use-copied-text";
 
 interface VerificationRecordProps {
   label: string;
@@ -7,10 +8,28 @@ interface VerificationRecordProps {
 }
 
 export function VerificationRecord({ label, value, copy }: VerificationRecordProps) {
+  const { copied, copy: copyText } = useCopiedText();
+
   return (
     <div className="flex items-center gap-2">
-      <span className="w-16 shrink-0 text-sm text-muted-foreground">{label}:</span>
-      <ClipboardText className="flex-1" size="sm" text={value} textToCopy={copy} />
+      <span className="w-16 shrink-0 font-mono text-[11px] uppercase tracking-wide text-fg-4">
+        {label}
+      </span>
+      <div className="flex min-w-0 flex-1 items-center gap-1.5 rounded-[var(--radius)] border border-edge bg-base px-2.5 py-1.5">
+        <code className="flex-1 truncate font-mono text-[12px] text-fg-2">{value}</code>
+        <button
+          type="button"
+          onClick={() => copyText(copy)}
+          aria-label={copied ? "Copied to clipboard" : "Copy to clipboard"}
+          className="shrink-0 text-fg-4 transition-[color] hover:text-fg"
+        >
+          {copied ? (
+            <span className="text-[11px] text-pos">Copied</span>
+          ) : (
+            <ClipboardIcon size={14} aria-hidden="true" />
+          )}
+        </button>
+      </div>
     </div>
   );
 }

--- a/packages/dashboard/src/components/dashboard/domains/domains-content.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/domains-content.tsx
@@ -1,7 +1,6 @@
-import { Button } from "@cloudflare/kumo/components/button";
 import { PlusIcon } from "@phosphor-icons/react";
 import { Suspense, useState } from "react";
-import { PageHeader } from "@/components/dashboard/page-header";
+import { Button } from "@/components/ui/button";
 import {
   _AddDomainForm,
   _DomainsEmptyState,
@@ -12,7 +11,7 @@ import { useDomains } from "./_use-domains";
 import { useProjectId } from "./_use-project-id";
 
 // ---------------------------------------------------------------------------
-// Domains Content (old page.tsx body)
+// Domains Content (new design system — plain Tailwind + tokens, no Kumo)
 // ---------------------------------------------------------------------------
 
 export function DomainsContent() {
@@ -38,22 +37,26 @@ export function DomainsContent() {
   }
 
   return (
-    <Suspense fallback={<div className="h-32 animate-pulse rounded-lg bg-muted" />}>
-      <div className="flex flex-col px-4 lg:px-6">
-        <PageHeader
-          title="Custom Domains"
-          description="Add a custom domain to serve your project from your own domain with SSL."
-          actions={
-            <Button
-              size="sm"
-              variant="outline"
-              icon={<PlusIcon aria-hidden="true" />}
-              onClick={() => setShowAddForm(!showAddForm)}
-            >
-              Add Domain
-            </Button>
-          }
-        />
+    <Suspense
+      fallback={<div className="h-32 animate-pulse rounded-[var(--radius-lg)] bg-panel2" />}
+    >
+      <div className="flex flex-col gap-6 px-5 py-7 sm:px-7">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex max-w-2xl flex-col gap-1.5">
+            <h1 className="text-[24px] font-semibold tracking-tight text-fg">Custom Domains</h1>
+            <p className="text-[13.5px] leading-6 text-fg-3">
+              Add a custom domain to serve your project from your own domain with SSL.
+            </p>
+          </div>
+          <Button
+            variant="secondary"
+            onClick={() => setShowAddForm(!showAddForm)}
+            className="min-h-[36px] py-2"
+          >
+            <PlusIcon size={15} aria-hidden="true" />
+            Add Domain
+          </Button>
+        </header>
 
         {showAddForm && (
           <_AddDomainForm

--- a/packages/dashboard/src/components/dashboard/domains/domains-page.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/domains-page.tsx
@@ -1,14 +1,17 @@
-import { DashboardShell } from "@/components/dashboard-shell";
+import { AppShell } from "@/components/app-shell";
+import { Providers } from "@/components/providers";
 import { DomainsContent } from "./domains-content";
 
 // ---------------------------------------------------------------------------
-// Page (wraps content in DashboardShell)
+// Page (wraps content in Providers + AppShell — new design system, no Kumo)
 // ---------------------------------------------------------------------------
 
 export function DomainsPage() {
   return (
-    <DashboardShell>
-      <DomainsContent />
-    </DashboardShell>
+    <Providers>
+      <AppShell>
+        <DomainsContent />
+      </AppShell>
+    </Providers>
   );
 }


### PR DESCRIPTION
## Summary

Rebuilds the `/dashboard/domains` route on plain Tailwind + the new design tokens, dropping **every** `@cloudflare/kumo` import. Behavior is 1:1 with the prior Kumo implementation.

## Changes

- **`domains-page.tsx`** — wraps content in `Providers` + `AppShell` (new shell) instead of the Kumo-backed `DashboardShell`.
- **`domains-content.tsx`** — local header + `Button` primitive (token classes), dropping the shared Kumo `PageHeader`/`Button`.
- **`add-domain-form.tsx`** — `Card` + plain `<input>` (`border-edge bg-panel2 focus:border-accent`) + `Button`.
- **`_domain-card.tsx`** — `Card` rows with `border-edge` + `font-mono` domain names.
- **`_domain-card-status-badge.tsx`** — token `Badge` tones (`live`/`warn`/`idle`) with status dot.
- **`_domain-card-unverified-alert.tsx` / `_domain-card-verified-alert.tsx`** — token-styled alert panels replacing `Banner`.
- **`_verification-method.tsx` / `_verification-record.tsx`** — restyled with tokens; self-contained copy control (reuses `useCopiedText`) replacing `ClipboardText`.
- **`_components/domains-empty-state.tsx`** — `Card` + `Button` replacing the Kumo-dependent shared `EmptyState`.

## Preserved (unchanged)

- All action hooks (`_use-domain-actions`, `_use-domains`, `_use-domains-list`, `_use-expanded-domains`, `_use-project-id`)
- Validation (`isValidDomain`)
- Domains service (`_domains-service.ts`)
- Verification methods logic and record data

## Verification

- `bunx biome check --write src/components/dashboard/domains/` — clean
- `bunx astro check` — **0 errors**, 0 warnings (177 hints, all pre-existing deprecation notices)
- `curl http://localhost:4325/dashboard/domains/` → **200**

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>