### PR TITLE
feat(dashboard): rebuild /settings/organizations in new design system (no Kumo)

### DIFF
--- a/packages/dashboard/src/components/dashboard/organizations/create/_create-org-form.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/_create-org-form.tsx
@@ -1,11 +1,14 @@
-import { Button } from "@cloudflare/kumo/components/button";
-import { Input } from "@cloudflare/kumo/components/input";
-import { LayerCard } from "@cloudflare/kumo/components/layer-card";
-import { Text } from "@cloudflare/kumo/components/text";
 import { useRouter } from "next/navigation";
 import type * as React from "react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import { DomainWarning } from "./_domain-warning";
 import { useCreateOrganization } from "./_use-create-organization";
+
+const inputClass =
+  "h-9 w-full rounded-[var(--radius)] border border-edge bg-panel px-3 text-[13.5px] text-fg placeholder:text-fg-4 outline-none transition-colors focus:border-accent/60 disabled:opacity-50";
+
+const labelClass = "font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4";
 
 interface CreateOrgFormProps {
   organizationName: string;
@@ -48,20 +51,21 @@ export function CreateOrgForm({
 
   return (
     <form onSubmit={handleSubmit}>
-      <LayerCard className="flex max-w-xl flex-col gap-6 p-6">
+      <Card className="flex max-w-xl flex-col gap-6 p-6">
         <div className="flex flex-col gap-2">
-          <Text variant="heading3" as="h2">
-            Organization Details
-          </Text>
-          <Text variant="secondary" as="p">
+          <h2 className="text-[16px] font-semibold text-fg">Organization Details</h2>
+          <p className="text-[13.5px] leading-6 text-fg-3">
             Enter a name for your organization. You can invite members after creation.
-          </Text>
+          </p>
         </div>
         <div className="flex flex-col gap-2">
-          <Input
+          <label htmlFor="name" className={labelClass}>
+            Organization Name
+          </label>
+          <input
             id="name"
             type="text"
-            label="Organization Name"
+            className={inputClass}
             value={organizationName}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
               setOrganizationName(e.currentTarget.value)
@@ -82,20 +86,19 @@ export function CreateOrgForm({
             type="submit"
             variant="primary"
             disabled={!organizationName.trim() || isSubmitting}
-            loading={isSubmitting}
           >
             {isSubmitting ? "Creating..." : "Create Organization"}
           </Button>
           <Button
             type="button"
-            variant="outline"
+            variant="secondary"
             onClick={() => router.push("/dashboard/settings/organizations")}
             disabled={isSubmitting}
           >
             Cancel
           </Button>
         </div>
-      </LayerCard>
+      </Card>
     </form>
   );
 }

--- a/packages/dashboard/src/components/dashboard/organizations/create/_create-org-header.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/_create-org-header.tsx
@@ -1,20 +1,19 @@
-import { Button } from "@cloudflare/kumo/components/button";
 import { ArrowLeftIcon } from "@phosphor-icons/react";
 import Link from "next/link";
 
 export function CreateOrgHeader() {
   return (
-    <header className="flex items-center gap-3 border-border border-b pb-5">
-      <Link href="/dashboard/settings/organizations">
-        <Button variant="ghost" shape="square" size="sm" aria-label="Back to organizations">
-          <ArrowLeftIcon aria-hidden="true" />
-        </Button>
+    <header className="flex items-center gap-3 border-b border-edge-soft pb-5">
+      <Link
+        href="/dashboard/settings/organizations"
+        aria-label="Back to organizations"
+        className="grid size-8 place-items-center rounded-[var(--radius)] text-fg-3 transition-colors hover:bg-panel2 hover:text-fg"
+      >
+        <ArrowLeftIcon className="size-4" aria-hidden="true" />
       </Link>
       <div className="flex flex-col gap-1">
-        <h1 className="text-[26px] tracking-tight text-foreground">Create Organization</h1>
-        <p className="text-[14.5px] leading-6 text-muted-foreground">
-          Set up a new organization for your team
-        </p>
+        <h1 className="text-[26px] tracking-tight text-fg">Create Organization</h1>
+        <p className="text-[14.5px] leading-6 text-fg-3">Set up a new organization for your team</p>
       </div>
     </header>
   );

--- a/packages/dashboard/src/components/dashboard/organizations/create/_create-org-loading.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/_create-org-loading.tsx
@@ -1,29 +1,29 @@
-import { Button } from "@cloudflare/kumo/components/button";
-import { Surface } from "@cloudflare/kumo/components/surface";
 import { ArrowLeftIcon } from "@phosphor-icons/react";
-import Link from "next/link";
-import { FormSkeleton, PageHeaderSkeleton } from "@/components/dashboard/loading-states";
+import { Card } from "@/components/ui/card";
 
 export function CreateOrgLoading() {
   return (
-    <div className="flex flex-col gap-6">
-      <div className="flex items-center gap-4">
-        <Link href="/dashboard/settings/organizations">
-          <Button
-            variant="ghost"
-            shape="square"
-            size="sm"
-            disabled
-            aria-label="Back to organizations"
-          >
-            <ArrowLeftIcon aria-hidden="true" />
-          </Button>
-        </Link>
-        <PageHeaderSkeleton />
+    <div className="flex flex-col gap-6 px-4 py-7 lg:px-6">
+      <div className="flex items-center gap-3 border-b border-edge-soft pb-5">
+        <span className="grid size-8 place-items-center rounded-[var(--radius)] text-fg-4">
+          <ArrowLeftIcon className="size-4" aria-hidden="true" />
+        </span>
+        <div className="flex flex-col gap-1.5">
+          <div className="h-5 w-44 animate-pulse rounded bg-panel2" />
+          <div className="h-3.5 w-60 animate-pulse rounded bg-panel2" />
+        </div>
       </div>
-      <Surface className="flex max-w-xl flex-col gap-6 p-6">
-        <FormSkeleton fields={1} />
-      </Surface>
+      <Card className="flex max-w-xl flex-col gap-6 p-6">
+        <div className="flex flex-col gap-2">
+          <div className="h-4 w-40 animate-pulse rounded bg-panel2" />
+          <div className="h-3.5 w-72 animate-pulse rounded bg-panel2" />
+        </div>
+        <div className="h-9 w-full animate-pulse rounded-[var(--radius)] border border-edge bg-panel2" />
+        <div className="flex gap-2">
+          <div className="h-9 w-40 animate-pulse rounded-[var(--radius)] bg-panel2" />
+          <div className="h-9 w-20 animate-pulse rounded-[var(--radius)] bg-panel2" />
+        </div>
+      </Card>
     </div>
   );
 }

--- a/packages/dashboard/src/components/dashboard/organizations/create/_domain-warning.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/_domain-warning.tsx
@@ -1,4 +1,3 @@
-import { Banner } from "@cloudflare/kumo/components/banner";
 import { WarningIcon } from "@phosphor-icons/react";
 
 interface DomainWarningProps {
@@ -8,12 +7,12 @@ interface DomainWarningProps {
 
 export function DomainWarning({ existingOrgName, existingOrgDomain }: DomainWarningProps) {
   return (
-    <Banner
-      variant="alert"
-      icon={<WarningIcon aria-hidden="true" weight="fill" />}
-      description={`An organization ${existingOrgName ?? "Unknown"} already exists for the domain ${
-        existingOrgDomain ?? "unknown"
-      }.`}
-    />
+    <div className="flex items-start gap-2.5 rounded-[var(--radius)] border border-warn/40 bg-warn/10 px-3 py-2.5 text-[13px] text-warn">
+      <WarningIcon className="mt-0.5 size-4 shrink-0" aria-hidden="true" weight="fill" />
+      <p>
+        An organization <span className="font-medium">{existingOrgName ?? "Unknown"}</span> already
+        exists for the domain <span className="font-mono">{existingOrgDomain ?? "unknown"}</span>.
+      </p>
+    </div>
   );
 }

--- a/packages/dashboard/src/components/dashboard/organizations/create/create-org-page.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/create-org-page.tsx
@@ -1,10 +1,13 @@
-import { DashboardShell } from "@/components/dashboard-shell";
+import { AppShell } from "@/components/app-shell";
+import { Providers } from "@/components/providers";
 import { CreateOrgContent } from "./create-org-content";
 
 export function CreateOrgPage() {
   return (
-    <DashboardShell>
-      <CreateOrgContent />
-    </DashboardShell>
+    <Providers>
+      <AppShell>
+        <CreateOrgContent />
+      </AppShell>
+    </Providers>
   );
 }

--- a/packages/dashboard/src/components/dashboard/organizations/list/organizations-list-content.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/list/organizations-list-content.tsx
@@ -1,17 +1,22 @@
 import { useOrganization, useUser } from "@clerk/react";
-import { Badge } from "@cloudflare/kumo/components/badge";
-import { Button } from "@cloudflare/kumo/components/button";
-import { LayerCard } from "@cloudflare/kumo/components/layer-card";
 import { BuildingsIcon, CaretRightIcon, PlusIcon } from "@phosphor-icons/react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { EmptyState } from "@/components/dashboard/empty-state";
-import { CardListSkeleton } from "@/components/dashboard/loading-states";
-import { PageHeader } from "@/components/dashboard/page-header";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import { useOrganizationsList } from "@/hooks/_use-organizations-list";
 
 function OrgListSkeleton() {
-  return <CardListSkeleton count={3} />;
+  return (
+    <div className="flex flex-col gap-3">
+      {[0, 1, 2].map((i) => (
+        <Card key={i} className="h-[72px] animate-pulse">
+          <div className="h-full w-full" />
+        </Card>
+      ))}
+    </div>
+  );
 }
 
 export function OrganizationsListContent() {
@@ -22,8 +27,8 @@ export function OrganizationsListContent() {
 
   if (!isUserLoaded || !isOrgListLoaded) {
     return (
-      <div className="flex flex-col gap-6 px-4 lg:px-6">
-        <PageHeader title="Organizations" description="Manage your organizations and members" />
+      <div className="flex flex-col gap-6 px-4 py-7 lg:px-6">
+        <Header />
         <OrgListSkeleton />
       </div>
     );
@@ -34,10 +39,8 @@ export function OrganizationsListContent() {
   }
 
   return (
-    <div className="flex flex-col gap-6 px-4 lg:px-6">
-      <PageHeader
-        title="Organizations"
-        description="Manage your organizations and members"
+    <div className="flex flex-col gap-6 px-4 py-7 lg:px-6">
+      <Header
         actions={
           <Link href="/dashboard/settings/organizations/create">
             <Button variant="primary">
@@ -49,50 +52,72 @@ export function OrganizationsListContent() {
       />
 
       {organizations.length === 0 ? (
-        <LayerCard className="border border-border">
-          <EmptyState
-            icon={<BuildingsIcon aria-hidden="true" />}
-            title="No organizations"
-            description="You don't belong to any organizations yet. Create one to get started."
-            action={{
-              label: "Create your first organization",
-              onClick: () => {
-                router.push("/dashboard/settings/organizations/create");
-              },
-            }}
-          />
-        </LayerCard>
+        <Card className="flex flex-col items-center gap-3 px-6 py-14 text-center">
+          <span className="grid size-10 place-items-center rounded-[var(--radius)] border border-edge bg-panel2 text-fg-3">
+            <BuildingsIcon className="size-5" aria-hidden="true" />
+          </span>
+          <div className="flex flex-col gap-1">
+            <p className="text-[15px] font-medium text-fg">No organizations</p>
+            <p className="text-[13.5px] text-fg-3">
+              You don&rsquo;t belong to any organizations yet. Create one to get started.
+            </p>
+          </div>
+          <Button
+            variant="secondary"
+            className="mt-1"
+            onClick={() => router.push("/dashboard/settings/organizations/create")}
+          >
+            Create your first organization
+          </Button>
+        </Card>
       ) : (
         <div className="flex flex-col gap-3">
-          {organizations.map((org) => (
-            <LayerCard key={org.id} className="p-4">
-              <div className="flex items-center gap-4">
-                <div className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-border bg-muted text-muted-foreground">
-                  <BuildingsIcon className="size-5" aria-hidden="true" />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <h3 className="truncate font-semibold text-foreground">{org.name}</h3>
-                    {activeOrg?.id === org.id && <Badge variant="primary">Active</Badge>}
+          {organizations.map((org) => {
+            const isActive = activeOrg?.id === org.id;
+            return (
+              <Card key={org.id} className="px-4 py-3.5">
+                <div className="flex items-center gap-4">
+                  <span className="grid size-10 shrink-0 place-items-center rounded-[var(--radius)] border border-edge bg-panel2 text-fg-3">
+                    <BuildingsIcon className="size-5" aria-hidden="true" />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <h3 className="truncate text-[14.5px] font-semibold text-fg">{org.name}</h3>
+                      {isActive && (
+                        <Badge tone="live" dot>
+                          Active
+                        </Badge>
+                      )}
+                    </div>
+                    <p className="num truncate font-mono text-[12.5px] text-fg-3">
+                      Created {new Date(org.createdAt).toLocaleDateString()}
+                    </p>
                   </div>
-                  <p className="text-sm text-muted-foreground">
-                    Created {new Date(org.createdAt).toLocaleDateString()}
-                  </p>
-                </div>
-                <Link href={`/dashboard/settings/organizations/members?org=${org.id}`}>
-                  <Button
-                    variant="ghost"
-                    shape="square"
+                  <Link
+                    href={`/dashboard/settings/organizations/members?org=${org.id}`}
                     aria-label={`View members for ${org.name}`}
+                    className="grid size-8 shrink-0 place-items-center rounded-[var(--radius)] text-fg-3 transition-colors hover:bg-panel2 hover:text-fg"
                   >
-                    <CaretRightIcon aria-hidden="true" />
-                  </Button>
-                </Link>
-              </div>
-            </LayerCard>
-          ))}
+                    <CaretRightIcon className="size-4" aria-hidden="true" weight="bold" />
+                  </Link>
+                </div>
+              </Card>
+            );
+          })}
         </div>
       )}
     </div>
+  );
+}
+
+function Header({ actions }: { actions?: React.ReactNode }) {
+  return (
+    <header className="flex items-end justify-between gap-4 border-b border-edge-soft pb-5">
+      <div className="flex flex-col gap-1">
+        <h1 className="text-[26px] tracking-tight text-fg">Organizations</h1>
+        <p className="text-[14.5px] leading-6 text-fg-3">Manage your organizations and members</p>
+      </div>
+      {actions}
+    </header>
   );
 }

--- a/packages/dashboard/src/components/dashboard/organizations/list/organizations-list-page.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/list/organizations-list-page.tsx
@@ -1,10 +1,13 @@
-import { DashboardShell } from "@/components/dashboard-shell";
+import { AppShell } from "@/components/app-shell";
+import { Providers } from "@/components/providers";
 import { OrganizationsListContent } from "./organizations-list-content";
 
 export function OrganizationsListPage() {
   return (
-    <DashboardShell>
-      <OrganizationsListContent />
-    </DashboardShell>
+    <Providers>
+      <AppShell>
+        <OrganizationsListContent />
+      </AppShell>
+    </Providers>
   );
 }

--- a/packages/dashboard/src/components/dashboard/organizations/members/_avatar-icon.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_avatar-icon.tsx
@@ -8,8 +8,8 @@ export function AvatarIcon({ icon }: AvatarIconProps) {
   const Icon: Icon = icon === "user" ? UserIcon : EnvelopeIcon;
 
   return (
-    <div className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border bg-muted text-muted-foreground">
+    <span className="grid size-8 shrink-0 place-items-center rounded-[var(--radius)] border border-edge bg-panel2 text-fg-3">
       <Icon className="size-4" aria-hidden="true" />
-    </div>
+    </span>
   );
 }

--- a/packages/dashboard/src/components/dashboard/organizations/members/_invite-member-form.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_invite-member-form.tsx
@@ -1,10 +1,7 @@
-import { Button } from "@cloudflare/kumo/components/button";
-import { Input } from "@cloudflare/kumo/components/input";
-import { LayerCard } from "@cloudflare/kumo/components/layer-card";
-import { Select } from "@cloudflare/kumo/components/select";
-import { Text } from "@cloudflare/kumo/components/text";
 import { PlusIcon } from "@phosphor-icons/react";
 import * as React from "react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 
 export type Role = "org:member" | "org:admin";
 
@@ -13,10 +10,10 @@ export interface InviteMemberFormProps {
   readonly onInvite: (email: string, role: Role) => Promise<void>;
 }
 
-const ROLE_ITEMS: Array<{ label: string; value: Role }> = [
-  { label: "Member", value: "org:member" },
-  { label: "Admin", value: "org:admin" },
-];
+const inputClass =
+  "h-9 w-full rounded-[var(--radius)] border border-edge bg-panel px-3 text-[13.5px] text-fg placeholder:text-fg-4 outline-none transition-colors focus:border-accent/60 disabled:opacity-50";
+
+const labelClass = "font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4";
 
 export function InviteMemberForm({ isInviting, onInvite }: InviteMemberFormProps) {
   const [emailAddress, setEmailAddress] = React.useState("");
@@ -35,39 +32,48 @@ export function InviteMemberForm({ isInviting, onInvite }: InviteMemberFormProps
   );
 
   return (
-    <LayerCard className="flex flex-col gap-4 p-6">
+    <Card className="flex flex-col gap-4 p-6">
       <div className="flex flex-col gap-2">
-        <Text variant="heading3" as="h2">
-          Invite Member
-        </Text>
-        <Text variant="secondary" as="p">
+        <h2 className="text-[16px] font-semibold text-fg">Invite Member</h2>
+        <p className="text-[13.5px] leading-6 text-fg-3">
           Send an invitation to join this organization
-        </Text>
+        </p>
       </div>
-      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
-        <Input
-          id="email"
-          type="email"
-          label="Email address"
-          placeholder="colleague@example.com"
-          value={emailAddress}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            setEmailAddress(e.currentTarget.value)
-          }
-          disabled={isInviting}
-          required
-        />
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
-          <Select<Role>
-            className="w-full sm:w-[180px]"
-            aria-label="Role"
-            label="Role"
-            value={selectedRole}
-            onValueChange={(v) => setSelectedRole((v ?? "org:member") as Role)}
-            items={ROLE_ITEMS}
+      <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+        <div className="flex flex-col gap-2">
+          <label htmlFor="email" className={labelClass}>
+            Email address
+          </label>
+          <input
+            id="email"
+            type="email"
+            className={inputClass}
+            placeholder="colleague@example.com"
+            value={emailAddress}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setEmailAddress(e.currentTarget.value)
+            }
             disabled={isInviting}
+            required
           />
-          <Button type="submit" variant="primary" disabled={isInviting} loading={isInviting}>
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+          <div className="flex w-full flex-col gap-2 sm:w-[180px]">
+            <label htmlFor="role" className={labelClass}>
+              Role
+            </label>
+            <select
+              id="role"
+              className={inputClass}
+              value={selectedRole}
+              onChange={(e) => setSelectedRole(e.currentTarget.value as Role)}
+              disabled={isInviting}
+            >
+              <option value="org:member">Member</option>
+              <option value="org:admin">Admin</option>
+            </select>
+          </div>
+          <Button type="submit" variant="primary" disabled={isInviting} className="sm:mb-px">
             {isInviting ? (
               "Sending..."
             ) : (
@@ -79,6 +85,6 @@ export function InviteMemberForm({ isInviting, onInvite }: InviteMemberFormProps
           </Button>
         </div>
       </form>
-    </LayerCard>
+    </Card>
   );
 }

--- a/packages/dashboard/src/components/dashboard/organizations/members/_member-cell.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_member-cell.tsx
@@ -12,8 +12,8 @@ export function MemberCell({ name, email, iconType, subtitle }: MemberCellProps)
     <div className="flex items-center gap-3">
       <AvatarIcon icon={iconType} />
       <div className="min-w-0">
-        <p className="truncate text-sm font-semibold text-foreground">{name}</p>
-        <p className="truncate text-sm text-muted-foreground">{subtitle ?? email}</p>
+        <p className="truncate text-[13.5px] font-medium text-fg">{name}</p>
+        <p className="num truncate font-mono text-[12px] text-fg-3">{subtitle ?? email}</p>
       </div>
     </div>
   );

--- a/packages/dashboard/src/components/dashboard/organizations/members/_member-list-card.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_member-list-card.tsx
@@ -1,7 +1,11 @@
-import { Surface } from "@cloudflare/kumo/components/surface";
-import { Text } from "@cloudflare/kumo/components/text";
 import type { ReactNode } from "react";
-import { type Column, DataTable } from "@/components/dashboard/data-table";
+import { Card } from "@/components/ui/card";
+
+export interface Column<T> {
+  key: string;
+  label: string;
+  render: (row: T) => ReactNode;
+}
 
 export interface MemberListCardProps<T> {
   readonly title: string;
@@ -28,25 +32,67 @@ export function MemberListCard<T>({
   empty,
   rowKey,
 }: MemberListCardProps<T>) {
+  const total = count ?? data.length;
+
   return (
-    <Surface className="flex flex-col gap-4 p-6">
+    <Card className="flex flex-col gap-4 p-6">
       <div className="flex flex-col gap-1">
-        <Text variant="heading3" as="h2">
-          {title}
-        </Text>
-        <Text variant="secondary" as="p">
-          {count ?? 0} {countLabel ?? "item"}
-          {(count ?? 0) !== 1 ? "s" : ""}
-        </Text>
+        <h2 className="text-[16px] font-semibold text-fg">{title}</h2>
+        <p className="num font-mono text-[12.5px] text-fg-3">
+          {total} {countLabel ?? "item"}
+          {total !== 1 ? "s" : ""}
+        </p>
       </div>
-      <DataTable
-        data={data as T[]}
-        columns={columns}
-        loading={isLoading}
-        loadingRows={3}
-        empty={empty}
-        rowKey={rowKey}
-      />
-    </Surface>
+
+      {isLoading ? (
+        <div className="flex flex-col">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="h-12 w-full animate-pulse border-b border-edge-soft bg-panel2/40"
+            />
+          ))}
+        </div>
+      ) : data.length === 0 ? (
+        <div className="flex flex-col items-center gap-2 py-10 text-center">
+          <span className="grid size-9 place-items-center rounded-[var(--radius)] border border-edge bg-panel2 text-fg-4">
+            {empty.icon}
+          </span>
+          <p className="text-[13.5px] font-medium text-fg-2">{empty.title}</p>
+          {empty.description && <p className="text-[12.5px] text-fg-3">{empty.description}</p>}
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse">
+            <thead>
+              <tr className="border-b border-edge">
+                {columns.map((c) => (
+                  <th
+                    key={c.key}
+                    className="px-3 py-2 text-left font-mono text-[10.5px] uppercase tracking-[0.1em] text-fg-4 first:pl-0 last:pr-0"
+                  >
+                    {c.label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {data.map((row) => (
+                <tr
+                  key={rowKey(row)}
+                  className="border-b border-edge-soft transition-colors last:border-0 hover:bg-panel2/50"
+                >
+                  {columns.map((c) => (
+                    <td key={c.key} className="px-3 py-3 first:pl-0 last:pr-0">
+                      {c.render(row)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Card>
   );
 }

--- a/packages/dashboard/src/components/dashboard/organizations/members/_members-list.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_members-list.tsx
@@ -1,8 +1,7 @@
 import { UserIcon } from "@phosphor-icons/react";
 import * as React from "react";
-import type { Column } from "@/components/dashboard/data-table";
 import { MemberCell } from "./_member-cell";
-import { MemberListCard } from "./_member-list-card";
+import { type Column, MemberListCard } from "./_member-list-card";
 import { RoleBadge } from "./_role-badge";
 
 export interface MembersListProps {
@@ -57,7 +56,7 @@ export function MembersList({ isLoading, members, count }: MembersListProps) {
       columns={columns}
       isLoading={isLoading}
       empty={{
-        icon: <UserIcon className="h-5 w-5" />,
+        icon: <UserIcon className="size-4" aria-hidden="true" />,
         title: "No members yet",
         description: "Invite team members to join your organization",
       }}

--- a/packages/dashboard/src/components/dashboard/organizations/members/_members-skeleton.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_members-skeleton.tsx
@@ -1,10 +1,11 @@
-import { Surface } from "@cloudflare/kumo/components/surface";
-import { FormSkeleton } from "@/components/dashboard/loading-states";
+import { Card } from "@/components/ui/card";
 
 export function _MembersSkeleton() {
   return (
-    <Surface className="flex flex-col gap-4 p-6">
-      <FormSkeleton fields={3} />
-    </Surface>
+    <Card className="flex flex-col gap-4 p-6">
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="h-10 w-full animate-pulse rounded-[var(--radius)] bg-panel2" />
+      ))}
+    </Card>
   );
 }

--- a/packages/dashboard/src/components/dashboard/organizations/members/_page-header.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_page-header.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@cloudflare/kumo/components/button";
 import { ArrowLeftIcon } from "@phosphor-icons/react";
 import Link from "next/link";
 
@@ -9,21 +8,20 @@ export interface _PageHeaderProps {
 
 export function _PageHeader({ organizationName, isLoading }: _PageHeaderProps) {
   return (
-    <header className="flex items-center gap-3 border-border border-b pb-5">
-      <Link href="/dashboard/settings/organizations">
-        <Button
-          variant="ghost"
-          shape="square"
-          size="sm"
-          disabled={isLoading}
-          aria-label="Back to organizations"
-        >
-          <ArrowLeftIcon aria-hidden="true" />
-        </Button>
+    <header className="flex items-center gap-3 border-b border-edge-soft pb-5">
+      <Link
+        href="/dashboard/settings/organizations"
+        aria-label="Back to organizations"
+        aria-disabled={isLoading}
+        className={`grid size-8 place-items-center rounded-[var(--radius)] text-fg-3 transition-colors hover:bg-panel2 hover:text-fg ${
+          isLoading ? "pointer-events-none opacity-50" : ""
+        }`}
+      >
+        <ArrowLeftIcon className="size-4" aria-hidden="true" />
       </Link>
       <div className="min-w-0 flex-1">
-        <h1 className="text-[26px] tracking-tight text-foreground">Members</h1>
-        <p className="text-[14.5px] leading-6 text-muted-foreground">
+        <h1 className="text-[26px] tracking-tight text-fg">Members</h1>
+        <p className="text-[14.5px] leading-6 text-fg-3">
           {organizationName ? `${organizationName} · ` : ""}Manage organization members
         </p>
       </div>

--- a/packages/dashboard/src/components/dashboard/organizations/members/_pending-invitations-list.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_pending-invitations-list.tsx
@@ -1,8 +1,6 @@
-import { Button } from "@cloudflare/kumo/components/button";
 import { EnvelopeIcon } from "@phosphor-icons/react";
-import type { Column } from "@/components/dashboard/data-table";
 import { MemberCell } from "./_member-cell";
-import { MemberListCard } from "./_member-list-card";
+import { type Column, MemberListCard } from "./_member-list-card";
 
 export interface _PendingInvitationsListProps {
   readonly isLoading: boolean;
@@ -44,9 +42,13 @@ export function _PendingInvitationsList({
       key: "actions",
       label: "",
       render: (row) => (
-        <Button variant="ghost" size="sm" onClick={() => onRevokeInvitation(row.id)}>
+        <button
+          type="button"
+          onClick={() => onRevokeInvitation(row.id)}
+          className="text-[12.5px] text-fg-3 transition-colors hover:text-neg"
+        >
           Revoke
-        </Button>
+        </button>
       ),
     },
   ];
@@ -60,7 +62,7 @@ export function _PendingInvitationsList({
       columns={columns}
       isLoading={isLoading}
       empty={{
-        icon: <EnvelopeIcon className="h-5 w-5" aria-hidden="true" />,
+        icon: <EnvelopeIcon className="size-4" aria-hidden="true" />,
         title: "No pending invitations",
       }}
       rowKey={(row) => row.id}

--- a/packages/dashboard/src/components/dashboard/organizations/members/_role-badge.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_role-badge.tsx
@@ -1,4 +1,4 @@
-import { Badge } from "@cloudflare/kumo/components/badge";
+import { Badge } from "@/components/ui/badge";
 
 export interface RoleBadgeProps {
   readonly role: string;
@@ -6,5 +6,5 @@ export interface RoleBadgeProps {
 
 export function RoleBadge({ role }: RoleBadgeProps) {
   const isAdmin = role === "org:admin";
-  return <Badge variant={isAdmin ? "primary" : "secondary"}>{isAdmin ? "Admin" : "Member"}</Badge>;
+  return <Badge tone={isAdmin ? "live" : "idle"}>{isAdmin ? "Admin" : "Member"}</Badge>;
 }

--- a/packages/dashboard/src/components/dashboard/organizations/members/members-content.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/members-content.tsx
@@ -1,8 +1,8 @@
 import { useOrganization, useOrganizationList, useUser } from "@clerk/react";
-import { LayerCard } from "@cloudflare/kumo/components/layer-card";
-import { Text } from "@cloudflare/kumo/components/text";
+import { useSearchParams } from "next/navigation";
 import * as React from "react";
 import { toast } from "sonner";
+import { Card } from "@/components/ui/card";
 import {
   _MembersSkeleton,
   _PageHeader,
@@ -18,7 +18,7 @@ import { useInviteMember } from "./_use-invite-member";
 
 export function MembersContent() {
   const { isLoaded: isUserLoaded, isSignedIn } = useUser();
-  const { isLoaded: isOrgListLoaded } = useOrganizationList({
+  const { isLoaded: isOrgListLoaded, setActive } = useOrganizationList({
     userMemberships: true,
   });
   const {
@@ -37,6 +37,20 @@ export function MembersContent() {
     },
   });
 
+  // `?org=` selects which organization's members to manage. When present and
+  // different from the currently active org, switch the active org so Clerk's
+  // useOrganization() hooks resolve the right membership / invitation lists.
+  const searchParams = useSearchParams();
+  const orgParam = searchParams?.get("org") ?? null;
+
+  React.useEffect(() => {
+    if (!orgParam || !setActive || !isOrgListLoaded) return;
+    if (organization?.id === orgParam) return;
+    setActive({ organization: orgParam }).catch(() => {
+      /* ignore — stale param or no access */
+    });
+  }, [orgParam, setActive, isOrgListLoaded, organization?.id]);
+
   const { inviteMember, isInviting } = useInviteMember(organization, invitations);
 
   const handleRevokeInvitation = React.useCallback(async (_invitationId: string) => {
@@ -46,7 +60,7 @@ export function MembersContent() {
   // Loading state
   if (!isUserLoaded || !isOrgListLoaded || !isOrgLoaded) {
     return (
-      <div className="flex flex-col gap-6 px-4 lg:px-6">
+      <div className="flex flex-col gap-6 px-4 py-7 lg:px-6">
         <_PageHeader isLoading />
         <_MembersSkeleton />
       </div>
@@ -56,22 +70,20 @@ export function MembersContent() {
   // Not signed in or no organization
   if (!isSignedIn || !organization) {
     return (
-      <div className="flex flex-col gap-6 px-4 lg:px-6">
+      <div className="flex flex-col gap-6 px-4 py-7 lg:px-6">
         <_PageHeader />
-        <LayerCard className="flex flex-col gap-1 p-6">
-          <Text variant="heading3" as="h2">
-            No organization selected
-          </Text>
-          <Text variant="secondary" as="p">
+        <Card className="flex flex-col gap-1 p-6">
+          <h2 className="text-[16px] font-semibold text-fg">No organization selected</h2>
+          <p className="text-[13.5px] leading-6 text-fg-3">
             Select an organization to manage its members.
-          </Text>
-        </LayerCard>
+          </p>
+        </Card>
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col gap-6 px-4 lg:px-6">
+    <div className="flex flex-col gap-6 px-4 py-7 lg:px-6">
       <_PageHeader organizationName={organization.name} />
       <InviteMemberForm isInviting={isInviting} onInvite={inviteMember} />
       <MembersList

--- a/packages/dashboard/src/components/dashboard/organizations/members/members-page.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/members-page.tsx
@@ -1,10 +1,22 @@
-import { DashboardShell } from "@/components/dashboard-shell";
+import { Suspense } from "react";
+import { AppShell } from "@/components/app-shell";
+import { Providers } from "@/components/providers";
 import { MembersContent } from "./members-content";
 
 export function MembersPage() {
   return (
-    <DashboardShell>
-      <MembersContent />
-    </DashboardShell>
+    <Providers>
+      <AppShell>
+        <Suspense
+          fallback={
+            <div className="flex min-h-[60dvh] items-center justify-center">
+              <div className="size-5 animate-spin rounded-full border-2 border-edge border-t-fg-4" />
+            </div>
+          }
+        >
+          <MembersContent />
+        </Suspense>
+      </AppShell>
+    </Providers>
   );
 }


### PR DESCRIPTION
## Summary

Rebuilds the `/dashboard/settings/organizations` subtree (list, create, members — 3 routes, 18 files) onto the new design system and drops **all** `@cloudflare/kumo` imports. Behavior is preserved 1:1 (Clerk `useOrganization`, `organization.inviteMember`, invitations, roles, domain advisory).

## Changes

- **Page wrappers** → `<Providers><AppShell>` (replaces Kumo `DashboardShell`). Members content wrapped in `<Suspense>` because it now uses `useSearchParams`.
- **List** (`organizations-list-content.tsx`) — `Card` rows + `ui/Badge` (active org) + `ui/Button`; replaced Kumo `LayerCard`/`Badge`/`Button`/`EmptyState`/skeletons.
- **Create** — `Card` + token-styled inputs + `ui/Button`; `DomainWarning` is now a token banner (`border-warn/40 bg-warn/10`), replacing Kumo `Banner`.
- **Members** — new local `MemberListCard` renders a plain `<table>` (border-edge, mono), replacing the Kumo `DataTable` dependency. Roles use `ui/Badge`. Invite form uses a native `<select>` + token inputs.
- **`?org=` support** — `members-content.tsx` reads `?org=` via `useSearchParams` and switches the active org (`useOrganizationList.setActive`) so the selected org's members/invitations load, matching the list's `members?org=<id>` links.
- `organization.inviteMember`, invitations `revalidate`, and the revoke-invitation toast are preserved exactly.

## Verify
- `bunx biome check src/components/dashboard/organizations/` — clean
- `bunx astro check` — 0 errors
- Dev server: `200` on `/dashboard/settings/organizations/`, `.../create/`, `.../members/`

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned organization creation, list, and member management pages with refreshed visual styling and component layouts.
  * Updated form inputs, buttons, and navigation controls across organization pages.
  * Enhanced loading and empty states with improved visual consistency.
  * Refreshed member role badges and invitation interface styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->