### PR TITLE
feat(dashboard): rebuild / projects index in new design system (no Kumo)

### DIFF
--- a/packages/dashboard/src/components/dashboard/projects/_create-project-form-actions.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/_create-project-form-actions.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@cloudflare/kumo/components/button";
+import { Button } from "@/components/ui/button";
 
 interface CreateProjectFormActionsProps {
   onCancel: () => void;
@@ -13,10 +13,15 @@ export function CreateProjectFormActions({
 }: CreateProjectFormActionsProps) {
   return (
     <>
-      <Button size="sm" variant="ghost" onClick={onCancel}>
+      <Button variant="ghost" onClick={onCancel} className="min-h-[36px] py-2">
         Cancel
       </Button>
-      <Button size="sm" variant="primary" onClick={onCreate} disabled={disabled}>
+      <Button
+        variant="primary"
+        onClick={onCreate}
+        disabled={disabled}
+        className="min-h-[36px] py-2"
+      >
         Create project
       </Button>
     </>

--- a/packages/dashboard/src/components/dashboard/projects/_create-project-form-header.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/_create-project-form-header.tsx
@@ -1,14 +1,10 @@
-import { Text } from "@cloudflare/kumo/components/text";
-
 export function CreateProjectFormHeader() {
   return (
     <div className="flex flex-col gap-1">
-      <Text variant="heading3" as="h2">
-        Create project
-      </Text>
-      <Text variant="secondary" size="sm" as="p">
+      <h2 className="text-[15px] font-semibold text-fg">Create project</h2>
+      <p className="text-[13px] leading-5 text-fg-3">
         Give your project a name. The slug is used in API paths.
-      </Text>
+      </p>
     </div>
   );
 }

--- a/packages/dashboard/src/components/dashboard/projects/_create-project-form.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/_create-project-form.tsx
@@ -1,4 +1,4 @@
-import { LayerCard } from "@cloudflare/kumo/components/layer-card";
+import { Card } from "@/components/ui/card";
 import { CreateProjectFormActions } from "./_create-project-form-actions";
 import { CreateProjectFormHeader } from "./_create-project-form-header";
 import { ProjectNameInput } from "./_project-name-input";
@@ -21,19 +21,6 @@ interface CreateProjectFormProps {
  * - Auto-generates slug from name
  * - Real-time slug availability checking
  * - Visual feedback for slug status (checking, available, taken)
- *
- * @example
- * ```tsx
- * <CreateProjectForm
- *   name={name}
- *   slug={slug}
- *   slugStatus={slugStatus}
- *   onNameChange={setNewName}
- *   onSlugChange={setSlug}
- *   onCreate={handleCreate}
- *   onCancel={handleCancel}
- * />
- * ```
  */
 export function CreateProjectForm({
   name,
@@ -48,7 +35,7 @@ export function CreateProjectForm({
     !name.trim() || !slug || slugStatus === "taken" || slugStatus === "checking";
 
   return (
-    <LayerCard className="mb-6 flex flex-col gap-4 p-6">
+    <Card className="mb-6 flex flex-col gap-4 p-6">
       <CreateProjectFormHeader />
       <div className="flex flex-col gap-4">
         <ProjectNameInput value={name} onChange={onNameChange} onSubmit={onCreate} />
@@ -61,6 +48,6 @@ export function CreateProjectForm({
           disabled={isSubmitDisabled}
         />
       </div>
-    </LayerCard>
+    </Card>
   );
 }

--- a/packages/dashboard/src/components/dashboard/projects/_dashboard-content.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/_dashboard-content.tsx
@@ -1,5 +1,4 @@
 import type { ProjectListItem } from "@agentstate/shared";
-import { CardListSkeleton } from "@/components/dashboard/loading-states";
 import { CreateProjectForm } from "./_create-project-form";
 import { ProjectsEmptyState } from "./_projects-empty-state";
 import { ProjectsTable } from "./_projects-table";
@@ -26,23 +25,6 @@ interface DashboardContentProps {
  * - Loading skeleton (when loading)
  * - Projects table (when projects exist)
  * - Empty state (when no projects)
- *
- * @example
- * ```tsx
- * <DashboardContent
- *   projects={projects}
- *   loadingProjects={loading}
- *   showCreate={showCreate}
- *   name={name}
- *   slug={slug}
- *   slugStatus={slugStatus}
- *   onNameChange={setNewName}
- *   onSlugChange={setSlug}
- *   onCreate={handleCreate}
- *   onCancel={handleCancel}
- *   onCreateClick={handleStartCreate}
- * />
- * ```
  */
 export function DashboardContent({
   projects,
@@ -73,7 +55,7 @@ export function DashboardContent({
       )}
 
       {/* Loading state */}
-      {loadingProjects && !showCreate && <CardListSkeleton count={3} />}
+      {loadingProjects && !showCreate && <ProjectsLoadingSkeleton />}
 
       {/* Project list */}
       {!loadingProjects && projects.length > 0 && <ProjectsTable projects={projects} />}
@@ -83,5 +65,29 @@ export function DashboardContent({
         <ProjectsEmptyState onCreateClick={onCreateClick} />
       )}
     </>
+  );
+}
+
+/** Lightweight skeleton matching the projects table rows (plain Tailwind + tokens). */
+function ProjectsLoadingSkeleton() {
+  return (
+    <div className="overflow-hidden rounded-[var(--radius-lg)] border border-edge">
+      <div className="border-b border-edge-soft bg-panel px-4 py-2.5">
+        <div className="h-3.5 w-40 animate-pulse rounded bg-panel2" />
+      </div>
+      <div className="divide-y divide-edge-soft">
+        {Array.from({ length: 3 }).map((_, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: Static skeleton rows, index is stable here
+          <div key={i} className="flex items-center gap-3 px-4 py-3.5">
+            <div className="size-8 shrink-0 animate-pulse rounded-[var(--radius)] bg-panel2" />
+            <div className="flex flex-1 flex-col gap-1.5">
+              <div className="h-3.5 w-32 animate-pulse rounded bg-panel2" />
+              <div className="h-3 w-24 animate-pulse rounded bg-panel2" />
+            </div>
+            <div className="h-3 w-10 animate-pulse rounded bg-panel2" />
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }

--- a/packages/dashboard/src/components/dashboard/projects/_dashboard-header.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/_dashboard-header.tsx
@@ -1,6 +1,5 @@
-import { Button } from "@cloudflare/kumo/components/button";
 import { Plus } from "@phosphor-icons/react";
-import { PageHeader } from "@/components/dashboard/page-header";
+import { Button } from "@/components/ui/button";
 
 interface DashboardHeaderProps {
   onCreateClick: () => void;
@@ -12,22 +11,20 @@ interface DashboardHeaderProps {
  * Features:
  * - Title and description
  * - "New Project" action button
- *
- * @example
- * ```tsx
- * <DashboardHeader onCreateClick={handleStartCreate} />
- * ```
  */
 export function DashboardHeader({ onCreateClick }: DashboardHeaderProps) {
   return (
-    <PageHeader
-      title="Projects"
-      description="Manage your API projects and keys."
-      actions={
-        <Button size="sm" variant="primary" icon={<Plus aria-hidden />} onClick={onCreateClick}>
+    <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <div className="flex max-w-2xl flex-col gap-1.5">
+        <h1 className="text-[24px] font-semibold tracking-tight text-fg">Projects</h1>
+        <p className="text-[13.5px] leading-6 text-fg-3">Manage your API projects and keys.</p>
+      </div>
+      <div className="flex items-center gap-2 sm:justify-end">
+        <Button variant="primary" onClick={onCreateClick} className="min-h-[36px] py-2">
+          <Plus size={15} aria-hidden="true" />
           New Project
         </Button>
-      }
-    />
+      </div>
+    </header>
   );
 }

--- a/packages/dashboard/src/components/dashboard/projects/_project-name-input.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/_project-name-input.tsx
@@ -1,4 +1,4 @@
-import { Input } from "@cloudflare/kumo/components/input";
+import { useEffect, useRef } from "react";
 
 interface ProjectNameInputProps {
   value: string;
@@ -7,14 +7,25 @@ interface ProjectNameInputProps {
 }
 
 export function ProjectNameInput({ value, onChange, onSubmit }: ProjectNameInputProps) {
+  // Focus the name field on mount (matches the original autoFocus behavior,
+  // implemented via ref to avoid the noAutofocus lint on a raw <input>).
+  const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
   return (
-    <Input
-      label="Project name"
-      placeholder="My Chatbot"
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      onKeyDown={(e) => e.key === "Enter" && onSubmit()}
-      autoFocus
-    />
+    <label className="flex flex-col gap-1.5">
+      <span className="text-[13px] font-medium text-fg-2">Project name</span>
+      <input
+        ref={inputRef}
+        type="text"
+        placeholder="My Chatbot"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => e.key === "Enter" && onSubmit()}
+        className="min-h-[40px] rounded-[var(--radius)] border border-edge bg-panel px-3 text-[13.5px] text-fg outline-none transition-colors placeholder:text-fg-4 focus:border-accent"
+      />
+    </label>
   );
 }

--- a/packages/dashboard/src/components/dashboard/projects/_project-slug-input.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/_project-slug-input.tsx
@@ -1,4 +1,3 @@
-import { Input } from "@cloudflare/kumo/components/input";
 import { Check, Spinner, X } from "@phosphor-icons/react";
 
 type SlugStatus = "idle" | "checking" | "available" | "taken";
@@ -14,26 +13,36 @@ export function ProjectSlugInput({ value, status, onChange }: ProjectSlugInputPr
   const isAvailable = status === "available" && !!value;
 
   return (
-    <div className="relative">
-      <Input
-        label="Project slug"
-        placeholder="my-chatbot"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        variant={isTaken ? "error" : "default"}
-        className="font-mono pr-8"
-        error={isTaken ? "This slug is already taken. Choose a different one." : undefined}
-        description={isAvailable ? "Available" : undefined}
-      />
-      {value && (
-        <div className="pointer-events-none absolute top-[34px] right-2.5" aria-hidden="true">
-          {status === "checking" && (
-            <Spinner className="size-4 animate-spin text-muted-foreground" />
-          )}
-          {isAvailable && <Check className="size-4 text-emerald-600" />}
-          {isTaken && <X className="size-4 text-kumo-danger" />}
-        </div>
+    <label className="flex flex-col gap-1.5">
+      <span className="text-[13px] font-medium text-fg-2">Project slug</span>
+      <div className="relative">
+        <input
+          type="text"
+          placeholder="my-chatbot"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          aria-invalid={isTaken || undefined}
+          className={`min-h-[40px] w-full rounded-[var(--radius)] border bg-panel px-3 font-mono text-[13.5px] text-fg outline-none transition-colors placeholder:text-fg-4 focus:border-accent ${
+            isTaken ? "border-neg/50" : "border-edge"
+          }`}
+        />
+        {value && (
+          <div
+            className="pointer-events-none absolute inset-y-0 right-2.5 flex items-center"
+            aria-hidden="true"
+          >
+            {status === "checking" && <Spinner className="size-4 animate-spin text-fg-4" />}
+            {isAvailable && <Check className="size-4 text-pos" />}
+            {isTaken && <X className="size-4 text-neg" />}
+          </div>
+        )}
+      </div>
+      {isTaken && (
+        <span className="text-[12px] text-neg">
+          This slug is already taken. Choose a different one.
+        </span>
       )}
-    </div>
+      {isAvailable && <span className="text-[12px] text-pos">Available</span>}
+    </label>
   );
 }

--- a/packages/dashboard/src/components/dashboard/projects/_projects-empty-state.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/_projects-empty-state.tsx
@@ -1,33 +1,31 @@
-import { LayerCard } from "@cloudflare/kumo/components/layer-card";
 import { Folder } from "@phosphor-icons/react";
-import { EmptyState } from "@/components/dashboard/empty-state";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 
 interface ProjectsEmptyStateProps {
   onCreateClick: () => void;
 }
 
 /**
- * ProjectsEmptyState - Empty state when user has no projects.
+ * ProjectsEmptyState - Empty state when the user has no projects.
  *
- * Uses EmptyState component wrapped in a dashed LayerCard for visual consistency.
- *
- * @example
- * ```tsx
- * <ProjectsEmptyState onCreateClick={handleCreate} />
- * ```
+ * Centered icon + copy + CTA inside a Card (plain Tailwind + tokens, no Kumo).
  */
 export function ProjectsEmptyState({ onCreateClick }: ProjectsEmptyStateProps) {
   return (
-    <LayerCard>
-      <EmptyState
-        icon={<Folder aria-hidden />}
-        title="No projects yet"
-        description="Projects group your conversations and API keys."
-        action={{
-          label: "Create your first project",
-          onClick: onCreateClick,
-        }}
-      />
-    </LayerCard>
+    <Card className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+      <span className="flex size-12 items-center justify-center rounded-[var(--radius-lg)] border border-edge bg-panel2 text-fg-3">
+        <Folder className="size-5" aria-hidden="true" />
+      </span>
+      <div className="flex max-w-xs flex-col gap-1">
+        <p className="text-[14px] font-medium text-fg">No projects yet</p>
+        <p className="text-[12.5px] leading-5 text-fg-3">
+          Projects group your conversations and API keys.
+        </p>
+      </div>
+      <Button variant="secondary" onClick={onCreateClick} className="min-h-[36px] py-2">
+        Create your first project
+      </Button>
+    </Card>
   );
 }

--- a/packages/dashboard/src/components/dashboard/projects/_projects-table.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/_projects-table.tsx
@@ -1,8 +1,7 @@
 import type { ProjectListItem } from "@agentstate/shared";
-import { LayerCard } from "@cloudflare/kumo/components/layer-card";
-import { Table } from "@cloudflare/kumo/components/table";
-import { Folder, Key } from "@phosphor-icons/react";
+import { Folder } from "@phosphor-icons/react";
 import { useRouter } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
 
 type Project = ProjectListItem;
 
@@ -11,37 +10,38 @@ interface ProjectsTableProps {
 }
 
 /**
- * ProjectsTable - Table displaying list of projects with click navigation.
+ * ProjectsTable - Plain table displaying the list of projects with click navigation.
  *
  * Features:
- * - Clickable rows with keyboard navigation
- * - Project name and slug display
- * - API key count
- * - Created date
- *
- * @example
- * ```tsx
- * <ProjectsTable projects={projects} />
- * ```
+ * - Clickable rows with keyboard navigation (Enter)
+ * - Project name and slug (mono)
+ * - API key count (mono, tabular-nums)
+ * - Created date (mono, tabular-nums)
  */
 export function ProjectsTable({ projects }: ProjectsTableProps) {
   const router = useRouter();
 
   return (
-    <LayerCard className="overflow-hidden p-0">
-      <Table>
-        <Table.Header>
-          <Table.Row className="bg-muted hover:bg-muted">
-            <Table.Head>Name</Table.Head>
-            <Table.Head className="hidden sm:table-cell">API Keys</Table.Head>
-            <Table.Head className="hidden sm:table-cell">Created</Table.Head>
-          </Table.Row>
-        </Table.Header>
-        <Table.Body>
+    <div className="overflow-hidden rounded-[var(--radius-lg)] border border-edge">
+      <table className="w-full border-collapse text-left">
+        <thead>
+          <tr className="border-b border-edge-soft bg-panel">
+            <th className="px-4 py-2.5 font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4 font-medium">
+              Name
+            </th>
+            <th className="hidden px-4 py-2.5 text-right font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4 font-medium sm:table-cell">
+              Keys
+            </th>
+            <th className="hidden px-4 py-2.5 text-right font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4 font-medium sm:table-cell">
+              Created
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-edge-soft">
           {projects.map((project) => (
-            <Table.Row
+            <tr
               key={project.id}
-              className="cursor-pointer hover:bg-muted"
+              className="cursor-pointer transition-colors hover:bg-panel2"
               onClick={() => router.push(`/dashboard/project/?slug=${project.slug}`)}
               onKeyDown={(e) => {
                 if (e.key === "Enter") {
@@ -52,33 +52,32 @@ export function ProjectsTable({ projects }: ProjectsTableProps) {
               tabIndex={0}
               aria-label={`Open ${project.name}`}
             >
-              <Table.Cell className="py-3.5">
+              <td className="py-3.5 pl-4 pr-4">
                 <div className="flex items-center gap-3">
-                  <span className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border bg-muted text-muted-foreground">
-                    <Folder className="size-4" aria-hidden />
+                  <span className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius)] border border-edge bg-panel2 text-fg-3">
+                    <Folder className="size-4" aria-hidden="true" />
                   </span>
-                  <div>
-                    <p className="text-sm font-semibold text-foreground">{project.name}</p>
-                    <p className="font-mono text-[11.5px] text-muted-foreground">{project.slug}</p>
+                  <div className="flex min-w-0 flex-col gap-0.5">
+                    <span className="truncate text-[13.5px] font-medium text-fg">
+                      {project.name}
+                    </span>
+                    <span className="num font-mono text-[11.5px] text-fg-4">{project.slug}</span>
                   </div>
                 </div>
-              </Table.Cell>
-              <Table.Cell className="hidden sm:table-cell">
-                <div className="flex items-center gap-1.5 text-[13px] text-muted-foreground">
-                  <Key className="size-3.5 text-muted-foreground" aria-hidden />
-                  {project.key_count ?? 0}
-                </div>
-              </Table.Cell>
-              <Table.Cell
+              </td>
+              <td className="hidden py-3.5 pr-4 text-right sm:table-cell">
+                <Badge tone="default">{project.key_count ?? 0}</Badge>
+              </td>
+              <td
                 suppressHydrationWarning
-                className="hidden text-[13px] text-muted-foreground sm:table-cell"
+                className="num hidden py-3.5 pr-4 text-right font-mono text-[12.5px] text-fg-3 sm:table-cell"
               >
                 {new Date(project.created_at).toLocaleDateString()}
-              </Table.Cell>
-            </Table.Row>
+              </td>
+            </tr>
           ))}
-        </Table.Body>
-      </Table>
-    </LayerCard>
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/packages/dashboard/src/components/dashboard/projects/projects-page.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/projects-page.tsx
@@ -1,4 +1,5 @@
-import { DashboardShell } from "@/components/dashboard-shell";
+import { AppShell } from "@/components/app-shell";
+import { Providers } from "@/components/providers";
 import { DashboardContent } from "./_dashboard-content";
 import { DashboardHeader } from "./_dashboard-header";
 import { useCreateProject } from "./_use-create-project";
@@ -32,7 +33,7 @@ function ProjectsContent() {
   } = useCreateProject(projects);
 
   return (
-    <div className="px-4 lg:px-6">
+    <div className="flex flex-col gap-6 px-5 py-7 sm:px-7">
       <DashboardHeader onCreateClick={handleStartCreate} />
       <DashboardContent
         projects={projects}
@@ -54,14 +55,16 @@ function ProjectsContent() {
 /**
  * ProjectsPage - client:only island for the /dashboard route.
  *
- * Wraps the page body in DashboardShell (Clerk Providers + auth gate +
- * sidebar/header chrome). Rendered as `client:only="react"` from
- * src/pages/dashboard/index.astro.
+ * Wraps the page body in the new design-system shell (Clerk Providers +
+ * AppShell auth gate + sidebar/header). Rendered as `client:only="react"`
+ * from src/pages/dashboard/index.astro. Plain Tailwind + tokens, no Kumo.
  */
 export function ProjectsPage() {
   return (
-    <DashboardShell>
-      <ProjectsContent />
-    </DashboardShell>
+    <Providers>
+      <AppShell>
+        <ProjectsContent />
+      </AppShell>
+    </Providers>
   );
 }


### PR DESCRIPTION
## Summary

Rebuilds the **`/dashboard` projects index** route (the main dashboard page) in the new plain-Tailwind design system, dropping every \`@cloudflare/kumo\` import. Continues the per-route Kumo removal series (#158–#162).

## Changes

All files under \`packages/dashboard/src/components/dashboard/projects/\`:

- **\`projects-page.tsx\`** — \`DashboardShell\` → \`<Providers><AppShell>\` (new design-system shell).
- **\`_dashboard-header.tsx\`** — Kumo \`Button\` → \`@/components/ui/button\` + \`Plus\` icon; inline header using \`text-fg\` tokens.
- **\`_dashboard-content.tsx\`** — replaces the shared \`CardListSkeleton\` (still Kumo-token-based and depended on by not-yet-rebuilt routes) with an inline token-based loading skeleton.
- **\`_create-project-form.tsx\`** — \`LayerCard\` → \`@/components/ui/card\`.
- **\`_create-project-form-header.tsx\`** — Kumo \`Text\` → plain elements with \`text-fg\`/\`text-fg-3\`.
- **\`_create-project-form-actions.tsx\`** — Kumo \`Button\` → \`@/components/ui/button\`.
- **\`_project-name-input.tsx\`** — Kumo \`Input\` → token input (\`border-edge bg-panel\`, \`focus:border-accent\`); \`autoFocus\` reproduced via ref to satisfy \`noAutofocus\` lint on raw \`<input>\`.
- **\`_project-slug-input.tsx\`** — Kumo \`Input\` → token input with status icon (\`Check\`/\`Spinner\`/\`X\`) and inline availability messages (\`text-pos\`/\`text-neg\`).
- **\`_projects-table.tsx\`** — Kumo \`LayerCard\`/\`Table\` → plain \`<table>\` with \`border-edge\`, mono + \`num\` (tabular-nums) IDs/counts/timestamps, and \`Badge\` for the key count.
- **\`_projects-empty-state.tsx\`** — \`LayerCard\` + shared \`EmptyState\` → \`@/components/ui/card\` + \`@/components/ui/button\`.

**Hooks unchanged:** \`_use-projects-data.ts\` and \`_use-create-project.ts\` use only \`@/lib/*\` + \`next/navigation\` (shimmed) + \`@agentstate/shared\` — no Kumo, untouched.

## Behavior

1:1 with the previous implementation: project list fetch, create-project form (name + auto-slug + debounced availability check + create + navigate), loading and empty states, and click/keyboard row navigation to \`/dashboard/project/?slug=...\` are all preserved.

## Verification

- \`bunx biome check\` on touched files — clean (0 errors, 0 warnings)
- \`bunx astro check\` — **0 errors, 0 warnings** (181 pre-existing hints, same Phosphor-icon deprecation notices as sibling routes)
- \`bunx astro dev --port 4322\` → \`curl /dashboard/\` returns **200**

## Scope

Surgical: only the 10 projects route files are in this commit. The shared \`EmptyState\` and \`CardListSkeleton\` are left untouched because other not-yet-rebuilt routes (organizations, project api-keys, domains loading skeleton) still import them; the empty state and loading skeleton are implemented inline here instead.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>