### PR TITLE
feat(dashboard): mobile drawer, user avatar, auth redirect

### DIFF
--- a/packages/dashboard/src/components/app-shell.tsx
+++ b/packages/dashboard/src/components/app-shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { SignIn, useAuth, useUser } from "@clerk/react";
+import { SignIn, UserButton, useAuth, useUser } from "@clerk/react";
 import {
   BookOpen,
   ChartLine,
@@ -8,11 +8,13 @@ import {
   Gear,
   GitBranch,
   House,
+  List,
   type Icon as PhosphorIcon,
   Plug,
   SquaresFour,
+  X,
 } from "@phosphor-icons/react";
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import { LogoMark } from "@/components/logo-mark";
 
 interface NavItem {
@@ -52,9 +54,6 @@ function useActivePath() {
   return pathname;
 }
 
-// avoid importing the shim name indirectly; tiny local hook
-import { useEffect, useState } from "react";
-
 function useStatePath() {
   const [p, setP] = useState(() => (typeof window === "undefined" ? "" : window.location.pathname));
   useEffect(() => {
@@ -70,7 +69,15 @@ function isActive(pathname: string, url: string) {
   return pathname.startsWith(url);
 }
 
-function NavList({ groups, pathname }: { groups: NavGroup[]; pathname: string }) {
+function NavList({
+  groups,
+  pathname,
+  onNavigate,
+}: {
+  groups: NavGroup[];
+  pathname: string;
+  onNavigate?: () => void;
+}) {
   return (
     <nav className="flex flex-col gap-5 px-3">
       {groups.map((g) => (
@@ -86,6 +93,7 @@ function NavList({ groups, pathname }: { groups: NavGroup[]; pathname: string })
                 <a
                   key={it.url}
                   href={it.url}
+                  onClick={onNavigate}
                   className={`flex min-h-[36px] items-center gap-3 rounded-[var(--radius)] px-3 py-2 text-[14px] transition-[background-color,color] duration-150 ${
                     active ? "bg-panel2 text-fg" : "text-fg-3 hover:bg-panel2 hover:text-fg"
                   }`}
@@ -114,21 +122,57 @@ function Gate({ children }: { children: ReactNode }) {
   if (!isSignedIn) {
     return (
       <div className="flex min-h-[100dvh] items-center justify-center bg-base px-4">
-        <SignIn routing="hash" />
+        <SignIn routing="hash" afterSignInUrl="/dashboard" afterSignUpUrl="/dashboard" />
       </div>
     );
   }
   return <>{children}</>;
 }
 
+function SidebarInner({ pathname, onNavigate }: { pathname: string; onNavigate?: () => void }) {
+  return (
+    <div className="flex-1 overflow-auto py-4">
+      <NavList groups={navGroups} pathname={pathname} onNavigate={onNavigate} />
+      <div className="mx-3 mt-5 border-t border-edge-soft pt-3">
+        <NavList
+          groups={[{ label: "", items: secondaryItems }]}
+          pathname={pathname}
+          onNavigate={onNavigate}
+        />
+      </div>
+    </div>
+  );
+}
+
 export function AppShell({ children }: { children: ReactNode }) {
   const pathname = useActivePath();
   const { user } = useUser();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  // close the mobile drawer on Escape
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMenuOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [menuOpen]);
+
+  // lock background scroll while the drawer is open
+  useEffect(() => {
+    if (!menuOpen) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [menuOpen]);
 
   return (
     <Gate>
       <div className="flex min-h-[100dvh] bg-base">
-        {/* sidebar */}
+        {/* sidebar (desktop) */}
         <aside className="hidden w-[244px] shrink-0 border-r border-edge lg:flex lg:flex-col">
           <div className="flex h-14 items-center gap-2.5 border-b border-edge-soft px-5">
             <a href="/dashboard" className="flex items-center gap-2 text-fg">
@@ -136,17 +180,57 @@ export function AppShell({ children }: { children: ReactNode }) {
               <span className="text-[14.5px] font-semibold tracking-tight">AgentState</span>
             </a>
           </div>
-          <div className="flex-1 overflow-auto py-4">
-            <NavList groups={navGroups} pathname={pathname} />
-            <div className="mx-3 mt-5 border-t border-edge-soft pt-3">
-              <NavList groups={[{ label: "", items: secondaryItems }]} pathname={pathname} />
-            </div>
-          </div>
+          <SidebarInner pathname={pathname} />
         </aside>
+
+        {/* drawer (mobile) */}
+        <div
+          className={`fixed inset-0 z-40 lg:hidden ${menuOpen ? "" : "pointer-events-none"}`}
+          aria-hidden={!menuOpen}
+        >
+          <button
+            type="button"
+            tabIndex={-1}
+            aria-label="Close menu"
+            onClick={() => setMenuOpen(false)}
+            className={`absolute inset-0 cursor-default bg-black/50 transition-opacity duration-200 ${
+              menuOpen ? "opacity-100" : "opacity-0"
+            }`}
+          />
+          <aside
+            className={`absolute left-0 top-0 flex h-full w-[260px] max-w-[82vw] flex-col border-r border-edge bg-base transition-transform duration-200 ${
+              menuOpen ? "translate-x-0" : "-translate-x-full"
+            }`}
+          >
+            <div className="flex h-14 items-center justify-between gap-2.5 border-b border-edge-soft px-5">
+              <a href="/dashboard" className="flex items-center gap-2 text-fg">
+                <LogoMark size={20} />
+                <span className="text-[14.5px] font-semibold tracking-tight">AgentState</span>
+              </a>
+              <button
+                type="button"
+                onClick={() => setMenuOpen(false)}
+                aria-label="Close menu"
+                className="grid size-8 place-items-center rounded-[var(--radius)] text-fg-3 transition-[background-color,color] hover:bg-panel2 hover:text-fg"
+              >
+                <X size={18} />
+              </button>
+            </div>
+            <SidebarInner pathname={pathname} onNavigate={() => setMenuOpen(false)} />
+          </aside>
+        </div>
 
         {/* main */}
         <div className="flex min-w-0 flex-1 flex-col">
           <header className="sticky top-0 z-10 flex h-14 items-center gap-3 border-b border-edge bg-base/85 px-5 backdrop-blur sm:px-7">
+            <button
+              type="button"
+              onClick={() => setMenuOpen(true)}
+              aria-label="Open menu"
+              className="grid size-8 shrink-0 place-items-center rounded-[var(--radius)] text-fg-3 transition-[background-color,color] hover:bg-panel2 hover:text-fg lg:hidden"
+            >
+              <List size={18} />
+            </button>
             <Breadcrumb pathname={pathname} />
             <div className="ml-auto flex items-center gap-2">
               {user && (
@@ -154,9 +238,7 @@ export function AppShell({ children }: { children: ReactNode }) {
                   {user.fullName ?? user.primaryEmailAddress?.emailAddress}
                 </span>
               )}
-              <span className="grid size-8 place-items-center rounded-full bg-panel2 font-mono text-[12px] text-fg">
-                {(user?.firstName ?? "U").slice(0, 1).toUpperCase()}
-              </span>
+              <UserButton />
             </div>
           </header>
           <main className="flex-1">{children}</main>

--- a/packages/dashboard/src/components/dashboard/traces/traces-page.tsx
+++ b/packages/dashboard/src/components/dashboard/traces/traces-page.tsx
@@ -227,75 +227,77 @@ function TracesContent() {
 
       {/* Traces table */}
       <div className="overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-panel">
-        <table className="w-full border-collapse">
-          <thead>
-            <tr className="border-b border-edge">
-              <th className="w-[40%] px-3 py-2 text-left">
-                <ColLabel>Title</ColLabel>
-              </th>
-              <th className="px-3 py-2 text-left">
-                <ColLabel>Observations</ColLabel>
-              </th>
-              <th className="px-3 py-2 text-left">
-                <ColLabel>Tokens</ColLabel>
-              </th>
-              <th className="px-3 py-2 text-left">
-                <ColLabel>Cost</ColLabel>
-              </th>
-              <th className="px-3 py-2 text-left">
-                <ColLabel>Created</ColLabel>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {loading &&
-              ROW_SKEL.map((k) => (
-                <tr key={k} className="border-b border-edge-soft">
-                  <td colSpan={5} className="px-3 py-2">
-                    <div className="h-4 w-full animate-pulse rounded-[var(--radius)] bg-panel2" />
-                  </td>
-                </tr>
-              ))}
-            {!loading && traces.length === 0 && (
-              <tr>
-                <td colSpan={5} className="py-8 text-center text-[13px] text-fg-4">
-                  No traces found.
-                </td>
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse">
+            <thead>
+              <tr className="border-b border-edge">
+                <th className="w-[40%] px-3 py-2 text-left">
+                  <ColLabel>Title</ColLabel>
+                </th>
+                <th className="px-3 py-2 text-left">
+                  <ColLabel>Observations</ColLabel>
+                </th>
+                <th className="px-3 py-2 text-left">
+                  <ColLabel>Tokens</ColLabel>
+                </th>
+                <th className="px-3 py-2 text-left">
+                  <ColLabel>Cost</ColLabel>
+                </th>
+                <th className="px-3 py-2 text-left">
+                  <ColLabel>Created</ColLabel>
+                </th>
               </tr>
-            )}
-            {traces.map((t) => {
-              const isActive = selectedId === t.id;
-              return (
-                <tr
-                  key={t.id}
-                  className={`cursor-pointer border-b border-edge-soft text-[13px] transition-[background-color] duration-150 hover:bg-panel2 ${
-                    isActive ? "bg-panel2" : ""
-                  }`}
-                  onClick={() => {
-                    const url = new URL(window.location.href);
-                    if (isActive) {
-                      url.searchParams.delete("id");
-                    } else {
-                      url.searchParams.set("id", t.id);
-                    }
-                    window.history.pushState({}, "", url.toString());
-                    window.dispatchEvent(new PopStateEvent("popstate"));
-                  }}
-                >
-                  <td className="px-3 py-2 font-medium text-fg">
-                    {t.title ?? <span className="text-fg-4">Untitled</span>}
+            </thead>
+            <tbody>
+              {loading &&
+                ROW_SKEL.map((k) => (
+                  <tr key={k} className="border-b border-edge-soft">
+                    <td colSpan={5} className="px-3 py-2">
+                      <div className="h-4 w-full animate-pulse rounded-[var(--radius)] bg-panel2" />
+                    </td>
+                  </tr>
+                ))}
+              {!loading && traces.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="py-8 text-center text-[13px] text-fg-4">
+                    No traces found.
                   </td>
-                  <td className="num px-3 py-2 text-fg-2">{t.message_count}</td>
-                  <td className="num px-3 py-2 text-fg-2">{formatTokens(t.total_tokens)}</td>
-                  <td className="num px-3 py-2 text-fg-2">
-                    {formatCost(t.total_cost_microdollars)}
-                  </td>
-                  <td className="num px-3 py-2 text-fg-3">{formatDate(t.created_at)}</td>
                 </tr>
-              );
-            })}
-          </tbody>
-        </table>
+              )}
+              {traces.map((t) => {
+                const isActive = selectedId === t.id;
+                return (
+                  <tr
+                    key={t.id}
+                    className={`cursor-pointer border-b border-edge-soft text-[13px] transition-[background-color] duration-150 hover:bg-panel2 ${
+                      isActive ? "bg-panel2" : ""
+                    }`}
+                    onClick={() => {
+                      const url = new URL(window.location.href);
+                      if (isActive) {
+                        url.searchParams.delete("id");
+                      } else {
+                        url.searchParams.set("id", t.id);
+                      }
+                      window.history.pushState({}, "", url.toString());
+                      window.dispatchEvent(new PopStateEvent("popstate"));
+                    }}
+                  >
+                    <td className="px-3 py-2 font-medium text-fg">
+                      {t.title ?? <span className="text-fg-4">Untitled</span>}
+                    </td>
+                    <td className="num px-3 py-2 text-fg-2">{t.message_count}</td>
+                    <td className="num px-3 py-2 text-fg-2">{formatTokens(t.total_tokens)}</td>
+                    <td className="num px-3 py-2 text-fg-2">
+                      {formatCost(t.total_cost_microdollars)}
+                    </td>
+                    <td className="num px-3 py-2 text-fg-3">{formatDate(t.created_at)}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       </div>
 
       {hasMore && (

--- a/packages/dashboard/src/components/ui/card.tsx
+++ b/packages/dashboard/src/components/ui/card.tsx
@@ -1,12 +1,6 @@
 import type { ReactNode } from "react";
 
-export function Card({
-  className = "",
-  children,
-}: {
-  className?: string;
-  children?: ReactNode;
-}) {
+export function Card({ className = "", children }: { className?: string; children?: ReactNode }) {
   return (
     <div className={`rounded-[var(--radius-lg)] border border-edge bg-panel ${className}`}>
       {children}

--- a/packages/dashboard/src/pages/index.astro
+++ b/packages/dashboard/src/pages/index.astro
@@ -27,9 +27,21 @@ const store  = createAISDKChatStore(state);
 const chatId = await store.createChat();
 await store.saveChat({ chatId, messages });`;
 const features: [string, string, string][] = [
-  ["State", "Any state, typed", "Threads, UI messages, RSC payloads, graph checkpoints — stored as typed v2 state under any key."],
-  ["Adapt", "Drop-in adapters", "First-class stores for AI SDK, TanStack, LangGraph and Cloudflare Agents. Or raw REST."],
-  ["Ops", "Usage & tracing", "Volume, tokens, cost and active projects — tracked per key, with request-level traces."],
+  [
+    "State",
+    "Any state, typed",
+    "Threads, UI messages, RSC payloads, graph checkpoints — stored as typed v2 state under any key.",
+  ],
+  [
+    "Adapt",
+    "Drop-in adapters",
+    "First-class stores for AI SDK, TanStack, LangGraph and Cloudflare Agents. Or raw REST.",
+  ],
+  [
+    "Ops",
+    "Usage & tracing",
+    "Volume, tokens, cost and active projects — tracked per key, with request-level traces.",
+  ],
 ];
 ---
 <MarketingLayout>

--- a/packages/dashboard/src/styles/tokens.css
+++ b/packages/dashboard/src/styles/tokens.css
@@ -52,8 +52,14 @@ body {
 ::selection {
   background: color-mix(in srgb, var(--color-accent) 30%, transparent);
 }
-h1, h2, h3 { text-wrap: balance; }
-p { text-wrap: pretty; }
+h1,
+h2,
+h3 {
+  text-wrap: balance;
+}
+p {
+  text-wrap: pretty;
+}
 .num {
   font-variant-numeric: tabular-nums;
 }


### PR DESCRIPTION
## What

Dashboard UX hardening for mobile + auth, all in the shell/navigation layer.

- **Mobile drawer sidebar** — a hamburger toggle in the header opens a slide-in drawer below `lg`. The desktop sidebar was `hidden … lg:flex`, so below 1024px there was *no navigation at all*. Drawer closes on backdrop click, the ✕ button, `Escape`, and on nav-select; background scroll locks while open.
- **User avatar in top menu** — replaced the static initials circle with Clerk `<UserButton />` (real avatar + account menu). Also adds **sign-out**, which was missing from the dashboard entirely.
- **Auth redirect** — `<SignIn>` now sends users to `/dashboard` after sign-in **and** sign-up (previously it stayed on whatever URL the gate rendered on).
- **Traces table** — wrapped in `overflow-x-auto` so the 5-column table scrolls on narrow screens instead of cramping. (Projects table already collapses via `hidden sm:table-cell` columns — unchanged.)

## Verification
- `bun run build` — 13/13 pages ✅
- `bunx biome check` on changed files — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile navigation drawer with menu controls that closes when selecting a route.

* **Bug Fixes**
  * Improved authentication flow by displaying sign-in component for unauthenticated users.
  * Enhanced traces table with horizontal scrolling support for improved mobile experience.
  * Simplified header interface with streamlined user controls.

* **Refactor**
  * Code formatting and structural improvements for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->