### PR TITLE
feat(dashboard): light/dark mode with theme toggle

### DIFF
--- a/packages/dashboard/src/components/app-shell.tsx
+++ b/packages/dashboard/src/components/app-shell.tsx
@@ -233,6 +233,46 @@ export function AppShell({ children }: { children: ReactNode }) {
             </button>
             <Breadcrumb pathname={pathname} />
             <div className="ml-auto flex items-center gap-2">
+              <button
+                type="button"
+                data-theme-toggle
+                aria-label="Toggle color theme"
+                className="grid size-8 place-items-center rounded-[var(--radius)] border border-edge text-fg-3 transition-[background-color,color] hover:bg-panel2 hover:text-fg"
+              >
+                <span className="icon-moon">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="15"
+                    height="15"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8z" />
+                  </svg>
+                </span>
+                <span className="icon-sun">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="15"
+                    height="15"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <circle cx="12" cy="12" r="4" />
+                    <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+                  </svg>
+                </span>
+              </button>
               {user && (
                 <span className="hidden text-[13px] text-fg-3 sm:inline">
                   {user.fullName ?? user.primaryEmailAddress?.emailAddress}

--- a/packages/dashboard/src/components/theme-script.astro
+++ b/packages/dashboard/src/components/theme-script.astro
@@ -1,0 +1,28 @@
+---
+/**
+ * Inline (pre-hydration) theme script — included in <head> by both layouts.
+ * 1. Applies the saved/system theme before paint (no FOUC).
+ * 2. Delegates clicks on any [data-theme-toggle] to flip + persist the theme.
+ * `is:inline` so it runs immediately and is not bundled/delayed.
+ */
+---
+{/* biome-ignore lint/security/noDangerouslySetInnerHtml: theme detection must run before hydration */}
+<script
+  is:inline
+  set:html={`(function () {
+  var el = document.documentElement;
+  var d = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  el.classList.toggle('dark', d);
+  el.setAttribute('data-mode', d ? 'dark' : 'light');
+  el.setAttribute('data-theme', d ? 'dark' : 'light');
+  document.addEventListener('click', function (e) {
+    var b = e.target.closest && e.target.closest('[data-theme-toggle]');
+    if (!b) return;
+    var next = el.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    el.classList.toggle('dark', next === 'dark');
+    el.setAttribute('data-mode', next);
+    el.setAttribute('data-theme', next);
+    try { localStorage.theme = next; } catch (_) {}
+  });
+})();`}
+/>

--- a/packages/dashboard/src/components/ui/button.astro
+++ b/packages/dashboard/src/components/ui/button.astro
@@ -11,7 +11,7 @@ const { variant = "secondary", href, class: cls = "", ...rest } = Astro.props;
 const base =
   "inline-flex min-h-[40px] items-center justify-center gap-1.5 rounded-[var(--radius)] px-4 py-2.5 text-[13px] font-medium transition-[background-color,color,border-color,transform] duration-150 active:scale-[0.96] disabled:opacity-50 disabled:pointer-events-none disabled:active:scale-100";
 const variants: Record<NonNullable<Props["variant"]>, string> = {
-  primary: "bg-white text-black hover:bg-zinc-200",
+  primary: "bg-fg text-base hover:opacity-90",
   secondary: "border border-edge text-fg hover:bg-panel2",
   ghost: "text-fg-3 hover:text-fg hover:bg-panel2",
   danger: "border border-neg/40 bg-neg/10 text-neg hover:bg-neg/20",

--- a/packages/dashboard/src/components/ui/button.tsx
+++ b/packages/dashboard/src/components/ui/button.tsx
@@ -11,7 +11,7 @@ const base =
   "inline-flex min-h-[40px] items-center justify-center gap-1.5 rounded-[var(--radius)] px-4 py-2.5 text-[13px] font-medium transition-[background-color,color,border-color,transform] duration-150 active:scale-[0.96] disabled:opacity-50 disabled:pointer-events-none disabled:active:scale-100";
 
 const variants: Record<Variant, string> = {
-  primary: "bg-white text-black hover:bg-zinc-200",
+  primary: "bg-fg text-base hover:opacity-90",
   secondary: "border border-edge text-fg hover:bg-panel2",
   ghost: "text-fg-3 hover:text-fg hover:bg-panel2",
   danger: "border border-neg/40 bg-neg/10 text-neg hover:bg-neg/20",

--- a/packages/dashboard/src/layouts/MarketingLayout.astro
+++ b/packages/dashboard/src/layouts/MarketingLayout.astro
@@ -3,6 +3,7 @@ import "../styles/tokens.css";
 import "@fontsource-variable/geist";
 import "@fontsource-variable/geist-mono";
 import Logo from "../components/logo.astro";
+import ThemeScript from "../components/theme-script.astro";
 
 interface Props {
   title?: string;
@@ -20,7 +21,7 @@ const {
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>{title}</title>
     <meta name="description" content={description} />
-    <meta name="color-scheme" content="dark" />
+    <ThemeScript />
   </head>
   <body class="min-h-screen bg-base text-fg-2">
     <!-- top nav -->
@@ -33,8 +34,26 @@ const {
           <a href="https://github.com/duyet/agentstate" class="hover:text-fg">GitHub</a>
         </nav>
         <div class="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            data-theme-toggle
+            aria-label="Toggle color theme"
+            class="grid size-8 place-items-center rounded-[var(--radius)] border border-edge text-fg-3 transition-[background-color,color] hover:bg-panel2 hover:text-fg"
+          >
+            <span class="icon-moon"
+              ><svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path
+                  d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8z" /></svg></span
+            >
+            <span class="icon-sun"
+              ><svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle
+                  cx="12"
+                  cy="12"
+                  r="4" /><path
+                  d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" /></svg></span
+            >
+          </button>
           <a href="/dashboard" class="rounded-[var(--radius)] border border-edge px-3.5 py-1.5 text-[13px] text-fg hover:bg-panel2">Sign in</a>
-          <a href="/dashboard" class="rounded-[var(--radius)] bg-white px-3.5 py-1.5 text-[13px] font-medium text-black hover:bg-zinc-200">Open dashboard</a>
+          <a href="/dashboard" class="rounded-[var(--radius)] bg-fg px-3.5 py-1.5 text-[13px] font-medium text-base hover:opacity-90">Open dashboard</a>
         </div>
       </div>
     </header>

--- a/packages/dashboard/src/layouts/RootLayout.astro
+++ b/packages/dashboard/src/layouts/RootLayout.astro
@@ -3,6 +3,7 @@ import "@fontsource-variable/space-grotesk";
 import "@fontsource-variable/hanken-grotesk";
 import "@fontsource-variable/jetbrains-mono";
 import "../styles/global.css";
+import ThemeScript from "../components/theme-script.astro";
 
 interface Props {
   title?: string;
@@ -27,14 +28,7 @@ const {
     <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png" />
     <link rel="icon" type="image/png" media="(prefers-color-scheme: light)" href="/brand/favicon-light-32.png" />
     <link rel="icon" type="image/png" media="(prefers-color-scheme: dark)" href="/brand/favicon-dark-32.png" />
-    {/* biome-ignore lint/security/noDangerouslySetInnerHtml: theme detection must run before hydration */}
-    <script is:inline set:html={`(function () {
-      var d = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
-      var el = document.documentElement;
-      el.classList.toggle('dark', d);
-      el.setAttribute('data-mode', d ? 'dark' : 'light');
-      el.setAttribute('data-theme', d ? 'dark' : 'light');
-    })();`} />
+    <ThemeScript />
   </head>
   <body class="antialiased">
     <slot />

--- a/packages/dashboard/src/pages/brand.astro
+++ b/packages/dashboard/src/pages/brand.astro
@@ -118,7 +118,7 @@ const iconAssets = [
         {logoAssets.map((a) => (
           <div class="overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-panel">
             <div
-              class={`flex h-32 items-center justify-center ${a.surface === "light" ? "bg-zinc-100" : "bg-panel"}`}
+              class={`flex h-32 items-center justify-center ${a.surface === "light" ? "bg-zinc-100" : "bg-[#09090b]"}`}
               style={`color-scheme:${a.surface === "light" ? "light" : "dark"}`}
             >
               <img src={`/brand/${a.file}`} alt={`${a.label} (${a.fmt})`} class="h-16 w-16" loading="lazy" />
@@ -154,7 +154,7 @@ const iconAssets = [
       <div class="grid grid-cols-2 gap-3 lg:grid-cols-4">
         {iconAssets.map((a) => (
           <div class="overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-panel">
-            <div class={`flex h-28 items-center justify-center ${a.surface === "light" ? "bg-zinc-100" : "bg-panel2"}`}>
+            <div class={`flex h-28 items-center justify-center ${a.surface === "light" ? "bg-zinc-100" : "bg-[#0f0f11]"}`}>
               <img
                 src={`/brand/${a.file}`}
                 alt={a.label}
@@ -325,7 +325,7 @@ const iconAssets = [
         <Logo size={32} class="mx-auto text-fg" />
         <h2 class="mt-5 text-[28px] font-semibold tracking-[-0.03em] text-fg sm:text-[32px]">One mark. Many runtimes.</h2>
         <p class="mx-auto mt-4 max-w-[460px] text-fg-3">Persistent state for every agent framework — behind one small API.</p>
-        <a href="/dashboard" class="mt-8 inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-white px-5 py-2.5 text-[14px] font-medium text-black hover:bg-zinc-200">Open dashboard →</a>
+        <a href="/dashboard" class="mt-8 inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-fg px-5 py-2.5 text-[14px] font-medium text-base hover:opacity-90">Open dashboard →</a>
       </div>
     </section>
 

--- a/packages/dashboard/src/pages/docs.astro
+++ b/packages/dashboard/src/pages/docs.astro
@@ -141,7 +141,7 @@ await store.saveChat({ chatId, messages });`;
             href="https://github.com/duyet/agentstate"
             target="_blank"
             rel="noreferrer"
-            class="inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-white px-4 py-2 text-[13px] font-medium text-black hover:bg-zinc-200"
+            class="inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-fg px-4 py-2 text-[13px] font-medium text-base hover:opacity-90"
           >
             GitHub ↗
           </a>
@@ -160,7 +160,7 @@ await store.saveChat({ chatId, messages });`;
         </p>
         <div class="mt-3.5 overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-[#0c0c0e]">
           <div class="flex h-9 items-center border-b border-edge-soft px-4 font-mono text-[11px] text-fg-4">quickstart.ts</div>
-          <pre class="overflow-auto p-4 font-mono text-[12.5px] leading-[1.75] text-zinc-300"><code>{quickCode}</code></pre>
+          <pre class="overflow-auto rounded-[var(--radius)] border border-edge bg-[#0c0c0e] p-4 font-mono text-[12.5px] leading-[1.75] text-zinc-300"><code>{quickCode}</code></pre>
         </div>
 
         <!-- Authentication -->
@@ -171,7 +171,7 @@ await store.saveChat({ chatId, messages });`;
         </p>
         <div class="mt-3.5 overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-[#0c0c0e]">
           <div class="flex h-9 items-center border-b border-edge-soft px-4 font-mono text-[11px] text-fg-4">auth.sh</div>
-          <pre class="overflow-auto p-4 font-mono text-[12.5px] leading-[1.75] text-zinc-300"><code>{authCode}</code></pre>
+          <pre class="overflow-auto rounded-[var(--radius)] border border-edge bg-[#0c0c0e] p-4 font-mono text-[12.5px] leading-[1.75] text-zinc-300"><code>{authCode}</code></pre>
         </div>
         <div class="mt-3.5 flex gap-2.5 rounded-[var(--radius-lg)] border border-edge bg-panel2 px-3.5 py-3">
           <span class="mt-px size-1.5 flex-shrink-0 rounded-full bg-accent"></span>
@@ -208,7 +208,7 @@ await store.saveChat({ chatId, messages });`;
         </p>
         <div class="mt-3.5 overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-[#0c0c0e]">
           <div class="flex h-9 items-center border-b border-edge-soft px-4 font-mono text-[11px] text-fg-4">ai-sdk.ts</div>
-          <pre class="overflow-auto p-4 font-mono text-[12.5px] leading-[1.75] text-zinc-300"><code>{adapterCode}</code></pre>
+          <pre class="overflow-auto rounded-[var(--radius)] border border-edge bg-[#0c0c0e] p-4 font-mono text-[12.5px] leading-[1.75] text-zinc-300"><code>{adapterCode}</code></pre>
         </div>
         <div class="mt-3.5 grid grid-cols-1 gap-px overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-edge sm:grid-cols-2">
           {

--- a/packages/dashboard/src/pages/index.astro
+++ b/packages/dashboard/src/pages/index.astro
@@ -57,7 +57,7 @@ const features: [string, string, string][] = [
           Store conversations, UI messages and graph state behind one API. Drop-in adapters for every framework you already use — stop rebuilding the memory backend.
         </p>
         <div class="mt-9 flex flex-wrap items-center gap-3">
-          <a href="/dashboard" class="inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-white px-5 py-2.5 text-[14px] font-medium text-black hover:bg-zinc-200">Open dashboard →</a>
+          <a href="/dashboard" class="inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-fg px-5 py-2.5 text-[14px] font-medium text-base hover:opacity-90">Open dashboard →</a>
           <a href="/docs" class="inline-flex items-center gap-1.5 rounded-[var(--radius)] border border-edge px-5 py-2.5 text-[14px] text-fg hover:bg-panel2">Read the docs</a>
         </div>
       </div>
@@ -143,7 +143,7 @@ const features: [string, string, string][] = [
       <div class="mx-auto max-w-[680px] px-5">
         <h2 class="text-[30px] font-semibold tracking-[-0.03em] text-fg sm:text-[36px]">Ship the agent,<br />not the backend.</h2>
         <p class="mx-auto mt-4 max-w-[460px] text-fg-3">Spin up a project, grab a key, and persist your first session in two minutes.</p>
-        <a href="/dashboard" class="mt-8 inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-white px-5 py-2.5 text-[14px] font-medium text-black hover:bg-zinc-200">Open dashboard →</a>
+        <a href="/dashboard" class="mt-8 inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-fg px-5 py-2.5 text-[14px] font-medium text-base hover:opacity-90">Open dashboard →</a>
       </div>
     </section>
   </main>

--- a/packages/dashboard/src/styles/tokens.css
+++ b/packages/dashboard/src/styles/tokens.css
@@ -6,7 +6,7 @@
 
 @custom-variant dark (&:is(.dark *));
 
-@theme inline {
+@theme {
   /* type */
   --font-sans: "Geist", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   --font-mono: "Geist Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
@@ -35,6 +35,39 @@
   --radius-sm: 6px;
   --radius: 8px;
   --radius-lg: 12px;
+}
+
+/*
+ * Light theme — flips the tokens. The `data-theme` attribute is set on <html>
+ * by the inline theme scripts in RootLayout / MarketingLayout (load-time,
+ * before paint, to avoid FOUC) and toggled by [data-theme-toggle] buttons.
+ * `:root[data-theme="light"]` outranks the default `:root` emission, so every
+ * bg / text / border utility that references these vars flips automatically.
+ */
+:root[data-theme="light"] {
+  color-scheme: light;
+
+  --color-base: #fafafa; /* app canvas */
+  --color-panel: #ffffff; /* cards, table head */
+  --color-panel2: #f4f4f5; /* hover / elevated */
+  --color-edge: #e4e4e7; /* primary borders */
+  --color-edge-soft: #ededee; /* subtle borders */
+
+  --color-fg: #18181b; /* headings / strong */
+  --color-fg-2: #3f3f46; /* body */
+  --color-fg-3: #71717a; /* muted */
+  --color-fg-4: #a1a1aa; /* faint */
+
+  --color-accent: #2563eb; /* slightly deeper for light-bg contrast */
+  --color-pos: #059669;
+  --color-warn: #d97706;
+  --color-neg: #dc2626;
+}
+
+/* theme toggle — reveal the icon matching the active theme */
+:root[data-theme="dark"] .icon-sun,
+:root[data-theme="light"] .icon-moon {
+  display: none;
 }
 
 /* base */


### PR DESCRIPTION
## What
Site-wide light/dark mode with a toggle, built on the existing token system + the pre-existing `RootLayout` theme-detection script.

### How
- **`tokens.css`**: dropped `@theme inline` → `@theme` so color utilities emit `var(--color-*)` (verified: were literals, now switchable). Added a `:root[data-theme=light]` block with an inverse-zinc palette + toggle-icon visibility rules. One file flips almost the whole site.
- **`theme-script.astro`** (new): shared pre-hydration script — load-time theme detection (no FOUC, runs before paint) + a delegated `[data-theme-toggle]` click handler. Wired into **both** layouts (RootLayout already had the detector; MarketingLayout had none — hardcoded dark).
- **Toggle button** (sun/moon, CSS-driven on `html[data-theme]`) in the marketing nav **and** the dashboard header. Persists to `localStorage.theme`, respects system `prefers-color-scheme` as default.
- **Theme-aware CTAs**: `bg-white text-black` → `bg-fg text-base` (auto-inverts per theme — strictly better than the static original). Docs code blocks + brand showcase surfaces made fixed-dark (intentional).

## Verification
- `bun run build` — 13/13 ✅
- Headless screenshots on landing + `/brand` in **both** themes: dark unchanged, light renders correctly (CTAs invert, code blocks stay dark, showcase surfaces correct). Toggle click verified dark↔light; `data-theme` persists across navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>