### PR TITLE
feat(dashboard): x.ai-style scroll-reveal on marketing pages

### DIFF
--- a/packages/dashboard/src/components/reveal-script.astro
+++ b/packages/dashboard/src/components/reveal-script.astro
@@ -1,0 +1,26 @@
+---
+/**
+ * Scroll-reveal — adds `.in` to [data-reveal] elements as they enter the
+ * viewport, triggering the CSS transition in global.css. No-op under
+ * prefers-reduced-motion (the CSS keeps those elements visible).
+ * Included at end of <body> so the observed elements already exist.
+ */
+---
+<script
+  is:inline
+  set:html={`(function () {
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+  var els = document.querySelectorAll('[data-reveal]');
+  if (!els.length) return;
+  if (!('IntersectionObserver' in window)) {
+    els.forEach(function (el) { el.classList.add('in'); });
+    return;
+  }
+  var io = new IntersectionObserver(function (entries) {
+    entries.forEach(function (e) {
+      if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); }
+    });
+  }, { rootMargin: '0px 0px -8% 0px', threshold: 0.08 });
+  els.forEach(function (el) { io.observe(el); });
+})();`}
+/>

--- a/packages/dashboard/src/layouts/MarketingLayout.astro
+++ b/packages/dashboard/src/layouts/MarketingLayout.astro
@@ -3,6 +3,7 @@ import "../styles/tokens.css";
 import "@fontsource-variable/geist";
 import "@fontsource-variable/geist-mono";
 import Logo from "../components/logo.astro";
+import RevealScript from "../components/reveal-script.astro";
 import ThemeScript from "../components/theme-script.astro";
 
 interface Props {
@@ -64,5 +65,6 @@ const {
         <span>© 2026 AgentState · MIT · built on Cloudflare D1</span>
       </div>
     </footer>
+    <RevealScript />
   </body>
 </html>

--- a/packages/dashboard/src/pages/brand.astro
+++ b/packages/dashboard/src/pages/brand.astro
@@ -88,7 +88,7 @@ const iconAssets = [
 >
   <main>
     <!-- header -->
-    <section class="mx-auto max-w-[1040px] px-5 pt-24 pb-12 sm:pt-32">
+    <section data-reveal class="mx-auto max-w-[1040px] px-5 pt-24 pb-12 sm:pt-32">
       <div class="max-w-[820px]">
         <Badge>Brand sheet</Badge>
         <h1 class="mt-5 text-[40px] font-semibold leading-[1.02] tracking-[-0.03em] text-fg sm:text-[56px]">
@@ -102,7 +102,7 @@ const iconAssets = [
     </section>
 
     <!-- brand assets (downloads) -->
-    <section class="mx-auto max-w-[1040px] px-5 pb-24">
+    <section data-reveal class="mx-auto max-w-[1040px] px-5 pb-24">
       <div class="mb-3 font-mono text-[11px] uppercase tracking-[0.15em] text-fg-4">Brand assets</div>
       <h2 class="max-w-[620px] text-[30px] font-semibold leading-[1.05] tracking-[-0.03em] text-fg sm:text-[36px]">
         Logos, ready to use.
@@ -188,7 +188,7 @@ const iconAssets = [
     </section>
 
     <!-- logo lockups -->
-    <section class="mx-auto max-w-[1040px] px-5 pb-24">
+    <section data-reveal class="mx-auto max-w-[1040px] px-5 pb-24">
       <div class="mb-6 font-mono text-[11px] uppercase tracking-[0.15em] text-fg-4">Logo</div>
       <div class="grid grid-cols-1 gap-px overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-edge sm:grid-cols-2 lg:grid-cols-3">
         <div class="flex flex-col bg-panel">
@@ -226,7 +226,7 @@ const iconAssets = [
     </section>
 
     <!-- color: surfaces -->
-    <section class="mx-auto max-w-[1040px] px-5 pb-24">
+    <section data-reveal class="mx-auto max-w-[1040px] px-5 pb-24">
       <div class="mb-6 font-mono text-[11px] uppercase tracking-[0.15em] text-fg-4">Color · surfaces</div>
       <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
         {surfaces.map((c) => <Swatch name={c.name} hex={c.hex} note={c.note} />)}
@@ -234,7 +234,7 @@ const iconAssets = [
     </section>
 
     <!-- color: text + accents -->
-    <section class="mx-auto max-w-[1040px] px-5 pb-24">
+    <section data-reveal class="mx-auto max-w-[1040px] px-5 pb-24">
       <div class="grid grid-cols-1 gap-12 lg:grid-cols-2">
         <div>
           <div class="mb-6 font-mono text-[11px] uppercase tracking-[0.15em] text-fg-4">Color · text</div>
@@ -248,7 +248,7 @@ const iconAssets = [
     </section>
 
     <!-- typography -->
-    <section class="mx-auto max-w-[1040px] px-5 pb-24">
+    <section data-reveal class="mx-auto max-w-[1040px] px-5 pb-24">
       <div class="mb-6 font-mono text-[11px] uppercase tracking-[0.15em] text-fg-4">Typography</div>
       <div class="grid grid-cols-1 gap-3 lg:grid-cols-2">
         <Card class="p-6">
@@ -271,7 +271,7 @@ const iconAssets = [
     </section>
 
     <!-- shape: radius -->
-    <section class="mx-auto max-w-[1040px] px-5 pb-24">
+    <section data-reveal class="mx-auto max-w-[1040px] px-5 pb-24">
       <div class="mb-6 font-mono text-[11px] uppercase tracking-[0.15em] text-fg-4">Shape</div>
       <div class="grid grid-cols-2 gap-3 sm:grid-cols-3">
         <Card class="p-6">
@@ -290,7 +290,7 @@ const iconAssets = [
     </section>
 
     <!-- guidelines -->
-    <section class="border-t border-edge-soft">
+    <section data-reveal class="border-t border-edge-soft">
       <div class="mx-auto max-w-[1040px] px-5 py-24">
         <div class="mb-3 font-mono text-[11px] uppercase tracking-wider text-fg-4">Guidelines</div>
         <h2 class="max-w-[620px] text-[30px] font-semibold leading-[1.05] tracking-[-0.03em] text-fg sm:text-[36px]">
@@ -320,7 +320,7 @@ const iconAssets = [
     </section>
 
     <!-- CTA -->
-    <section class="border-t border-edge-soft py-24 text-center">
+    <section data-reveal class="border-t border-edge-soft py-24 text-center">
       <div class="mx-auto max-w-[680px] px-5">
         <Logo size={32} class="mx-auto text-fg" />
         <h2 class="mt-5 text-[28px] font-semibold tracking-[-0.03em] text-fg sm:text-[32px]">One mark. Many runtimes.</h2>

--- a/packages/dashboard/src/pages/index.astro
+++ b/packages/dashboard/src/pages/index.astro
@@ -47,7 +47,7 @@ const features: [string, string, string][] = [
 <MarketingLayout>
   <main>
     <!-- hero -->
-    <section class="mx-auto max-w-[1040px] px-5 pt-24 pb-16 sm:pt-32">
+    <section data-reveal class="mx-auto max-w-[1040px] px-5 pt-24 pb-16 sm:pt-32">
       <div class="max-w-[820px]">
         <span class="inline-flex items-center gap-2 rounded-full border border-edge px-3 py-1 text-[12.5px] text-fg-3"><span class="size-1.5 rounded-full bg-accent"></span>v2 state API · graph checkpoints &amp; tracing</span>
         <h1 class="mt-7 text-[44px] font-semibold leading-[0.98] tracking-[-0.04em] text-fg sm:text-[68px]">
@@ -64,7 +64,7 @@ const features: [string, string, string][] = [
     </section>
 
     <!-- code -->
-    <section class="mx-auto max-w-[1040px] px-5 pb-24">
+    <section data-reveal class="mx-auto max-w-[1040px] px-5 pb-24">
       <Card class="overflow-hidden p-0">
         <div class="flex h-10 items-center gap-2 border-b border-edge-soft px-4">
           <span class="size-2.5 rounded-full bg-fg-4/60"></span>
@@ -77,7 +77,7 @@ const features: [string, string, string][] = [
     </section>
 
     <!-- adapters -->
-    <section class="mx-auto max-w-[1040px] px-5 pb-24">
+    <section data-reveal class="mx-auto max-w-[1040px] px-5 pb-24">
       <div class="mb-6 font-mono text-[11px] uppercase tracking-[0.15em] text-fg-4">Works with your stack</div>
       <div class="grid grid-cols-2 gap-px overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-edge sm:grid-cols-4 lg:grid-cols-7">
         {adapters.map(([name, pkg]) => (
@@ -90,7 +90,7 @@ const features: [string, string, string][] = [
     </section>
 
     <!-- features: editorial list (not 3-equal cards) -->
-    <section class="mx-auto max-w-[1040px] px-5 pb-24">
+    <section data-reveal class="mx-auto max-w-[1040px] px-5 pb-24">
       <div class="mb-6 font-mono text-[11px] uppercase tracking-[0.15em] text-fg-4">What it does</div>
       <ul class="divide-y divide-edge-soft border-y border-edge-soft">
         {features.map(([tag, title, desc]) => (
@@ -106,7 +106,7 @@ const features: [string, string, string][] = [
     </section>
 
     <!-- API -->
-    <section class="border-t border-edge-soft">
+    <section data-reveal class="border-t border-edge-soft">
       <div class="mx-auto max-w-[1040px] px-5 py-24">
         <div class="mb-3 font-mono text-[11px] uppercase tracking-wider text-fg-4">API surface</div>
         <h2 class="max-w-[620px] text-[34px] font-semibold leading-[1.05] tracking-[-0.03em] text-fg sm:text-[40px]">
@@ -139,7 +139,7 @@ const features: [string, string, string][] = [
     </section>
 
     <!-- CTA -->
-    <section class="border-t border-edge-soft py-24 text-center">
+    <section data-reveal class="border-t border-edge-soft py-24 text-center">
       <div class="mx-auto max-w-[680px] px-5">
         <h2 class="text-[30px] font-semibold tracking-[-0.03em] text-fg sm:text-[36px]">Ship the agent,<br />not the backend.</h2>
         <p class="mx-auto mt-4 max-w-[460px] text-fg-3">Spin up a project, grab a key, and persist your first session in two minutes.</p>

--- a/packages/dashboard/src/styles/tokens.css
+++ b/packages/dashboard/src/styles/tokens.css
@@ -96,3 +96,25 @@ p {
 .num {
   font-variant-numeric: tabular-nums;
 }
+
+/* ---- scroll reveal (IntersectionObserver toggles .in; reveal-script.astro) ----
+   Lives in tokens.css so BOTH layouts (MarketingLayout + RootLayout) load it.
+   Easing matches x.ai's transform motion: cubic-bezier(0,0,0.2,1) ease-out. */
+[data-reveal] {
+  opacity: 0;
+  transform: translateY(14px);
+  transition:
+    opacity 0.5s cubic-bezier(0, 0, 0.2, 1) var(--reveal-delay, 0ms),
+    transform 0.5s cubic-bezier(0, 0, 0.2, 1) var(--reveal-delay, 0ms);
+}
+[data-reveal].in {
+  opacity: 1;
+  transform: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-reveal] {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
## What
A tasteful, restrained scroll-reveal motion system across the marketing pages, learned from inspecting **x.ai's** actual motion CSS.

### Grounded in x.ai
Probed x.ai's computed styles: their reveal mechanic is an IntersectionObserver toggling `visible`/`invisible` classes, with `transform 0.5s cubic-bezier(0,0,0.2,1)` (ease-out). This PR mirrors that: opacity + translateY reveal, the same easing.

### How
- `reveal-script.astro` (new): IntersectionObserver adds `.in` to `[data-reveal]` as they enter the viewport. No-op under `prefers-reduced-motion`.
- Reveal CSS in **`tokens.css`** (not `global.css`) so **both** layouts load it — marketing pages only import `tokens.css`.
- Applied `data-reveal` to every landing + `/brand` section.
- **Dashboard intentionally left instant** — it's a data app; animating tables/analytics on scroll would hurt UX. "Across page" = the marketing surface.

## Verification
- `bun run build` — 13/13 ✅
- Headless check: on load 2/6 above-fold sections revealed, 4 below-fold at `opacity:0`; after scroll all 6 revealed. Reduced-motion guard forces visible + skips observer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>