### PR TITLE
fix(dashboard): /brand adaptive mark black-on-white + horizontal lockup

### DIFF
--- a/packages/dashboard/public/brand/agentstate-lockup-dark.svg
+++ b/packages/dashboard/public/brand/agentstate-lockup-dark.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 176 36" width="704" height="144" role="img" aria-label="AgentState (white, for dark backgrounds)">
+  <title>AgentState</title>
+  <g transform="translate(0 6)">
+    <rect x="3" y="4" width="18" height="4" rx="2" fill="#fafafa" fill-opacity="0.35" />
+    <rect x="3" y="10" width="18" height="4" rx="2" fill="#fafafa" fill-opacity="0.65" />
+    <rect x="3" y="16" width="18" height="4" rx="2" fill="#fafafa" />
+  </g>
+  <text x="32" y="25" font-family="Geist, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="19" font-weight="600" letter-spacing="-0.01em" fill="#fafafa">AgentState</text>
+</svg>

--- a/packages/dashboard/public/brand/agentstate-lockup.svg
+++ b/packages/dashboard/public/brand/agentstate-lockup.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 176 36" width="704" height="144" role="img" aria-label="AgentState">
+  <title>AgentState</title>
+  <style>
+    .c { fill: #0a0a0a; }
+    @media (prefers-color-scheme: dark) { .c { fill: #fafafa; } }
+  </style>
+  <g transform="translate(0 6)">
+    <rect class="c" x="3" y="4" width="18" height="4" rx="2" fill-opacity="0.35" />
+    <rect class="c" x="3" y="10" width="18" height="4" rx="2" fill-opacity="0.65" />
+    <rect class="c" x="3" y="16" width="18" height="4" rx="2" />
+  </g>
+  <text class="c" x="32" y="25" font-family="Geist, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="19" font-weight="600" letter-spacing="-0.01em">AgentState</text>
+</svg>

--- a/packages/dashboard/src/pages/brand.astro
+++ b/packages/dashboard/src/pages/brand.astro
@@ -33,12 +33,18 @@ const sizes = [16, 20, 28, 40, 56];
 // Downloadable brand assets — files live in public/brand/ (regenerable via
 // scripts/gen-brand-assets.ts). SITE is the hotlinkable origin.
 const SITE = "https://agentstate.app";
-const logoAssets = [
+const logoAssets: {
+  label: string;
+  fmt: string;
+  file: string;
+  surface: "light" | "dark";
+  wide?: boolean;
+}[] = [
   {
     label: "Primary mark",
     fmt: "SVG · adaptive",
     file: "agentstate-logo.svg",
-    surface: "dark" as const,
+    surface: "light" as const,
   },
   {
     label: "Primary mark",
@@ -57,6 +63,20 @@ const logoAssets = [
     fmt: "PNG · 512²",
     file: "agentstate-logo-dark.png",
     surface: "dark" as const,
+  },
+  {
+    label: "Horizontal lockup",
+    fmt: "SVG · adaptive",
+    file: "agentstate-lockup.svg",
+    surface: "light" as const,
+    wide: true,
+  },
+  {
+    label: "Horizontal lockup",
+    fmt: "SVG · white",
+    file: "agentstate-lockup-dark.svg",
+    surface: "dark" as const,
+    wide: true,
   },
 ];
 const iconAssets = [
@@ -121,7 +141,12 @@ const iconAssets = [
               class={`flex h-32 items-center justify-center ${a.surface === "light" ? "bg-zinc-100" : "bg-[#09090b]"}`}
               style={`color-scheme:${a.surface === "light" ? "light" : "dark"}`}
             >
-              <img src={`/brand/${a.file}`} alt={`${a.label} (${a.fmt})`} class="h-16 w-16" loading="lazy" />
+              <img
+                src={`/brand/${a.file}`}
+                alt={`${a.label} (${a.fmt})`}
+                class={a.wide ? "h-12 w-auto max-w-[78%]" : "h-16 w-16"}
+                loading="lazy"
+              />
             </div>
             <div class="flex items-center justify-between gap-3 border-t border-edge-soft px-4 py-3">
               <div class="min-w-0">


### PR DESCRIPTION
## What
Two fixes to the `/brand` logo section per review:

- **Adaptive primary mark now black-on-white**: the "Primary mark · SVG · adaptive" card preview was forced to dark surface (`color-scheme: dark`), so the adaptive SVG rendered its light layers → white-on-dark. Flipped the card to a light surface so it shows the default **black mark on white**.
- **Added a horizontal lockup** (logo + "AgentState" wordmark) as a downloadable asset — adaptive (black-on-white) and white-on-dark SVGs, with wide-aspect preview handling.

## Verification
- `bun run build` — 13/13 ✅
- Headless screenshots of the logo grid: adaptive card now black-on-white; both lockup cards render the mark + wordmark (loaded 704×144, displayed 235×48).

### Known limitation
The lockup SVGs use `<text>` with a `Geist → system-ui` font stack. Loaded via `<img>` or opened elsewhere, the wordmark renders in the viewer's available sans (close to Geist, not pixel-identical). Text→paths (font-embedded) would make it render identically everywhere — happy to do as a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new horizontal lockup logo variants in light and dark versions, now available for download.
  * Improved logo rendering with responsive sizing that automatically adjusts display based on the specific logo variant type.

* **Bug Fixes**
  * Fixed primary logo mark to correctly default to the light surface instead of dark.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->