### PR TITLE
fix(sdk): unbreak the dts build (baseUrl TS5101) — main CI is red

### DIFF
--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -4,7 +4,12 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "declaration": true,
-    "lib": ["ES2022", "DOM"]
+    "lib": ["ES2022", "DOM"],
+    // tsup's --dts build (rollup-plugin-dts) injects a `baseUrl`, which TS 5.9+
+    // escalates to error TS5101 (deprecated, removed in TS 7.0). We never set
+    // baseUrl ourselves; silence the injected-option deprecation so the dts
+    // build keeps working across TS upgrades.
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## What
Adds `"ignoreDeprecations": "6.0"` to `packages/sdk/tsconfig.json` so the SDK's `tsup --dts` build stops failing with `error TS5101: Option 'baseUrl' is deprecated`.

## Why
**`main` CI is currently red** (run for #181 failed), which blocks every PR and the auto-deploy job. tsup's `--dts` build (via `rollup-plugin-dts`) injects a `baseUrl` compiler option; TS 5.9+ escalates that deprecation to a hard error (removed in TS 7.0). CI runs `bun-version: latest`, so a recent TypeScript bump (around the #178 dep bump) turned a passing build into a failing one even though no SDK source changed. We never set `baseUrl` ourselves, so silencing the injected-option deprecation is the correct, minimal fix.

## Risk & rollback
- Risk: 🟢 build-config only. No source, no emitted-output, no API change. `ignoreDeprecations` only suppresses the deprecation diagnostic for an option we don't author.
- Rollback: revert this PR.

## Verification (local, TS 5.9.3)
- [x] `cd packages/sdk && bun run typecheck` — clean
- [x] `bun run build` — CJS/ESM/**DTS** all "Build success" (DTS was the failing step)
- [x] `bun run test` — 12 passed / 2 skipped
- [x] Commit contains only `packages/sdk/tsconfig.json`

🤖 Autonomous overnight PR — baseline-unblocking priority. Co-authored per repo convention.