### PR TITLE
docs(readme): coordination-first reframe (MSG-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,26 @@
 
 Open source (MIT), self-host anytime, free to start — no credit card.
 
-Conversation history database-as-a-service for AI agents.
+State and coordination layer for AI agent fleets.
 
-You're building AI agents — not a conversation database. Stop reinventing storage, analytics, and history management. Just call an API.
+You're building AI agents — not a distributed systems backend. Stop reinventing state management, locking, delegation, and history storage. Just call an API.
+
+AgentState gives agent fleets five primitives — everything needed to coordinate work, track decisions, and share state across many concurrent agents.
 
 Built for vibe coders. No SDK needed — give your coding agent the [API docs](https://agentstate.app/dashboard/docs/) and let it wire things up. Or use the REST API directly with any language, any framework.
 
 ## Features
 
-- **Conversation CRUD** — Create, read, update, delete conversations with messages
+### Five primitives
+
+- **States** — Versioned key/value state with an append-only event log; query across all agents in a fleet
+- **Leases** — Distributed locks for exactly-one-writer coordination across N concurrent agents ([recipe](docs/recipes/leases.md))
+- **Claims** — Verifiable assertions with attached evidence you can audit later ([recipe](docs/recipes/claims.md))
+- **Capability Tokens** — Scoped, revocable delegation so sub-agents get only the access they need ([recipe](docs/recipes/capability-tokens.md))
+- **Conversations** — Full message history with CRUD, search, tags, bulk export, and AI-generated titles
+
+### Supporting capabilities
+
 - **API Key Auth** — SHA-256 hashed keys with project scoping
 - **AI-Powered** — Auto-generate titles and follow-up questions
 - **Cursor Pagination** — Efficient, stable pagination for large datasets


### PR DESCRIPTION
## What

Reframes the README intro and Features section so AgentState leads with its real story: a **state & coordination layer for agent fleets**, with five primitives surfaced up-front instead of buried.

Changes (surgical — `README.md` only):
- Tagline: `Conversation history database-as-a-service` → `State and coordination layer for AI agent fleets`
- Intro paragraph rewritten to name the five primitives and position them as the core offering
- Features section split into **Five primitives** (States, Leases, Claims, Capability Tokens, Conversations) and **Supporting capabilities** (existing 9 bullets preserved, none lost)
- Recipe links added for the three primitives that have docs: Leases, Claims, Capability Tokens

## Why

MSG-1 (Month-1 messaging priority): AgentState currently looks like a memory-only tool. Visitors with fleet-coordination needs bounce before seeing that Leases, Claims, States, and Capability Tokens exist. This stops that.

## Risk

🟢 Docs-only change. No code, no schema, no tests affected.

## Rollback

`git revert aa78da5` or simply revert the PR.

## Verification

- [x] All five primitive names match the product (States, Leases, Claims, Capability Tokens, Conversations)
- [x] Recipe links resolve: `docs/recipes/leases.md`, `docs/recipes/claims.md`, `docs/recipes/capability-tokens.md` (all exist on main)
- [x] Badges line preserved: `[![License: MIT]...` and `[![PRs Welcome]...`
- [x] Trust line preserved: `Open source (MIT), self-host anytime, free to start — no credit card.`
- [x] Documentation table preserved (untouched)
- [x] Quick Start, API Endpoints, Tech Stack, Development, License sections: untouched
- [x] No information lost — all 9 original conversation feature bullets remain under Supporting capabilities