### PR TITLE
test(api): coordination edge cases (lease contention, claim verify, scope denial)

### DIFF
--- a/packages/api/test/v2-leases-contention.test.ts
+++ b/packages/api/test/v2-leases-contention.test.ts
@@ -1,0 +1,409 @@
+/**
+ * Coordination edge-case regression tests — QUAL-3
+ *
+ * Focuses on the "exactly-one-writer" lease guarantee (acquire → contention → release →
+ * re-acquire with higher fencing token), scope-denial enforcement, and isolated
+ * json_value claim verification (pass and fail paths).
+ *
+ * WHY these tests matter:
+ *   - Lease acquisition was completely untested before QUAL-3. The 409 LEASE_CONFLICT
+ *     path is the core concurrency guarantee: if two workers race to acquire the same
+ *     state key, only one wins. A regression here silently corrupts distributed state.
+ *   - Monotonic fencing tokens prevent split-brain writes after a release: a re-acquired
+ *     lease must have a strictly higher token than any previous holder, so stale writers
+ *     can be detected and rejected.
+ *   - Scope denial tests ensure capability tokens cannot escape their declared scope;
+ *     without them a single `lease:write` token would silently gain `claim:write` access.
+ *   - The isolated json_value verify tests pin the exact success/failure message strings
+ *     that upstream consumers parse to determine claim disposition.
+ */
+
+import { SELF } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { applyMigrations, authHeaders, seedProject, TEST_PROJECT_ID } from "./setup";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface CapabilityTokenResponse {
+  id: string;
+  name: string;
+  key_prefix: string;
+  token: string;
+  scopes: string[];
+  expires_at: number | null;
+  created_at: number;
+  last_used_at: number | null;
+  revoked_at: number | null;
+}
+
+interface LeaseResponse {
+  id: string;
+  state_key: string;
+  holder: string;
+  fencing_token: number;
+  expires_at: number;
+  created_at: number;
+  renewed_at: number;
+}
+
+interface Claim {
+  id: string;
+  project_id: string;
+  subject_type: string;
+  subject_id: string;
+  statement: string;
+  status: "pending" | "verified" | "failed";
+  created_at: number;
+  updated_at: number;
+  evidence?: Array<{
+    id: string;
+    kind: string;
+    source: string;
+    data: unknown;
+    json_path: string | null;
+    expected_value: unknown;
+  }>;
+}
+
+interface VerificationRun {
+  id: string;
+  project_id: string;
+  claim_id: string;
+  status: "verified" | "failed";
+  details: {
+    results: Array<{
+      evidence_id: string;
+      kind: string;
+      source: string;
+      passed: boolean;
+      message: string;
+    }>;
+  };
+  created_at: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Mint a capability token via the real API (so it's stored in the test DB and
+ * its hash is resolvable by scopedAuth).  Returns the full response including
+ * the raw token string needed for Authorization headers.
+ */
+async function mintCapabilityToken(
+  scopes: string[],
+  name = "test-token",
+): Promise<CapabilityTokenResponse> {
+  const res = await SELF.fetch("http://localhost/api/v1/capability-tokens", {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify({ name, scopes }),
+  });
+  expect(res.status, `mintCapabilityToken(${scopes.join(",")})`).toBe(201);
+  return res.json<CapabilityTokenResponse>();
+}
+
+function capTokenHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+  };
+}
+
+async function acquireLease(
+  stateKey: string,
+  token: string,
+  opts: { holder?: string; ttl_ms?: number } = {},
+): Promise<Response> {
+  return SELF.fetch(`http://localhost/api/v1/states/${stateKey}/lease`, {
+    method: "POST",
+    headers: capTokenHeaders(token),
+    body: JSON.stringify({ holder: opts.holder ?? "worker-1", ttl_ms: opts.ttl_ms ?? 30_000 }),
+  });
+}
+
+async function releaseLease(leaseId: string, token: string): Promise<Response> {
+  return SELF.fetch(`http://localhost/api/v1/leases/${leaseId}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+async function createClaim(token: string, body: Record<string, unknown>): Promise<Response> {
+  return SELF.fetch("http://localhost/api/v1/claims", {
+    method: "POST",
+    headers: capTokenHeaders(token),
+    body: JSON.stringify(body),
+  });
+}
+
+async function verifyClaim(claimId: string, token: string): Promise<Response> {
+  return SELF.fetch(`http://localhost/api/v1/claims/${claimId}/verify`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  await applyMigrations();
+  await seedProject();
+});
+
+beforeEach(async () => {
+  // Reset only the tables touched by this file; applyMigrations/seedProject run once.
+  // The DB is wiped in seedProject (beforeAll), but since we share the DB across
+  // tests in this file we must clean per-test to avoid cross-contamination.
+  // We rely on applyMigrations having created these tables already.
+  const { env } = await import("cloudflare:test");
+  await env.DB.prepare("DELETE FROM state_leases").run();
+  await env.DB.prepare("DELETE FROM capability_tokens").run();
+  await env.DB.prepare("DELETE FROM claim_verification_runs").run();
+  await env.DB.prepare("DELETE FROM claim_evidence").run();
+  await env.DB.prepare("DELETE FROM claims").run();
+  await env.DB.prepare("DELETE FROM rate_limits").run();
+});
+
+// ---------------------------------------------------------------------------
+// Lease: acquire
+// ---------------------------------------------------------------------------
+
+describe("Lease acquisition", () => {
+  it("acquires a lease for a new state key and returns the full lease shape", async () => {
+    // WHY: acquisition itself was never tested — this pins the happy-path contract
+    // so regressions (wrong status code, missing fields) are caught immediately.
+    const token = await mintCapabilityToken(["lease:write"], "acquire-happy");
+
+    const res = await acquireLease("state:acquire-happy", token.token, {
+      holder: "worker-a",
+      ttl_ms: 60_000,
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json<LeaseResponse>();
+    expect(body.id).toBeTruthy();
+    expect(body.state_key).toBe("state:acquire-happy");
+    expect(body.holder).toBe("worker-a");
+    expect(body.fencing_token).toBeTypeOf("number");
+    expect(body.expires_at).toBeGreaterThan(Date.now());
+    expect(body.created_at).toBeTypeOf("number");
+    expect(body.renewed_at).toBeTypeOf("number");
+  });
+
+  it("returns 409 LEASE_CONFLICT when a second worker tries to acquire an active lease (exactly-one-writer guarantee)", async () => {
+    // WHY: This is the core distributed-locking invariant. If two workers can both
+    // receive 201, they both believe they own the state and will overwrite each other's
+    // writes without knowing it.  The fencing_token mechanism only helps if acquisition
+    // is exclusive — a broken 409 path silently destroys that guarantee.
+    const token = await mintCapabilityToken(["lease:write"], "contention");
+
+    const first = await acquireLease("state:contention", token.token, { holder: "worker-1" });
+    expect(first.status).toBe(201);
+
+    const second = await acquireLease("state:contention", token.token, { holder: "worker-2" });
+    expect(second.status).toBe(409);
+
+    const body = await second.json<{ error: { code: string; message: string } }>();
+    expect(body.error.code).toBe("LEASE_CONFLICT");
+    expect(body.error.message).toBe("State already has an active lease");
+  });
+
+  it("allows re-acquisition after release, with a strictly higher fencing token (monotonic guarantee)", async () => {
+    // WHY: After a release, the new holder must receive a fencing_token strictly greater
+    // than the previous one.  Monotonic tokens let storage backends reject stale writes
+    // (e.g. compare-and-swap on the token value).  If re-acquired with the same or lower
+    // token, a lagging first worker could silently overwrite the new holder's data.
+    const token = await mintCapabilityToken(["lease:write"], "reacquire");
+
+    const first = await acquireLease("state:reacquire", token.token, { holder: "worker-1" });
+    expect(first.status).toBe(201);
+    const firstLease = await first.json<LeaseResponse>();
+
+    const release = await releaseLease(firstLease.id, token.token);
+    expect(release.status).toBe(204);
+
+    const second = await acquireLease("state:reacquire", token.token, { holder: "worker-2" });
+    expect(second.status).toBe(201);
+    const secondLease = await second.json<LeaseResponse>();
+
+    expect(secondLease.fencing_token).toBeGreaterThan(firstLease.fencing_token);
+  });
+
+  it("returns 403 FORBIDDEN when a capability token lacks lease:write scope", async () => {
+    // WHY: A token minted for state:read only must not be able to acquire locks.
+    // If scope enforcement is broken, any capability token becomes a lease:write token.
+    const readOnlyToken = await mintCapabilityToken(["state:read"], "no-lease-scope");
+
+    const res = await acquireLease("state:scope-denied", readOnlyToken.token, {
+      holder: "worker-x",
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json<{ error: { code: string } }>();
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Claims: json_value verification (isolated cases)
+// ---------------------------------------------------------------------------
+
+describe("Claim json_value evidence verification", () => {
+  it("verifies a claim as 'verified' when json_value evidence matches (pass)", async () => {
+    // WHY: The existing verify tests cover mixed-evidence scenarios.
+    // This test isolates the json_value path so a regression in readJsonPath or
+    // JSON serialisation is pinpointed to this evidence kind specifically.
+    const token = await mintCapabilityToken(["claim:write"], "json-verify-pass");
+
+    const createRes = await createClaim(token.token, {
+      subject_type: "task",
+      subject_id: "json-value-pass-1",
+      statement: "Task completed with status ok",
+      evidence: [
+        {
+          kind: "json_value",
+          source: "task-result:1",
+          data: { status: "ok", retries: 0 },
+          json_path: "$.status",
+          expected_value: "ok",
+        },
+      ],
+    });
+    expect(createRes.status).toBe(201);
+    const claim = await createRes.json<Claim>();
+
+    const verifyRes = await verifyClaim(claim.id, token.token);
+    expect(verifyRes.status).toBe(201);
+    const run = await verifyRes.json<VerificationRun>();
+
+    expect(run.status).toBe("verified");
+    expect(run.details.results).toHaveLength(1);
+    expect(run.details.results[0].passed).toBe(true);
+    expect(run.details.results[0].kind).toBe("json_value");
+    // Pin the success message so any change to the message string is caught.
+    expect(run.details.results[0].message).toBe("json value matched");
+
+    // Claim status must also have been updated to 'verified'.
+    const { env } = await import("cloudflare:test");
+    const row = await env.DB.prepare("SELECT status FROM claims WHERE id = ?")
+      .bind(claim.id)
+      .first<{ status: string }>();
+    expect(row?.status).toBe("verified");
+  });
+
+  it("verifies a claim as 'failed' when json_value evidence does not match (fail)", async () => {
+    // WHY: The json_value fail path is exercised in isolation here. The existing
+    // verify-fail test uses text_hash mismatch.  A separate json_value mismatch test
+    // ensures the JSON comparison code (readJsonPath + JSON.stringify equality) is
+    // covered as a distinct code branch.
+    const token = await mintCapabilityToken(["claim:write"], "json-verify-fail");
+
+    const createRes = await createClaim(token.token, {
+      subject_type: "task",
+      subject_id: "json-value-fail-1",
+      statement: "Task should have failed status",
+      evidence: [
+        {
+          kind: "json_value",
+          source: "task-result:2",
+          data: { status: "ok" },
+          json_path: "$.status",
+          expected_value: "nope", // does not match the actual "ok"
+        },
+      ],
+    });
+    expect(createRes.status).toBe(201);
+    const claim = await createRes.json<Claim>();
+
+    const verifyRes = await verifyClaim(claim.id, token.token);
+    expect(verifyRes.status).toBe(201);
+    const run = await verifyRes.json<VerificationRun>();
+
+    expect(run.status).toBe("failed");
+    expect(run.details.results).toHaveLength(1);
+    expect(run.details.results[0].passed).toBe(false);
+    expect(run.details.results[0].kind).toBe("json_value");
+    // Pin the failure message so downstream parsers aren't silently broken.
+    expect(run.details.results[0].message).toBe("json value mismatch");
+
+    // Claim status must also have been updated to 'failed'.
+    const { env } = await import("cloudflare:test");
+    const row = await env.DB.prepare("SELECT status FROM claims WHERE id = ?")
+      .bind(claim.id)
+      .first<{ status: string }>();
+    expect(row?.status).toBe("failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Claims: scope denial
+// ---------------------------------------------------------------------------
+
+describe("Claim scope denial", () => {
+  it("returns 403 FORBIDDEN when a capability token lacks claim:write scope", async () => {
+    // WHY: The claims router guards all routes with scopedAuth({ scope: "claim:write" }).
+    // If that guard regresses, any capability token could create or verify claims
+    // regardless of what it was minted for.
+    const stateOnlyToken = await mintCapabilityToken(["state:read"], "no-claim-scope");
+
+    const res = await createClaim(stateOnlyToken.token, {
+      subject_type: "task",
+      subject_id: "scope-denied",
+      statement: "should not be created",
+      evidence: [
+        {
+          kind: "json_value",
+          source: "state:1",
+          data: { x: 1 },
+          json_path: "$.x",
+          expected_value: 1,
+        },
+      ],
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json<{ error: { code: string } }>();
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Capability token revocation
+// ---------------------------------------------------------------------------
+
+describe("Capability token revocation", () => {
+  it("returns 401 UNAUTHORIZED when a revoked capability token is used on a scoped route", async () => {
+    // WHY: After DELETE /api/v1/capability-tokens/:id sets revokedAt, the token's
+    // hash is no longer found by the scopedAuth DB query (isNull(revokedAt) filter).
+    // The middleware then falls through to the api_key path, finds nothing, and must
+    // return 401. If revocation is broken, a compromised token remains valid forever.
+    const token = await mintCapabilityToken(["lease:write"], "revoke-me");
+
+    // Confirm the token works before revocation.
+    const beforeRevoke = await acquireLease("state:revoke-before", token.token, {
+      holder: "pre-revoke-worker",
+    });
+    expect(beforeRevoke.status).toBe(201);
+
+    // Revoke via the management API (requires the master API key, not the cap token).
+    const revokeRes = await SELF.fetch(
+      `http://localhost/api/v1/capability-tokens/${token.id}`,
+      { method: "DELETE", headers: authHeaders() },
+    );
+    expect(revokeRes.status).toBe(204);
+
+    // After revocation the token must be rejected.
+    const afterRevoke = await acquireLease("state:revoke-after", token.token, {
+      holder: "post-revoke-worker",
+    });
+    expect(afterRevoke.status).toBe(401);
+    const body = await afterRevoke.json<{ error: { code: string } }>();
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+});


### PR DESCRIPTION
## What

Adds `packages/api/test/v2-leases-contention.test.ts` with 8 new regression tests covering coordination edge cases that were entirely untested before QUAL-3:

**Lease acquisition (4 tests)**
- `Acquire succeeds` — pins the happy-path contract: `POST /api/v1/states/:state_key/lease` with `lease:write` token → 201 with `{ id, state_key, holder, fencing_token, expires_at, created_at, renewed_at }`
- `Contention → 409` — second acquire on the same key while first is active → 409, code `LEASE_CONFLICT`, message `"State already has an active lease"` (exactly-one-writer guarantee)
- `Release then re-acquire` — after `DELETE /api/v1/leases/:id`, re-acquiring yields 201 and `fencing_token` is strictly greater than the released one (monotonic guarantee)
- `Acquire scope denial` — token without `lease:write` → 403 `FORBIDDEN`

**Claims: json_value verification (2 tests)**
- `json_value pass` — single-evidence claim with matching json_path → `verified`, result `passed: true`, message `"json value matched"`
- `json_value fail` — single-evidence claim with mismatched expected_value → `failed`, result `passed: false`, message `"json value mismatch"`

**Claims: scope denial (1 test)**
- Token without `claim:write` → 403 `FORBIDDEN` on `POST /api/v1/claims`

**Capability token revocation (1 test)**
- After `DELETE /api/v1/capability-tokens/:id`, the token is rejected with 401 `UNAUTHORIZED` on any scoped route

## Why (QUAL-3)

Lease acquisition was **completely untested**. The 409 LEASE_CONFLICT path is the core concurrency guarantee — if two workers can both receive 201 for the same state_key, distributed state silently corrupts. Monotonic fencing tokens only matter if re-acquisition is also covered.

The isolated json_value tests complement the existing mixed-evidence tests by pinning exactly where a regression in `readJsonPath` or JSON serialisation would surface.

## Risk

🟢 **Test-only, additive.** No source files touched. Zero risk of production regression.

## Rollback

`git revert <commit>` or `gh pr close` — no schema or source changes to undo.

## Verification

```
# Before this PR
Tests: 264 passed (264) | Files: 19 passed (19)

# After this PR  
Tests: 272 passed (272) | Files: 20 passed (20)

bunx biome check packages/api/src/  →  no fixes, 0 errors
```