### PR TITLE
docs(recipes): states + conversations recipes (complete the 5-primitive set)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -14,3 +14,5 @@
 | [Recipe: Leases](recipes/leases.md) | Distributed locking — coordinate N agents with exactly-one-writer semantics |
 | [Recipe: Claims](recipes/claims.md) | Verifiable agent output — attest and audit work with evidence |
 | [Recipe: Capability Tokens](recipes/capability-tokens.md) | Scoped sub-agent delegation — least-privilege tokens for untrusted processes |
+| [Recipe: States](recipes/states.md) | Versioned key/value storage — durable agent state with time-travel reads and SSE watch |
+| [Recipe: Conversations](recipes/conversations.md) | Agent memory primitive — create, append, search, export, and AI-enrich conversation history |

--- a/docs/recipes/conversations.md
+++ b/docs/recipes/conversations.md
@@ -1,0 +1,417 @@
+# Conversations — The Agent Memory Primitive
+
+Use conversations when you need to record, retrieve, search, and export the full message history of an AI agent or chatbot. Conversations are the core storage primitive of AgentState — a durable, queryable log of `(role, content)` turns that any agent can write to and read from.
+
+## Core flow
+
+1. **Create** — `POST /api/v1/conversations` with an optional list of seed messages, an external ID, and metadata. Returns the conversation with its system-assigned `id`.
+2. **Append** — `POST /api/v1/conversations/:id/messages` streams new turns into the conversation as the agent runs.
+3. **Read** — `GET /api/v1/conversations/:id` returns the conversation and all messages. Filter fields with `?fields=`.
+4. **List** — `GET /api/v1/conversations` pages through all conversations with cursor-based pagination. Filter by tag.
+5. **Search** — `GET /api/v1/conversations/search?q=` runs full-text search across message content.
+6. **Export** — `POST /api/v1/conversations/export` bulk-exports conversations with messages so you always own your data.
+7. **Generate** — `POST /api/v1/conversations/:id/generate-title` and `/follow-ups` run AI inference to enrich conversations automatically.
+
+---
+
+## curl examples
+
+### Create a conversation with seed messages
+
+```bash
+curl -s -X POST https://agentstate.app/api/v1/conversations \
+  -H "Authorization: Bearer as_live_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "external_id": "session-abc-123",
+    "title": "Q3 planning session",
+    "metadata": { "user_id": "user-42", "channel": "web" },
+    "messages": [
+      { "role": "user", "content": "What were our Q2 highlights?" },
+      { "role": "assistant", "content": "Q2 highlights: 22% revenue growth, launched v2 API, hired 8 engineers." }
+    ]
+  }'
+```
+
+**201 — conversation created:**
+```json
+{
+  "id": "conv_MDEyMzQ1Njc4OTAxMjM0NQ",
+  "project_id": "proj_xyz",
+  "external_id": "session-abc-123",
+  "title": "Q3 planning session",
+  "metadata": { "user_id": "user-42", "channel": "web" },
+  "message_count": 2,
+  "token_count": 0,
+  "total_cost_microdollars": 0,
+  "total_tokens": 0,
+  "created_at": 1718700000000,
+  "updated_at": 1718700000000,
+  "messages": [
+    { "id": "msg_aaa", "role": "user", "content": "What were our Q2 highlights?", "created_at": 1718700000000 },
+    { "id": "msg_bbb", "role": "assistant", "content": "Q2 highlights: 22% revenue growth...", "created_at": 1718700000000 }
+  ]
+}
+```
+
+### Append messages
+
+```bash
+curl -s -X POST https://agentstate.app/api/v1/conversations/conv_MDEyMzQ1Njc4OTAxMjM0NQ/messages \
+  -H "Authorization: Bearer as_live_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [
+      { "role": "user", "content": "What should we focus on in Q3?" },
+      {
+        "role": "assistant",
+        "content": "Three priorities: international expansion, infra reliability, and SDK adoption.",
+        "model": "claude-3-5-sonnet-20241022",
+        "input_tokens": 120,
+        "output_tokens": 45,
+        "cost_microdollars": 1800
+      }
+    ]
+  }'
+```
+
+**201 — messages appended:**
+```json
+{
+  "messages": [
+    { "id": "msg_ccc", "role": "user", "content": "What should we focus on in Q3?", "created_at": 1718700060000 },
+    { "id": "msg_ddd", "role": "assistant", "content": "Three priorities...", "model": "claude-3-5-sonnet-20241022", "input_tokens": 120, "output_tokens": 45, "cost_microdollars": 1800, "created_at": 1718700060000 }
+  ]
+}
+```
+
+### List conversations (cursor-based pagination, newest first)
+
+```bash
+curl -s "https://agentstate.app/api/v1/conversations?limit=20&order=desc" \
+  -H "Authorization: Bearer as_live_..."
+
+# Next page:
+curl -s "https://agentstate.app/api/v1/conversations?limit=20&order=desc&cursor=<next_cursor>" \
+  -H "Authorization: Bearer as_live_..."
+
+# Filter by tag:
+curl -s "https://agentstate.app/api/v1/conversations?tag=production" \
+  -H "Authorization: Bearer as_live_..."
+```
+
+**200:**
+```json
+{
+  "data": [{ "id": "conv_MDEyMzQ1Njc4OTAxMjM0NQ", "title": "Q3 planning session", "message_count": 4, "..." : "..." }],
+  "pagination": { "limit": 20, "next_cursor": "1718699900000" }
+}
+```
+
+### Get a single conversation (with optional field selection)
+
+```bash
+# All fields including messages (default)
+curl -s https://agentstate.app/api/v1/conversations/conv_MDEyMzQ1Njc4OTAxMjM0NQ \
+  -H "Authorization: Bearer as_live_..."
+
+# Only conversation metadata — no messages fetched
+curl -s "https://agentstate.app/api/v1/conversations/conv_MDEyMzQ1Njc4OTAxMjM0NQ?fields=id,title,message_count" \
+  -H "Authorization: Bearer as_live_..."
+```
+
+### Look up by your own external ID
+
+```bash
+curl -s https://agentstate.app/api/v1/conversations/by-external-id/session-abc-123 \
+  -H "Authorization: Bearer as_live_..."
+```
+
+### List messages in a conversation (paginated)
+
+```bash
+curl -s "https://agentstate.app/api/v1/conversations/conv_MDEyMzQ1Njc4OTAxMjM0NQ/messages?limit=50" \
+  -H "Authorization: Bearer as_live_..."
+
+# Page from a specific message ID
+curl -s "https://agentstate.app/api/v1/conversations/conv_MDEyMzQ1Njc4OTAxMjM0NQ/messages?after=msg_bbb&limit=50" \
+  -H "Authorization: Bearer as_live_..."
+```
+
+### Full-text search across message content
+
+```bash
+curl -s "https://agentstate.app/api/v1/conversations/search?q=international+expansion&limit=10" \
+  -H "Authorization: Bearer as_live_..."
+```
+
+### Update a conversation's title or metadata
+
+```bash
+curl -s -X PUT https://agentstate.app/api/v1/conversations/conv_MDEyMzQ1Njc4OTAxMjM0NQ \
+  -H "Authorization: Bearer as_live_..." \
+  -H "Content-Type: application/json" \
+  -d '{ "title": "Q3 planning — final" }'
+```
+
+### Delete a conversation
+
+```bash
+curl -s -X DELETE https://agentstate.app/api/v1/conversations/conv_MDEyMzQ1Njc4OTAxMjM0NQ \
+  -H "Authorization: Bearer as_live_..."
+# → 204 No Content
+```
+
+### Bulk delete (up to 100 IDs)
+
+```bash
+curl -s -X POST https://agentstate.app/api/v1/conversations/bulk-delete \
+  -H "Authorization: Bearer as_live_..." \
+  -H "Content-Type: application/json" \
+  -d '{ "ids": ["conv_MDEyMzQ1Njc4OTAxMjM0NQ", "conv_YWJjZGVmZ2hpams"] }'
+```
+
+**200:**
+```json
+{ "deleted": 2 }
+```
+
+### Export conversations with messages
+
+```bash
+# Export specific IDs
+curl -s -X POST https://agentstate.app/api/v1/conversations/export \
+  -H "Authorization: Bearer as_live_..." \
+  -H "Content-Type: application/json" \
+  -d '{ "ids": ["conv_MDEyMzQ1Njc4OTAxMjM0NQ"] }'
+
+# Export all (omit ids)
+curl -s -X POST https://agentstate.app/api/v1/conversations/export \
+  -H "Authorization: Bearer as_live_..." \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+**200:**
+```json
+{ "data": [{ "id": "conv_...", "messages": [...] }], "count": 1 }
+```
+
+### AI — generate a title
+
+```bash
+curl -s -X POST https://agentstate.app/api/v1/conversations/conv_MDEyMzQ1Njc4OTAxMjM0NQ/generate-title \
+  -H "Authorization: Bearer as_live_..."
+```
+
+**200:**
+```json
+{ "title": "Q3 planning session: priorities and goals" }
+```
+
+### AI — generate follow-up questions
+
+```bash
+curl -s -X POST https://agentstate.app/api/v1/conversations/conv_MDEyMzQ1Njc4OTAxMjM0NQ/follow-ups \
+  -H "Authorization: Bearer as_live_..."
+```
+
+**200:**
+```json
+{ "questions": ["Which markets should we enter first?", "What does infra reliability mean in practice?", "How do we measure SDK adoption success?"] }
+```
+
+### AI — generate title and follow-ups in one call
+
+```bash
+curl -s -X POST https://agentstate.app/api/v1/conversations/conv_MDEyMzQ1Njc4OTAxMjM0NQ/generate-all \
+  -H "Authorization: Bearer as_live_..."
+```
+
+**200:**
+```json
+{ "title": "Q3 planning session: priorities and goals", "follow_ups": ["Which markets should we enter first?"] }
+```
+
+---
+
+## TypeScript SDK
+
+```typescript
+import { AgentState } from "@agentstate/sdk";
+
+const client = new AgentState({ apiKey: "as_live_..." });
+
+// Create a conversation with seed messages
+const conv = await client.createConversation({
+  external_id: "session-abc-123",
+  title: "Q3 planning session",
+  metadata: { user_id: "user-42" },
+  messages: [
+    { role: "user", content: "What were our Q2 highlights?" },
+    { role: "assistant", content: "Q2 highlights: 22% revenue growth, launched v2 API." },
+  ],
+});
+console.log(`Created: ${conv.id}`);
+
+// Append messages as the conversation continues
+const { messages } = await client.appendMessages(conv.id, [
+  { role: "user", content: "What should we focus on in Q3?" },
+  {
+    role: "assistant",
+    content: "Three priorities: international expansion, reliability, SDK adoption.",
+    model: "claude-3-5-sonnet-20241022",
+    input_tokens: 120,
+    output_tokens: 45,
+  },
+]);
+
+// Read back the full conversation
+const full = await client.getConversation(conv.id);
+console.log(`Messages: ${full.messages.length}`);
+
+// Look up by your own ID
+const byExternal = await client.getConversationByExternalId("session-abc-123");
+
+// List with pagination
+let cursor: string | null = null;
+do {
+  const page = await client.listConversations({ limit: 20, order: "desc", cursor: cursor ?? undefined });
+  for (const c of page.data) {
+    console.log(`${c.id}  ${c.title}`);
+  }
+  cursor = page.pagination.next_cursor;
+} while (cursor);
+
+// List messages in a conversation
+const msgPage = await client.listMessages(conv.id, { limit: 50 });
+
+// Update title or metadata
+await client.updateConversation(conv.id, { title: "Q3 planning — final" });
+
+// AI enrichment
+const { title } = await client.generateTitle(conv.id);
+const { questions } = await client.generateFollowUps(conv.id);
+console.log(`Generated title: ${title}`);
+console.log(`Follow-ups: ${questions.join(", ")}`);
+
+// Bulk export — your data is yours
+const exported = await client.exportConversations(["conv_MDEyMzQ1Njc4OTAxMjM0NQ"]);
+console.log(`Exported ${exported.count} conversation(s)`);
+
+// Delete
+await client.deleteConversation(conv.id); // → void (204)
+```
+
+---
+
+## Python SDK
+
+```python
+from agentstate import AgentStateClient
+
+client = AgentStateClient(api_key="as_live_...")
+
+# Create a conversation with seed messages
+conv = client.create_conversation(
+    messages=[
+        {"role": "user", "content": "What were our Q2 highlights?"},
+        {"role": "assistant", "content": "Q2 highlights: 22% revenue growth, launched v2 API."},
+    ],
+    external_id="session-abc-123",
+    title="Q3 planning session",
+    metadata={"user_id": "user-42"},
+)
+conv_id = conv["id"]
+print(f"Created: {conv_id}")
+
+# Append messages as the conversation continues
+result = client.append_messages(
+    conv_id,
+    messages=[
+        {"role": "user", "content": "What should we focus on in Q3?"},
+        {
+            "role": "assistant",
+            "content": "Three priorities: international expansion, reliability, SDK adoption.",
+            "model": "claude-3-5-sonnet-20241022",
+            "input_tokens": 120,
+            "output_tokens": 45,
+        },
+    ],
+)
+print(f"Appended {len(result['messages'])} message(s)")
+
+# Read back the full conversation
+full = client.get_conversation(conv_id)
+print(f"Messages: {len(full['messages'])}")
+
+# Look up by your own ID
+by_external = client.get_conversation_by_external_id("session-abc-123")
+
+# List with pagination
+cursor = None
+while True:
+    page = client.list_conversations(limit=20, cursor=cursor, order="desc")
+    for c in page["data"]:
+        print(f"{c['id']}  {c['title']}")
+    cursor = page["pagination"]["next_cursor"]
+    if not cursor:
+        break
+
+# List messages in a conversation
+msg_page = client.list_messages(conv_id, limit=50)
+
+# Update title or metadata
+client.update_conversation(conv_id, title="Q3 planning — final")
+
+# AI enrichment
+title_result = client.generate_title(conv_id)
+follow_ups = client.generate_follow_ups(conv_id)
+print(f"Generated title: {title_result['title']}")
+print(f"Follow-ups: {follow_ups['questions']}")
+
+# Bulk export — your data is yours
+exported = client.export_conversations(ids=["conv_MDEyMzQ1Njc4OTAxMjM0NQ"])
+print(f"Exported {exported['count']} conversation(s)")
+
+# Delete
+client.delete_conversation(conv_id)  # → None (204)
+```
+
+---
+
+## Key concepts
+
+### Conversation and message model
+
+A conversation is a top-level container with an `id`, optional `external_id`, `title`, `metadata`, and aggregate counters (`message_count`, `token_count`, `total_tokens`, `total_cost_microdollars`). Messages are ordered by `created_at` ascending, with a stable tie-breaker on insertion order when multiple messages share the same timestamp.
+
+Each message carries: `role` (one of `user`, `assistant`, `system`, `tool`), `content`, and optional observability fields: `model`, `input_tokens`, `output_tokens`, `token_count`, `cost_microdollars`, `observation_type`, `start_time`, `end_time`, `status`, and `level`. These fields let you log full LLM tracing metadata alongside the message content.
+
+### External ID — map your sessions to AgentState IDs
+
+Pass `external_id` at creation time to map your own session or thread identifier to the AgentState conversation ID. Retrieve it later via `GET /api/v1/conversations/by-external-id/:externalId` without maintaining a lookup table on your side.
+
+### Cursor-based pagination
+
+All list endpoints use cursor pagination — never offset. The `next_cursor` field in `pagination` is an opaque token (a Unix timestamp in milliseconds); pass it as `?cursor=` on the next request. Omit it for the first page. Cursor pagination is stable under concurrent writes: new conversations added after the first page request do not shift earlier pages.
+
+### Full-text search
+
+`GET /api/v1/conversations/search?q=<query>` searches message content across all conversations in your project. Matches return the parent conversation, not individual messages. Supports cursor pagination for large result sets.
+
+### Bulk export — your data is yours
+
+`POST /api/v1/conversations/export` returns full conversation objects with their messages embedded. Omit `ids` to export everything. Use this to feed downstream analytics, migrate between systems, or produce audit logs. The response includes `count` and a `data` array — no pagination; all requested conversations are returned in one response.
+
+### AI title and follow-up generation
+
+`POST /api/v1/conversations/:id/generate-title` sends the conversation's first 20 messages to Workers AI and writes the returned title back to the conversation record. `POST /api/v1/conversations/:id/follow-ups` sends the last 20 messages and returns a `questions` array of suggested follow-up prompts. Both operations are idempotent and can be called at any point after messages are present. `POST /api/v1/conversations/:id/generate-all` runs both in a single round-trip and returns `{ title, follow_ups }`.
+
+### One of five primitives
+
+Conversations are one of the five core primitives of AgentState. The other four are **states** (versioned key/value), **leases** (distributed locking), **capability tokens** (scoped delegation), and **claims** (verifiable agent output). See the sibling recipes for each.
+
+---
+
+[Get a free API key at agentstate.app](https://agentstate.app) or see [getting-started.md](../getting-started.md) for a two-minute setup guide.

--- a/docs/recipes/states.md
+++ b/docs/recipes/states.md
@@ -1,0 +1,352 @@
+# States — Versioned Key/Value Storage for Agents
+
+Use states when you need durable, versioned storage for agent data — task progress, scratchpad context, configuration, or any value that changes over time and must survive restarts. Every write is appended to an immutable event log, giving you full history and time-travel reads.
+
+## Core flow
+
+1. **Write** — call `PUT /api/v1/states/:state_key` with `agent_id` and `data`. Creates the record if new, replaces it if it exists. Returns the current snapshot with a monotonically increasing `latest_sequence`.
+2. **Read** — `GET /api/v1/states/:state_key` returns the latest snapshot. Add `?at_sequence=` or `?at_time=` to travel back to any earlier version.
+3. **Query** — `POST /api/v1/states/query` finds states by `agent_id`, tags, JSON path predicates, or time range across your whole project.
+4. **Watch** — `GET /api/v1/states/watch` opens an SSE stream. The client receives every write and delete event in real time.
+5. **Delete** — `DELETE /api/v1/states/:state_key` soft-deletes the record and appends a `delete` event to the log.
+6. **Audit** — `GET /api/v1/states/:state_key/events` pages through the full append-only event log.
+
+> Writes are idempotent when you pass an `Idempotency-Key` header. Retrying the same key with the same payload replays the original response without a second write.
+
+---
+
+## curl examples
+
+### Write (upsert) a state
+
+```bash
+curl -s -X PUT https://agentstate.app/api/v1/states/agent:pipeline-7/progress \
+  -H "Authorization: Bearer as_live_..." \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: run-2024-06-18-step-3" \
+  -d '{
+    "agent_id": "pipeline-worker-1",
+    "data": { "step": 3, "completed": ["ingest", "parse", "validate"], "next": "transform" },
+    "metadata": { "run_id": "run-2024-06-18" },
+    "tags": ["pipeline", "active"]
+  }'
+```
+
+**200 — state written:**
+```json
+{
+  "state_key": "agent:pipeline-7/progress",
+  "agent_id": "pipeline-worker-1",
+  "data": { "step": 3, "completed": ["ingest", "parse", "validate"], "next": "transform" },
+  "metadata": { "run_id": "run-2024-06-18" },
+  "tags": ["pipeline", "active"],
+  "latest_sequence": 3,
+  "created_at": 1718700000000,
+  "updated_at": 1718700120000,
+  "deleted_at": null
+}
+```
+
+### Read the latest state
+
+```bash
+curl -s https://agentstate.app/api/v1/states/agent:pipeline-7/progress \
+  -H "Authorization: Bearer as_live_..."
+```
+
+### Time-travel read — state as it was at sequence 2
+
+```bash
+curl -s "https://agentstate.app/api/v1/states/agent:pipeline-7/progress?at_sequence=2" \
+  -H "Authorization: Bearer as_live_..."
+```
+
+### Time-travel read — state as it was at a given timestamp
+
+```bash
+curl -s "https://agentstate.app/api/v1/states/agent:pipeline-7/progress?at_time=1718700060000" \
+  -H "Authorization: Bearer as_live_..."
+```
+
+### Query states by agent, tag, and JSON field
+
+```bash
+curl -s -X POST https://agentstate.app/api/v1/states/query \
+  -H "Authorization: Bearer as_live_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent_id": "pipeline-worker-1",
+    "tags": ["active"],
+    "json_path": "$.next",
+    "json_equals": "transform",
+    "limit": 20
+  }'
+```
+
+**200 — query result:**
+```json
+{
+  "data": [
+    {
+      "state_key": "agent:pipeline-7/progress",
+      "agent_id": "pipeline-worker-1",
+      "data": { "step": 3, "next": "transform" },
+      "latest_sequence": 3,
+      "created_at": 1718700000000,
+      "updated_at": 1718700120000,
+      "deleted_at": null
+    }
+  ],
+  "pagination": {
+    "limit": 1,
+    "next_cursor": null
+  }
+}
+```
+
+### List the event log (immutable history)
+
+```bash
+curl -s "https://agentstate.app/api/v1/states/agent:pipeline-7/progress/events?after=0&limit=50" \
+  -H "Authorization: Bearer as_live_..."
+```
+
+**200 — event log:**
+```json
+{
+  "data": [
+    {
+      "sequence": 1,
+      "id": "evt_MDEyMzQ1Njc4OTAxMjM0NQ",
+      "state_key": "agent:pipeline-7/progress",
+      "agent_id": "pipeline-worker-1",
+      "event_type": "upsert",
+      "data": { "step": 1, "completed": [], "next": "ingest" },
+      "metadata": null,
+      "tags": ["pipeline", "active"],
+      "idempotency_key": null,
+      "created_at": 1718700000000
+    }
+  ],
+  "pagination": {
+    "limit": 1,
+    "next_cursor": "1"
+  }
+}
+```
+
+### Delete a state (optionally under a held lease)
+
+```bash
+curl -s -X DELETE https://agentstate.app/api/v1/states/agent:pipeline-7/progress \
+  -H "Authorization: Bearer as_live_..." \
+  -H "X-Lease-Id: MDEyMzQ1Njc4OTAxMjM0NQ"
+# → 200 with { "deleted": true, "event": { ... } }
+```
+
+### Watch — SSE stream of all state events for the project
+
+```bash
+# Reconnect from last-seen sequence with Last-Event-ID
+curl -s -N -H "Authorization: Bearer as_live_..." \
+  -H "Last-Event-ID: 42" \
+  "https://agentstate.app/api/v1/states/watch"
+
+# Or with a capability token via query param (no custom header support in some SSE clients)
+curl -s -N "https://agentstate.app/api/v1/states/watch?token=as_cap_...&after=42"
+```
+
+**SSE events:**
+```
+id: 3
+event: state.upsert
+data: {"sequence":3,"state_key":"agent:pipeline-7/progress","agent_id":"pipeline-worker-1","event_type":"upsert","data":{"step":3},...}
+```
+
+---
+
+## TypeScript SDK
+
+```typescript
+import { AgentState, AgentStateError } from "@agentstate/sdk";
+
+const client = new AgentState({ apiKey: "as_live_..." });
+
+// Write state with idempotency key
+const state = await client.upsertState(
+  "agent:pipeline-7/progress",
+  {
+    agent_id: "pipeline-worker-1",
+    data: { step: 3, completed: ["ingest", "parse"], next: "transform" },
+    metadata: { run_id: "run-2024-06-18" },
+    tags: ["pipeline", "active"],
+  },
+  { idempotencyKey: "run-2024-06-18-step-3" },
+);
+console.log(`Sequence: ${state.latest_sequence}`);
+
+// Read latest state
+const latest = await client.getState("agent:pipeline-7/progress");
+
+// Time-travel reads
+const atSeq = await client.getState("agent:pipeline-7/progress", { at_sequence: 2 });
+const atTime = await client.getState("agent:pipeline-7/progress", { at_time: 1718700060000 });
+
+// Query across all states in the project
+const results = await client.queryStates({
+  agent_id: "pipeline-worker-1",
+  tags: ["active"],
+  json_path: "$.next",
+  json_equals: "transform",
+  limit: 20,
+});
+for (const s of results.data) {
+  console.log(`${s.state_key}  seq=${s.latest_sequence}`);
+}
+
+// List the append-only event log
+const events = await client.listStateEvents("agent:pipeline-7/progress", { after: 0, limit: 50 });
+for (const evt of events.data) {
+  console.log(`seq=${evt.sequence}  type=${evt.event_type}  at=${evt.created_at}`);
+}
+
+// Delete (optionally guarded by a lease)
+const del = await client.deleteState("agent:pipeline-7/progress");
+console.log(`Deleted: ${del.deleted}, event seq=${del.event.sequence}`);
+
+// Acquire a lease before writing (to ensure exactly-one-writer)
+// See leases.md for the full lease recipe.
+const lease = await client.createStateLease("agent:pipeline-7/progress", {
+  holder: "pipeline-worker-1",
+  ttl_ms: 30_000,
+});
+
+// Write under the lease, then release
+await client.upsertState(
+  "agent:pipeline-7/progress",
+  { agent_id: "pipeline-worker-1", data: { step: 4 }, lease_id: lease.id },
+);
+await client.releaseStateLease(lease.id);
+```
+
+---
+
+## Python SDK
+
+```python
+from agentstate import AgentStateClient
+
+client = AgentStateClient(api_key="as_live_...")
+
+# Write state with idempotency key
+state = client.upsert_state(
+    "agent:pipeline-7/progress",
+    {
+        "agent_id": "pipeline-worker-1",
+        "data": {"step": 3, "completed": ["ingest", "parse"], "next": "transform"},
+        "metadata": {"run_id": "run-2024-06-18"},
+        "tags": ["pipeline", "active"],
+    },
+    idempotency_key="run-2024-06-18-step-3",
+)
+print(f"Sequence: {state['latest_sequence']}")
+
+# Read latest state
+latest = client.get_state("agent:pipeline-7/progress")
+
+# Time-travel reads
+at_seq = client.get_state("agent:pipeline-7/progress", at_sequence=2)
+at_time = client.get_state("agent:pipeline-7/progress", at_time=1718700060000)
+
+# Query across all states in the project
+results = client.query_states({
+    "agent_id": "pipeline-worker-1",
+    "tags": ["active"],
+    "json_path": "$.next",
+    "json_equals": "transform",
+    "limit": 20,
+})
+for s in results["data"]:
+    print(f"{s['state_key']}  seq={s['latest_sequence']}")
+
+# List the append-only event log
+events = client.list_state_events("agent:pipeline-7/progress", after=0, limit=50)
+for evt in events["data"]:
+    print(f"seq={evt['sequence']}  type={evt['event_type']}  at={evt['created_at']}")
+
+# Delete (optionally guarded by a lease)
+result = client.delete_state("agent:pipeline-7/progress")
+print(f"Deleted: {result['deleted']}")
+
+# Acquire a lease before writing (to ensure exactly-one-writer)
+# See leases.md for the full lease recipe.
+lease = client.create_state_lease(
+    "agent:pipeline-7/progress",
+    holder="pipeline-worker-1",
+    ttl_ms=30_000,
+)
+
+# Write under the lease, then release
+client.upsert_state(
+    "agent:pipeline-7/progress",
+    {"agent_id": "pipeline-worker-1", "data": {"step": 4}, "lease_id": lease["id"]},
+)
+client.release_state_lease(lease["id"])
+```
+
+---
+
+## Key concepts
+
+### Key/value model with an append-only event log
+
+Each state is a key/value record identified by a `state_key` you choose (e.g., `agent:run-42/checkpoint`). Every `PUT` or `DELETE` appends an immutable event to the state's log and increments `latest_sequence`. The event log is permanent; you can always replay history or audit past values.
+
+### Idempotency keys
+
+Pass `Idempotency-Key: <string>` on `PUT` or `DELETE`. If the server has already processed that key, it returns the original response without performing a second write. This makes retries safe across network failures or timeouts. The key is scoped to your project.
+
+### Time-travel reads
+
+`GET /api/v1/states/:state_key?at_sequence=N` returns the state snapshot as it existed when sequence `N` was written. `?at_time=<unix_ms>` returns the last snapshot written at or before that timestamp. Both parameters are exclusive — supply at most one per request.
+
+### SSE watch — real-time event stream
+
+`GET /api/v1/states/watch` opens a `text/event-stream` connection. Every `PUT` and `DELETE` across your whole project emits an SSE event with `event: state.upsert` or `event: state.delete`. Resume from a checkpoint using `Last-Event-ID: <sequence>` or `?after=<sequence>`. Pass `?token=as_cap_...` to authenticate via query string when your SSE client cannot set custom headers. Requires scope `state:watch`.
+
+### Allowed scopes
+
+| Scope | Routes permitted |
+|-------|-----------------|
+| `state:read` | `GET /:state_key`, `GET /:state_key/events`, `POST /query` |
+| `state:write` | `PUT /:state_key`, `DELETE /:state_key` |
+| `state:watch` | `GET /watch` |
+| `lease:write` | `POST /:state_key/lease` |
+
+Project API keys (`as_live_...`) have implicit access to all routes. Capability tokens (`as_cap_...`) are restricted to the scopes listed at mint time. See [capability-tokens.md](capability-tokens.md) for how to delegate scoped access to sub-agents.
+
+### Lease-guarded writes
+
+Pass `lease_id` in the `PUT` or `DELETE` body, or pass it as `?lease_id=` (DELETE only) or `X-Lease-Id` header (DELETE only), to bind the mutation to a held lease. If the lease has expired or was released, the request is rejected. This prevents stale agents from overwriting work done by the current lease holder. See [leases.md](leases.md) for the full lease recipe.
+
+### QueryStates — filter options
+
+The `POST /api/v1/states/query` body accepts:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `agent_id` | string | Exact-match filter on the writing agent |
+| `tags` | string[] | States that carry all listed tags |
+| `updated_after` | number (ms) | States updated after this Unix timestamp |
+| `updated_before` | number (ms) | States updated before this Unix timestamp |
+| `json_path` | string | JSONPath expression evaluated against `data` |
+| `json_equals` | any | Value `json_path` must equal |
+| `predicates` | `{path, equals}[]` | Up to 10 additional JSON predicates |
+| `at_sequence` | number | Return each state as it appeared at this global sequence |
+| `at_time` | number (ms) | Return each state as it appeared at this time |
+| `limit` | number | Max records per page (default 50, max 100) |
+| `cursor` | string | Pagination cursor from previous response |
+
+---
+
+[Get a free API key at agentstate.app](https://agentstate.app) or see [getting-started.md](../getting-started.md) for a two-minute setup guide.


### PR DESCRIPTION
## What

Adds the final two primitive recipes, completing the full set of five:

- `docs/recipes/states.md` — versioned key/value storage: upsert/get/delete/query, time-travel reads (`at_sequence`, `at_time`), append-only event log, SSE watch stream, idempotency keys, lease-guarded writes, and `QueryStates` filter reference table
- `docs/recipes/conversations.md` — agent memory primitive: create with seed messages, append, list (cursor pagination), get (field selection), search, by-external-id lookup, update, delete, bulk-delete (≤100), export, AI title/follow-ups/generate-all; message observability fields documented
- `docs/INDEX.md` — two new rows added next to the existing recipe rows

Each recipe follows the identical structure as the existing three (leases, claims, capability-tokens): H1 + one-liner, Core flow numbered list, runnable curl examples with JSON responses, TypeScript SDK, Python SDK, Key concepts, closing CTA.

## Why

Completes the backlog item DOC (primitive recipes). All five primitives now have a runnable recipe that readers can copy-paste directly.

## Verification

All schemas, method names, and routes were verified against actual source before writing:

- `UpsertStateSchema` (`agent_id`, `data`, `metadata`, `tags`, `lease_id`) and `QueryStatesSchema` (all fields) confirmed in `packages/api/src/lib/validation.ts`
- State route handlers confirmed in `packages/api/src/routes/v2/states/index.ts` (PUT/GET/DELETE/POST query/GET events/GET watch/POST lease)
- TS SDK method names (`upsertState`, `getState`, `queryStates`, `deleteState`, `listStateEvents`, `createStateLease`) confirmed in `packages/sdk/src/index.ts`
- Python SDK method names (`upsert_state`, `get_state`, `query_states`, `delete_state`, `list_state_events`, `create_state_lease`) confirmed in `packages/python-sdk/agentstate/client.py`
- Conversation routes confirmed in `packages/api/src/routes/conversations/` (crud, messages, search, bulk, analytics, ai.ts)
- `generate-all` endpoint exists in `ai.ts` but is NOT in either SDK — listed only under curl, not in SDK sections
- Python `upsert_state` signature (`state_key`, `state_dict`, `idempotency_key=None`) matches actual source
- Scopes (`state:read`, `state:write`, `state:watch`, `lease:write`) match `CAPABILITY_SCOPES` constant in validation.ts
- Base URL `https://agentstate.app`, all paths under `/api/v1/`

## Risk

🟢 Docs-only — no code changes, no schema changes, no runtime impact.

## Rollback

`git revert <commit>` or simply delete the two new files and revert the INDEX.md addition.