### PR TITLE
feat(api): standard security response headers (SEC-2)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -6,6 +6,7 @@ import { errorResponse } from "./lib/helpers";
 import { clerkDashboardAuth } from "./middleware/clerk-dashboard-auth";
 import { dbMiddleware } from "./middleware/db";
 import { requestIdMiddleware } from "./middleware/request-id";
+import { securityHeaders } from "./middleware/security-headers";
 import aiRouter from "./routes/ai";
 import analyticsRouter from "./routes/analytics";
 import analyticsPublicRouter from "./routes/analytics-public";
@@ -34,6 +35,7 @@ const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 // ---------------------------------------------------------------------------
 
 app.use("*", requestIdMiddleware);
+app.use("*", securityHeaders);
 
 // CORS configuration with origin reflection for security
 const ALLOWED_ORIGINS = [

--- a/packages/api/src/middleware/security-headers.ts
+++ b/packages/api/src/middleware/security-headers.ts
@@ -1,0 +1,27 @@
+import { createMiddleware } from "hono/factory";
+import type { Bindings, Variables } from "../types";
+
+/**
+ * Sets standard security response headers on every response.
+ *
+ * Headers applied:
+ * - X-Content-Type-Options: nosniff         — prevents MIME-type sniffing
+ * - X-Frame-Options: DENY                   — disallows framing (clickjacking protection)
+ * - Referrer-Policy: strict-origin-when-cross-origin — limits referrer leakage
+ * - Strict-Transport-Security: max-age=31536000; includeSubDomains
+ *                                           — enforces HTTPS (safe; no preload)
+ *
+ * Intentionally excluded (deferred for human review):
+ * - Content-Security-Policy — needs careful tuning to avoid breaking the dashboard
+ * - Cross-Origin-Opener-Policy / Cross-Origin-Embedder-Policy / Cross-Origin-Resource-Policy
+ *   — can break legitimate cross-origin API fetches
+ */
+export const securityHeaders = createMiddleware<{ Bindings: Bindings; Variables: Variables }>(
+  async (c, next) => {
+    await next();
+    c.header("X-Content-Type-Options", "nosniff");
+    c.header("X-Frame-Options", "DENY");
+    c.header("Referrer-Policy", "strict-origin-when-cross-origin");
+    c.header("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  },
+);

--- a/packages/api/test/security-headers.test.ts
+++ b/packages/api/test/security-headers.test.ts
@@ -1,0 +1,36 @@
+import { SELF } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+import { applyMigrations, seedProject } from "./setup";
+
+describe("Security headers", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await seedProject();
+  });
+
+  it("sets all four security headers on a successful JSON response", async () => {
+    const response = await SELF.fetch("http://localhost/api");
+    expect(response.status).toBe(200);
+
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("X-Frame-Options")).toBe("DENY");
+    expect(response.headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+    expect(response.headers.get("Strict-Transport-Security")).toBe(
+      "max-age=31536000; includeSubDomains",
+    );
+  });
+
+  it("sets all four security headers on an error response (401 from protected route)", async () => {
+    // A request to a protected route with no auth header triggers a 401 short-circuit.
+    // Security headers must still be present even when a handler short-circuits early.
+    const response = await SELF.fetch("http://localhost/v1/conversations");
+    expect(response.status).toBe(401);
+
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("X-Frame-Options")).toBe("DENY");
+    expect(response.headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+    expect(response.headers.get("Strict-Transport-Security")).toBe(
+      "max-age=31536000; includeSubDomains",
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds a `securityHeaders` Hono middleware that sets four standard HTTP security headers on **every** response — including errors and static dashboard assets:

| Header | Value |
|--------|-------|
| `X-Content-Type-Options` | `nosniff` |
| `X-Frame-Options` | `DENY` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` |

The middleware is wired in `index.ts` immediately after `requestIdMiddleware` (second in the chain) so it runs on all routes.

Files changed (exactly three):
- `packages/api/src/middleware/security-headers.ts` — new middleware
- `packages/api/src/index.ts` — import + `app.use("*", securityHeaders)` after `requestIdMiddleware`
- `packages/api/test/security-headers.test.ts` — new test file

## Why

Standard browser-security hygiene and a trust signal for enterprise customers. These four headers are low-risk, universally recommended, and directly implementable on an HTTPS-only API + dashboard served from a single Cloudflare Worker. Implements SEC-2 from the security backlog.

## Risk 🟡

**Additive only** — no existing behavior changed.

- **`X-Content-Type-Options: nosniff`** — prevents MIME sniffing; no functional impact on well-formed responses.
- **`X-Frame-Options: DENY`** — blocks iframe embedding; safe because the dashboard is not designed to be embedded. Dashboard navigation is direct.
- **`Referrer-Policy: strict-origin-when-cross-origin`** — limits referrer header to origin-only on cross-origin navigation; no API impact.
- **`Strict-Transport-Security: max-age=31536000; includeSubDomains`** — enforces HTTPS for 1 year. Safe because the API and dashboard are HTTPS-only on Cloudflare. `preload` deliberately omitted to avoid irrevocable HSTS preload list commitment without explicit human sign-off.

## Rollback

Revert this commit. No DB or config changes.

## Verification

- `bunx vitest run` — **274 passed (274)** (was 272 before this PR; +2 new tests)
- New tests assert all four headers on:
  1. Successful JSON response (`GET /api` → 200)
  2. Error response (`GET /v1/conversations` with no auth → 401) — proves headers are set even when middleware short-circuits
- `bunx biome check packages/api/src/` — clean (0 errors, 0 warnings)
- `bunx tsc --noEmit -p packages/api/tsconfig.json` — 0 errors

## CORS audit (no code change)

Current CORS config in `index.ts` (`app.use("*", cors({...}))`) uses **origin reflection**: if the incoming `Origin` header is in `ALLOWED_ORIGINS`, that exact origin is echoed back. If the origin is absent, `*` is returned. If the origin is present but not in the allowlist, `ALLOWED_ORIGINS[0]` (`https://agentstate.app`) is returned.

**Observation**: Returning `ALLOWED_ORIGINS[0]` for disallowed origins while `credentials: true` is set means browsers will still block the cross-origin request (the reflected origin won't match the actual request origin), so cookie/auth leakage is prevented. However, returning a static non-matching origin rather than `null`/`false` is unconventional — a strict approach would be to return `null` for disallowed origins. This is low risk in practice (browsers enforce the mismatch) but worth a dedicated SEC PR for human review.

## Deferred (needs human review)

- **Content-Security-Policy** — needs careful tuning per page type to avoid breaking the Astro dashboard (inline scripts, Clerk, etc.)
- **Cross-Origin-Opener-Policy / Cross-Origin-Embedder-Policy / Cross-Origin-Resource-Policy** — can break legitimate cross-origin API fetch calls from third-party agents; needs impact analysis before enabling