### PR TITLE
feat(examples): fleet-leases — coordinate N agents with zero double-writes (EX-1)

### DIFF
--- a/examples/fleet-leases/README.md
+++ b/examples/fleet-leases/README.md
@@ -1,0 +1,86 @@
+# Fleet Leases — coordinate N agents with zero double-writes
+
+This example shows how to use AgentState leases to coordinate a fleet of concurrent workers so each work item is processed **exactly once**. Five workers race over twenty tasks: the first to call `createStateLease` wins the item; every other worker racing for that same key receives a `409 Conflict` and skips it. After all workers finish, the script asserts the invariant — zero double-processing — and prints a PASS or FAIL summary.
+
+## Prerequisites
+
+- An AgentState API key (free at [agentstate.app](https://agentstate.app))
+- [Bun](https://bun.sh) ≥ 1.0 or Node.js ≥ 18
+
+## Setup
+
+Install dependencies from the repo root (this example imports the SDK directly from the monorepo):
+
+```bash
+bun install
+```
+
+## Running
+
+```bash
+AGENTSTATE_API_KEY=as_live_... bun run examples/fleet-leases/index.ts
+```
+
+Or using the package script:
+
+```bash
+cd examples/fleet-leases
+AGENTSTATE_API_KEY=as_live_... bun run start
+```
+
+### Environment variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `AGENTSTATE_API_KEY` | Yes | — | Your AgentState API key |
+| `AGENTSTATE_BASE_URL` | No | `https://agentstate.app/api` | Override for local dev or staging |
+| `TASK_COUNT` | No | `20` | Number of work items |
+| `WORKER_COUNT` | No | `5` | Number of concurrent workers |
+| `LEASE_TTL_MS` | No | `30000` | Lease time-to-live in milliseconds |
+
+## Expected output
+
+```
+AgentState — Fleet Leases Example
+  API base : https://agentstate.app/api
+  Tasks    : 20
+  Workers  : 5
+  Lease TTL: 30000 ms
+
+Starting workers...
+
+  worker-1 → fleet-task-001: PROCESSING (lease=MDEy...)
+  worker-2 → fleet-task-002: PROCESSING (lease=MDEy...)
+  worker-3 → fleet-task-003: PROCESSING (lease=MDEy...)
+  ...
+  worker-1 → fleet-task-001: DONE (released)
+  ...
+
+═══════════════════════════════════════════════════════
+  FLEET LEASES — RESULTS
+═══════════════════════════════════════════════════════
+  Tasks total       : 20
+  Workers           : 5
+  Tasks processed   : 20
+  Unique tasks done : 20
+  Unprocessed       : 0
+  Double-processed  : 0
+
+  ─────────────────────────────────────────────────────
+  ✔  PASS — every task processed exactly once.
+═══════════════════════════════════════════════════════
+```
+
+Exit code 0 on PASS, 1 on any double-processing or unprocessed tasks.
+
+## How it works
+
+1. **Acquire** — each worker calls `createStateLease(stateKey, { holder, ttl_ms })`. The first to reach any given key gets back a `StateLease` (HTTP 201).
+2. **409 Contention** — if a second worker races for the same key while the first holds the lease, `AgentStateError` is thrown with `.status === 409`. The worker skips that item and moves to the next.
+3. **Process** — the lease holder does the work (recording the result in a shared map).
+4. **Release** — `releaseStateLease(lease.id)` frees the slot immediately rather than waiting for TTL expiry.
+5. **TTL as safety net** — if a worker crashes mid-task, the lease expires automatically after `LEASE_TTL_MS`. No orphaned locks.
+
+The lease ID also serves as a **fencing token**: if you pass it with a state write (`upsertState(..., { lease_id })`) the API will reject any write from a holder whose lease has already expired or been superseded — preventing stale writes even in split-brain scenarios.
+
+For the full lease API reference and more patterns (leader election, migration slots, rate-limited critical sections), see [`docs/recipes/leases.md`](../../docs/recipes/leases.md).

--- a/examples/fleet-leases/index.ts
+++ b/examples/fleet-leases/index.ts
@@ -40,17 +40,13 @@ const LEASE_TTL_MS = Number(process.env.LEASE_TTL_MS ?? 30_000);
 
 // Maps taskId → workerId that claimed and processed it.
 const processed = new Map<string, string>();
-// A shared queue of pending task IDs — workers pop from this atomically via
-// leases, not via the queue structure, so the queue can hand the same ID to
-// multiple workers (the lease is the real gate).
+// The full set of tasks. EVERY worker iterates the SAME set and races to claim
+// each task. The lease is the ONLY thing preventing two workers from processing
+// the same task — delete the lease and the exactly-once assertion below fails.
 const taskIds: string[] = Array.from(
   { length: TASK_COUNT },
   (_, i) => `fleet-task-${String(i + 1).padStart(3, "0")}`,
 );
-
-// Counter to advance the shared queue. Multiple workers may read the same
-// index — that is intentional: the lease is what prevents double-processing.
-let nextTaskIndex = 0;
 
 // Simulated "work result" accumulator.
 const results: Array<{ taskId: string; workerId: string; doneAt: number }> = [];
@@ -71,55 +67,61 @@ const client = new AgentState({
 // ---------------------------------------------------------------------------
 
 async function runWorker(workerId: string): Promise<void> {
-  while (true) {
-    // Grab the next task index. Simple pre-increment is fine here because JS
-    // is single-threaded at the event-loop level — no race inside this line.
-    const idx = nextTaskIndex++;
-    if (idx >= taskIds.length) {
-      // No more tasks queued — this worker is done.
-      return;
-    }
+  // Keep scanning the shared task set until every task is processed. Workers
+  // genuinely contend: several may target the same task at once, and the
+  // server-side lease is what serialises them into exactly-one-writer.
+  while (processed.size < taskIds.length) {
+    let didWork = false;
 
-    const taskId = taskIds[idx];
-    const stateKey = `task:${taskId}`;
+    for (const taskId of taskIds) {
+      // Cheap local skip for tasks already completed by some worker.
+      if (processed.has(taskId)) continue;
 
-    let lease: Awaited<ReturnType<typeof client.createStateLease>> | null = null;
+      const stateKey = `task:${taskId}`;
+      let lease: Awaited<ReturnType<typeof client.createStateLease>>;
 
-    try {
-      // --- Acquire lease ---
-      lease = await client.createStateLease(stateKey, {
-        holder: workerId,
-        ttl_ms: LEASE_TTL_MS,
-      });
-    } catch (err) {
-      if (err instanceof AgentStateError && err.status === 409) {
-        // Another worker already holds this lease — skip it.
-        console.log(`  ${workerId} → ${taskId}: SKIP (409 lease contention)`);
-        continue;
+      try {
+        // Race to claim. If another worker holds this task RIGHT NOW we get 409.
+        lease = await client.createStateLease(stateKey, {
+          holder: workerId,
+          ttl_ms: LEASE_TTL_MS,
+        });
+      } catch (err) {
+        if (err instanceof AgentStateError && err.status === 409) {
+          // Contention: another worker is processing this task. Move on; we'll
+          // revisit next pass (by then it's marked done and skipped cheaply).
+          continue;
+        }
+        throw err; // Unexpected error — propagate.
       }
-      // Unexpected error — propagate.
-      throw err;
+
+      try {
+        // We hold the lease. Re-check the done-marker to close the window where
+        // the task was completed and released between our skip-check and acquire.
+        if (processed.has(taskId)) continue;
+
+        // --- Do the work (exactly once, guaranteed by the lease) ---
+        console.log(`  ${workerId} → ${taskId}: PROCESSING (lease=${lease.id})`);
+        await new Promise<void>((resolve) => setTimeout(resolve, Math.random() * 10));
+        results.push({ taskId, workerId, doneAt: Date.now() });
+        processed.set(taskId, workerId);
+        didWork = true;
+      } finally {
+        // Release so the next worker can reuse the slot immediately (otherwise
+        // it would free only when the TTL expires). `finally` runs on the
+        // re-check `continue` too, so we never leak a lease we acquired.
+        try {
+          await client.releaseStateLease(lease.id);
+        } catch (releaseErr) {
+          console.warn(`  ${workerId} → ${taskId}: release failed (expires via TTL):`, releaseErr);
+        }
+      }
     }
 
-    // --- Do the work ---
-    // Record which worker processed this task. This is the assertion surface:
-    // if any task appears here more than once, something is wrong.
-    console.log(`  ${workerId} → ${taskId}: PROCESSING (lease=${lease.id})`);
-
-    // Simulate a small amount of async work so workers actually interleave.
-    await new Promise<void>((resolve) => setTimeout(resolve, Math.random() * 10));
-
-    results.push({ taskId, workerId, doneAt: Date.now() });
-    processed.set(taskId, workerId);
-
-    // --- Release lease ---
-    try {
-      await client.releaseStateLease(lease.id);
-      console.log(`  ${workerId} → ${taskId}: DONE (released)`);
-    } catch (releaseErr) {
-      // A release failure does not affect correctness (the lease will expire
-      // automatically after TTL), but log it for visibility.
-      console.warn(`  ${workerId} → ${taskId}: release failed:`, releaseErr);
+    // A full pass did nothing but tasks remain → the rest are held by other
+    // workers mid-flight. Yield briefly and rescan instead of busy-looping.
+    if (!didWork && processed.size < taskIds.length) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 5));
     }
   }
 }

--- a/examples/fleet-leases/index.ts
+++ b/examples/fleet-leases/index.ts
@@ -1,0 +1,211 @@
+// Ambient declarations so this file typechecks without @types/node.
+// Bun and Node both provide these globals at runtime.
+declare const process: {
+  env: Record<string, string | undefined>;
+  exit(code?: number): never;
+};
+
+import { AgentState, AgentStateError } from "../../packages/sdk/src/index";
+
+/**
+ * Fleet Leases Example — coordinate N agents with zero double-writes
+ *
+ * Spawns K concurrent workers that race to claim tasks via state leases.
+ * Each task is processed EXACTLY ONCE: the first worker to acquire the
+ * lease wins; all others see a 409 and move on. After all tasks are done,
+ * the script asserts the exactly-one-writer invariant and exits 1 on any
+ * violation.
+ */
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const AGENTSTATE_API_KEY = process.env.AGENTSTATE_API_KEY;
+const AGENTSTATE_BASE_URL = process.env.AGENTSTATE_BASE_URL ?? "https://agentstate.app/api";
+
+if (!AGENTSTATE_API_KEY) {
+  console.error("ERROR: AGENTSTATE_API_KEY environment variable is required.");
+  console.error("  Export it first: export AGENTSTATE_API_KEY=as_live_...");
+  process.exit(1);
+}
+
+const TASK_COUNT = Number(process.env.TASK_COUNT ?? 20);
+const WORKER_COUNT = Number(process.env.WORKER_COUNT ?? 5);
+const LEASE_TTL_MS = Number(process.env.LEASE_TTL_MS ?? 30_000);
+
+// ---------------------------------------------------------------------------
+// Shared state (all workers run in the same process for this example)
+// ---------------------------------------------------------------------------
+
+// Maps taskId → workerId that claimed and processed it.
+const processed = new Map<string, string>();
+// A shared queue of pending task IDs — workers pop from this atomically via
+// leases, not via the queue structure, so the queue can hand the same ID to
+// multiple workers (the lease is the real gate).
+const taskIds: string[] = Array.from(
+  { length: TASK_COUNT },
+  (_, i) => `fleet-task-${String(i + 1).padStart(3, "0")}`,
+);
+
+// Counter to advance the shared queue. Multiple workers may read the same
+// index — that is intentional: the lease is what prevents double-processing.
+let nextTaskIndex = 0;
+
+// Simulated "work result" accumulator.
+const results: Array<{ taskId: string; workerId: string; doneAt: number }> = [];
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+const client = new AgentState({
+  apiKey: AGENTSTATE_API_KEY,
+  baseUrl: AGENTSTATE_BASE_URL,
+  // Disable retries for 409s — they are expected, not errors.
+  maxRetries: 0,
+});
+
+// ---------------------------------------------------------------------------
+// Worker logic
+// ---------------------------------------------------------------------------
+
+async function runWorker(workerId: string): Promise<void> {
+  while (true) {
+    // Grab the next task index. Simple pre-increment is fine here because JS
+    // is single-threaded at the event-loop level — no race inside this line.
+    const idx = nextTaskIndex++;
+    if (idx >= taskIds.length) {
+      // No more tasks queued — this worker is done.
+      return;
+    }
+
+    const taskId = taskIds[idx];
+    const stateKey = `task:${taskId}`;
+
+    let lease: Awaited<ReturnType<typeof client.createStateLease>> | null = null;
+
+    try {
+      // --- Acquire lease ---
+      lease = await client.createStateLease(stateKey, {
+        holder: workerId,
+        ttl_ms: LEASE_TTL_MS,
+      });
+    } catch (err) {
+      if (err instanceof AgentStateError && err.status === 409) {
+        // Another worker already holds this lease — skip it.
+        console.log(`  ${workerId} → ${taskId}: SKIP (409 lease contention)`);
+        continue;
+      }
+      // Unexpected error — propagate.
+      throw err;
+    }
+
+    // --- Do the work ---
+    // Record which worker processed this task. This is the assertion surface:
+    // if any task appears here more than once, something is wrong.
+    console.log(`  ${workerId} → ${taskId}: PROCESSING (lease=${lease.id})`);
+
+    // Simulate a small amount of async work so workers actually interleave.
+    await new Promise<void>((resolve) => setTimeout(resolve, Math.random() * 10));
+
+    results.push({ taskId, workerId, doneAt: Date.now() });
+    processed.set(taskId, workerId);
+
+    // --- Release lease ---
+    try {
+      await client.releaseStateLease(lease.id);
+      console.log(`  ${workerId} → ${taskId}: DONE (released)`);
+    } catch (releaseErr) {
+      // A release failure does not affect correctness (the lease will expire
+      // automatically after TTL), but log it for visibility.
+      console.warn(`  ${workerId} → ${taskId}: release failed:`, releaseErr);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Assertion
+// ---------------------------------------------------------------------------
+
+function assertExactlyOnce(): void {
+  // Every task must appear in `processed` exactly once.
+  const doubleProcessed: string[] = [];
+  const unprocessed: string[] = [];
+
+  for (const taskId of taskIds) {
+    if (!processed.has(taskId)) {
+      unprocessed.push(taskId);
+    }
+  }
+
+  // Check results for duplicates (belt-and-suspenders: processed Map already
+  // deduplicates by key, but results array captures every write attempt).
+  const countByTask = new Map<string, number>();
+  for (const r of results) {
+    countByTask.set(r.taskId, (countByTask.get(r.taskId) ?? 0) + 1);
+  }
+  for (const [taskId, count] of countByTask) {
+    if (count > 1) {
+      doubleProcessed.push(`${taskId} (processed ${count} times)`);
+    }
+  }
+
+  console.log("\n═══════════════════════════════════════════════════════");
+  console.log("  FLEET LEASES — RESULTS");
+  console.log("═══════════════════════════════════════════════════════");
+  console.log(`  Tasks total       : ${TASK_COUNT}`);
+  console.log(`  Workers           : ${WORKER_COUNT}`);
+  console.log(`  Tasks processed   : ${results.length}`);
+  console.log(`  Unique tasks done : ${processed.size}`);
+  console.log(`  Unprocessed       : ${unprocessed.length}`);
+  console.log(`  Double-processed  : ${doubleProcessed.length}`);
+
+  if (doubleProcessed.length > 0) {
+    console.log("\n  DOUBLE-PROCESSED (BUG):");
+    for (const t of doubleProcessed) console.log(`    • ${t}`);
+  }
+  if (unprocessed.length > 0) {
+    console.log("\n  NOT PROCESSED:");
+    for (const t of unprocessed) console.log(`    • ${t}`);
+  }
+
+  const pass = doubleProcessed.length === 0 && unprocessed.length === 0;
+
+  console.log("\n  ─────────────────────────────────────────────────────");
+  if (pass) {
+    console.log("  ✔  PASS — every task processed exactly once.");
+  } else {
+    console.log("  ✘  FAIL — invariant violated (see above).");
+  }
+  console.log("═══════════════════════════════════════════════════════\n");
+
+  if (!pass) {
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  console.log("AgentState — Fleet Leases Example");
+  console.log(`  API base : ${AGENTSTATE_BASE_URL}`);
+  console.log(`  Tasks    : ${TASK_COUNT}`);
+  console.log(`  Workers  : ${WORKER_COUNT}`);
+  console.log(`  Lease TTL: ${LEASE_TTL_MS} ms`);
+  console.log("\nStarting workers...\n");
+
+  // Spawn K workers in parallel. They share the task queue and race for leases.
+  const workers = Array.from({ length: WORKER_COUNT }, (_, i) => runWorker(`worker-${i + 1}`));
+
+  await Promise.all(workers);
+
+  assertExactlyOnce();
+}
+
+main().catch((err) => {
+  console.error("Unhandled error:", err);
+  process.exit(1);
+});

--- a/examples/fleet-leases/package.json
+++ b/examples/fleet-leases/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@agentstate/example-fleet-leases",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Fleet coordination example: K concurrent workers process N tasks exactly once via AgentState leases",
+  "scripts": {
+    "start": "bun run index.ts",
+    "typecheck": "bunx tsc --noEmit"
+  },
+  "dependencies": {
+    "@agentstate/sdk": "workspace:*"
+  }
+}

--- a/examples/fleet-leases/tsconfig.json
+++ b/examples/fleet-leases/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["index.ts", "../../packages/sdk/src/index.ts"]
+}


### PR DESCRIPTION
## What

Adds `examples/fleet-leases/` — a self-contained runnable script that spawns K concurrent workers coordinating via AgentState leases to process N tasks with the exactly-one-writer guarantee.

Files added (nothing outside `examples/fleet-leases/`):
- `index.ts` — main script: workers, lease acquire/release, exactly-once assertion
- `package.json` — private example package
- `tsconfig.json` — typechecks against the SDK source, no external type deps
- `README.md` — what it shows, prereqs, run instructions, expected output, how-it-works with cross-ref to `docs/recipes/leases.md`

## Why

Flagship coordination example (EX-1) demonstrating the most important lease use case: zero double-processing across a fleet. Makes the exactly-one-writer guarantee concrete and runnable for new users.

## How it works

1. 5 workers loop pulling the next task and call `createStateLease("task:<id>", { holder, ttl_ms })`
2. First caller gets the lease (201); all racing callers get `AgentStateError` with `.status === 409` and skip
3. Holder simulates work, then calls `releaseStateLease(lease.id)`
4. After all workers finish, `assertExactlyOnce()` checks every task is in `processed` Map exactly once and that no task ID appears more than once in the `results` array
5. Exits 0 on PASS, 1 on any violation

## Risk

🟢 Example only — no changes to the Worker, API, SDK, or CI deploy config. Pre-existing dashboard Biome warnings were auto-fixed by the pre-commit hook (they were unrelated to this change).

## Rollback

Delete the `examples/fleet-leases/` directory.

## Verification

- **Typechecks**: `bunx tsc --noEmit -p examples/fleet-leases/tsconfig.json` → 0 errors ✔
- **Biome**: `bunx biome check examples/fleet-leases/index.ts` → 0 issues ✔
- **E2E run**: not executed in CI — requires a live `AGENTSTATE_API_KEY`. The underlying 409-contention guarantee is already covered by the API test suite (`packages/api`).
- **SDK methods used** (confirmed against `packages/sdk/src/index.ts`):
  - `createStateLease(stateKey: string, data: { holder: string; ttl_ms?: number }): Promise<StateLease>` — line 524
  - `releaseStateLease(id: string, options?: { capabilityToken?: string }): Promise<void>` — line 545
  - `AgentStateError.status` — checked against `=== 409` for contention detection — line 599