### PR TITLE
docs(index): 5-primitives table linking each recipe (MSG-2)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,5 +1,17 @@
 # Documentation Index
 
+## 5 Coordination Primitives
+
+| Primitive | What it's for | Recipe |
+|-----------|---------------|--------|
+| **States** | Versioned key/value storage — durable agent state with time-travel reads and SSE watch | [recipes/states.md](recipes/states.md) |
+| **Leases** | Distributed locking — coordinate N agents with exactly-one-writer semantics | [recipes/leases.md](recipes/leases.md) |
+| **Capability Tokens** | Scoped sub-agent delegation — least-privilege tokens for untrusted processes | [recipes/capability-tokens.md](recipes/capability-tokens.md) |
+| **Claims** | Verifiable agent output — attest and audit work with evidence | [recipes/claims.md](recipes/claims.md) |
+| **Conversations** | Agent memory primitive — create, append, search, export, and AI-enrich conversation history | [recipes/conversations.md](recipes/conversations.md) |
+
+## All Guides
+
 | Guide | Description |
 |-------|-------------|
 | [Getting Started](getting-started.md) | Zero to working in 2 minutes |


### PR DESCRIPTION
## What

Add a **5 Coordination Primitives** table near the top of `docs/INDEX.md` with columns: Primitive | What it's for | Recipe. Each of the five rows (States, Leases, Capability Tokens, Claims, Conversations) links to its recipe file.

## Why

A new reader had to scroll the full guide list to discover the core surface. The table gives an instant overview of what AgentState coordinates and where to go next.

## Risk

Docs-only change. No code touched.

## Rollback

`git revert` the single commit.