### PR TITLE
docs(blog): why agent memory tools aren't enough for multi-agent systems (CONTENT-3)

### DIFF
--- a/docs/blog/README.md
+++ b/docs/blog/README.md
@@ -7,6 +7,7 @@ Developer-focused posts about building AI agent systems.
 | Date | Title |
 |------|-------|
 | 2026-06-18 | [Coordinating a fleet of agents with leases (zero double-writes)](./coordinating-a-fleet-of-agents-with-leases.md) |
+| 2026-06-18 | [Why agent memory tools aren't enough for multi-agent systems](./why-agent-memory-isnt-enough.md) |
 
 ---
 

--- a/docs/blog/why-agent-memory-isnt-enough.md
+++ b/docs/blog/why-agent-memory-isnt-enough.md
@@ -1,0 +1,150 @@
+# Why agent memory tools aren't enough for multi-agent systems
+
+_Published 2026-06-18_
+
+---
+
+Vector stores, conversation histories, and retrieval-augmented generation are all forms of **agent memory** — a way for a single agent to recall what it has seen before. Memory is essential. But when you move from one agent to a fleet of agents working in parallel, memory alone cannot keep them from stepping on each other.
+
+This post explains why, and what kind of infrastructure fills the gap.
+
+---
+
+## What memory tools actually give you
+
+Agent memory — whether it's a vector store, a long-context window stuffed with history, or a database of past summaries — solves **recall**. A single agent can look up what happened in earlier sessions, retrieve semantically similar examples, or resume where it left off.
+
+That is a genuine and valuable capability. But recall is passive: it answers "what did we do before?" It cannot answer "who is doing this right now?" It has no notion of exclusive ownership, no mechanism to prevent two readers from both deciding they are the one who should act.
+
+Memory reads are non-exclusive by design. A vector store does not care how many agents query it at the same time. That's fine for retrieval. It is a problem for coordination.
+
+---
+
+## The failure mode: double-processing
+
+Suppose you have three agents draining a queue of work items — document summaries to generate, orders to fulfill, embeddings to compute. Each agent fetches the list and picks the next available item. Without any coordination layer, two agents independently notice that `doc-001` is unprocessed and both start working on it. The result:
+
+- Two identical summaries written to the same output slot.
+- Two embedding API calls billed for one document.
+- Downstream logic that assumed exactly-one write now sees a race condition.
+
+Memory gives neither agent a way to declare "I have this one." A vector search for "what's claimed?" returns nothing, because no one has written a claim yet — and even if one agent writes immediately after reading, the other agent already started.
+
+This is not a corner case. It is the default behavior of any fan-out system without mutual exclusion.
+
+---
+
+## What mutual exclusion looks like: a lease
+
+The right primitive here is a **lease** — an exclusive, time-bounded claim on a named key. The protocol is straightforward:
+
+1. An agent races to acquire the lease by calling `POST /api/v1/states/:key/lease`.
+2. The first caller gets HTTP 201 and a lease object. Every other caller racing for the same key gets HTTP 409 while the lease is active.
+3. The winner does the work, then releases the lease with `DELETE /api/v1/leases/:id`.
+4. If the winner crashes mid-work, the lease expires after its TTL and the next agent can claim the slot.
+
+Here is the acquire → work → release cycle in curl:
+
+```bash
+# Step 1: Acquire. First caller wins, all others get 409.
+curl -s -X POST https://agentstate.app/api/v1/states/task:doc-001/lease \
+  -H "Authorization: Bearer $AGENTSTATE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"holder": "agent-1", "ttl_ms": 30000}'
+# → 201 with lease.id, fencing_token, expires_at
+
+# Step 2: Do the work (embedding call, DB write, etc.)
+
+# Step 3: Release so the next agent can pick up the next unclaimed task.
+curl -s -X DELETE https://agentstate.app/api/v1/leases/<lease.id> \
+  -H "Authorization: Bearer $AGENTSTATE_KEY"
+# → 204 No Content
+```
+
+The 409 response tells agent-2 to skip `doc-001` and move to `doc-002` — no retry loop, no polling, no external queue broker. The lease TTL is the safety net: a crashed agent is evicted after at most one TTL period.
+
+Each lease also carries a `fencing_token` — a monotonically increasing integer per state key. Pass this token with any downstream write so stale agents whose lease expired mid-flight cannot overwrite the work of the current holder.
+
+Memory has no equivalent to any of this. A vector store cannot issue a 409.
+
+---
+
+## The broader coordination gap
+
+Mutual exclusion is the sharpest example, but fleet coordination involves more than locking. Here is where each of AgentState's five primitives maps to a real coordination need that memory cannot address:
+
+### Mutual exclusion — leases (`/api/v1/leases`)
+
+Covered above. One agent holds the key; all others observe 409 and skip. Automatic TTL eviction handles crashes. Fencing tokens prevent stale writes.
+
+### Trust between agents — claims (`/api/v1/claims`)
+
+In a pipeline where one agent produces output consumed by another, the consumer has no way to verify that the producer did what it claimed. A vector store entry says "the summary is in here" — it does not prove the summary matches the source.
+
+Claims give agents a way to file verifiable evidence. The producer hashes the output text and posts the hash alongside the claim statement:
+
+```bash
+curl -s -X POST https://agentstate.app/api/v1/claims \
+  -H "Authorization: Bearer $AGENTSTATE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "subject_type": "conversation",
+    "subject_id": "conv_abc",
+    "statement": "Summary is faithful to the source document.",
+    "evidence": [{"kind": "text_hash", "source": "summary", "data": "...", "hash": "..."}]
+  }'
+# → 201 with claim.id and status: "pending"
+```
+
+Any downstream agent or audit process can then call `POST /api/v1/claims/:id/verify` to re-hash the stored data and confirm the claim is still valid. This is a coordination guarantee — provenance — not retrieval.
+
+### Safe delegation to sub-agents — capability tokens (`/api/v1/capability-tokens`)
+
+When an orchestrator spawns a sub-agent to do a specific task, it should give that sub-agent exactly the permissions it needs — not the full project key. Memory stores carry no concept of scope. If the sub-agent's environment is compromised or the sub-agent misbehaves, it could read or write anything the orchestrator can access.
+
+Capability tokens are minted from the project API key and restricted to a list of scopes at creation time. An orchestrator that wants a summarizer sub-agent to write claims but nothing else:
+
+```bash
+curl -s -X POST https://agentstate.app/api/v1/capability-tokens \
+  -H "Authorization: Bearer $AGENTSTATE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "summarizer", "scopes": ["claim:write"], "expires_at": 1718786400000}'
+# → 201 with token: "as_cap_..."
+```
+
+The sub-agent receives `as_cap_...` — not the project key. Any request outside `claim:write` returns HTTP 403. When the job is done, the orchestrator revokes the token with `DELETE /api/v1/capability-tokens/:id`. Revocation is immediate.
+
+### Consistent shared state — states (`/api/v1/states`)
+
+Multiple agents that need to share a single view of the world — a pipeline checkpoint, a running job configuration, a progress counter — need a place to write and read that value with consistency guarantees. Retrieval from a vector store is approximate and unordered. States are exact, versioned, and append-only.
+
+Every write to `PUT /api/v1/states/:key` increments a `latest_sequence`. You can read the current snapshot, read a prior snapshot at any sequence or timestamp, subscribe to an SSE stream of all writes project-wide, or query states by agent ID, tags, or JSON predicates. Writes can be guarded by a held lease, so only the current lock holder can update the shared value.
+
+### Shared history — conversations (`/api/v1/conversations`)
+
+Conversations are the memory-adjacent primitive: a durable, queryable log of `(role, content)` turns. Multiple agents can append to the same conversation, search its content with full-text queries, and export the full history. Unlike a general-purpose vector store, each conversation is a structured object with metadata, token counts, and cursor-based pagination — purpose-built for the shape of agent dialogue rather than approximate similarity search.
+
+---
+
+## Memory and coordination are not substitutes
+
+The framing "memory vs. coordination" is slightly misleading. A well-built multi-agent system needs both. Memory lets agents recall context from earlier runs. Coordination lets agents work concurrently without corrupting shared resources.
+
+The mistake is assuming that more memory — longer context, better retrieval, richer embeddings — eventually solves the coordination problem. It does not. No matter how good the recall, two agents reading the same unguarded state will race. Coordination requires primitives that are inherently exclusive and time-bounded, not primitives that are inherently shared and approximate.
+
+If you are building a multi-agent system today and finding that agents occasionally duplicate work, produce inconsistent outputs, or fail silently when a sub-agent misbehaves, the gap is almost certainly coordination, not recall.
+
+---
+
+## Get started
+
+A free API key gives you access to all five primitives — leases, claims, capability tokens, states, and conversations.
+
+**[Get your free key at agentstate.app](https://agentstate.app)**
+
+```bash
+npm install @agentstate/sdk
+# or: pip install agentstate
+```
+
+See [getting-started.md](../getting-started.md) for a two-minute walkthrough, and the [recipes](../recipes/) directory for runnable examples of each primitive.


### PR DESCRIPTION
## What

Adds `docs/blog/why-agent-memory-isnt-enough.md` — a category POV blog post arguing that agent memory tools (vector stores, RAG, long-context recall) solve single-agent recall but cannot provide the coordination guarantees multi-agent fleets require. Maps each coordination need to a real AgentState primitive with verified API routes.

Also appends one row to `docs/blog/README.md` to list the new post.

## Why

CONTENT-3 from the content plan. Targets developers evaluating infrastructure for multi-agent systems — positions AgentState as coordination layer, not just memory.

Angle: the failure mode is concrete (double-processing when two agents race for the same task), the solution is a lease (409 = skip, not retry), and each of the five primitives addresses a distinct coordination gap that memory fundamentally cannot.

## Risk & rollback

🟢 docs-only — no code, no schema, no API changes. Rollback = revert the commit.

## Verification

- Internal links checked: `docs/getting-started.md`, `docs/recipes/` (leases, claims, capability-tokens, states, conversations) — all resolve.
- All product claims grounded in real routes from recipe files (`/api/v1/leases`, `/api/v1/claims`, `/api/v1/capability-tokens`, `/api/v1/states`, `/api/v1/conversations`). No fabricated metrics, benchmarks, pricing, or customer counts.
- curl snippet uses `$AGENTSTATE_KEY` placeholder — no real keys.
- Secret scan: `git diff origin/main...HEAD | grep -nE 'sk_live_|pk_live_|CLERK_SECRET|...'` — empty (clean).