### PR TITLE
docs: tighten quickstart + fix stale refs (CONTENT-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ curl -X POST https://agentstate.app/api/v1/conversations \
     ]
   }'
 
-# Retrieve it later
-curl https://agentstate.app/api/v1/conversations/:id \
+# Retrieve it (replace $CONVERSATION_ID with the id from the response above)
+curl https://agentstate.app/api/v1/conversations/$CONVERSATION_ID \
   -H "Authorization: Bearer as_live_your_key"
 ```
 
@@ -127,7 +127,7 @@ bun install
 # API (port 8787)
 cd packages/api && bunx wrangler dev
 
-# Dashboard (port 3000, separate dev server)
+# Dashboard (port 4321, separate dev server)
 cd packages/dashboard && bun run dev
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,17 +9,7 @@ Store and retrieve AI agent conversations with AgentState in under 2 minutes.
 
 ## Step 1: Get an API key
 
-Create a project at [agentstate.app](https://agentstate.app) to get your API key.
-
-You can also create one via the API:
-
-```bash
-curl -X POST https://agentstate.app/api/v1/projects \
-  -H "Content-Type: application/json" \
-  -d '{"name": "My Project"}'
-```
-
-The response includes your API key (format: `as_live_` + 40 characters). Save it -- the full key is only shown once.
+Sign up at [agentstate.app](https://agentstate.app), create a project, and copy the API key from the dashboard. Keys have the format `as_live_` followed by 40 characters. Save it — the full key is shown only once.
 
 ## Step 2: Install the SDK
 
@@ -121,3 +111,4 @@ See [Environment Variables](./environment-variables.md) for the full list of con
 - [SDK Guide](./sdk.md) -- Advanced SDK usage and error handling
 - [Framework Integration](./integration.md) -- Vercel AI SDK, Cloudflare Agents, LangGraph
 - [Environment Variables](./environment-variables.md) -- Configuration reference
+- [Leases recipe](./recipes/leases.md) -- Distributed locking for exactly-one-writer coordination across agent fleets


### PR DESCRIPTION
## What
Polish the 2-minute getting-started flow and fix stale references.

## Why
CONTENT-4 (onboarding/growth). New users hit the quickstart first; it must be correct.

## Changes
- `getting-started.md`: remove the broken keyless `POST /api/v1/projects` curl (project creation requires Clerk dashboard auth, so it would 401) → point to dashboard signup; add leases-recipe pointer.
- `README.md`: dashboard dev port `3000`→`4321` (matches actual dev server); use `$CONVERSATION_ID` in the retrieve example.

## Risk & rollback
🟢 docs-only. Rollback = revert PR.

## Verification
- Project-creation auth confirmed: `app.use("/api/v1/projects", clerkDashboardAuth)` in index.ts.
- All paths/SDK names match `docs/api-reference.md`; secret-scan clean.

🤖 Autonomous overnight PR (edit-only agent + central git).