### PR TITLE
refactor(api): centralize tunable constants into lib/config.ts (DEHARD-1)

### DIFF
--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -1,0 +1,54 @@
+/**
+ * config.ts — Single source of truth for tunable runtime constants.
+ *
+ * Every constant exported here is the authoritative value referenced by its
+ * call sites (no shadow copies left hardcoded elsewhere). Group by concern and
+ * keep values "boring": they should change only when product/ops policy changes,
+ * not during routine refactors.
+ *
+ * Note: auth/rate-limit constants are deliberately NOT centralized here — those
+ * live next to their security-critical logic and are changed under human review.
+ */
+
+// ---------------------------------------------------------------------------
+// Leases
+// ---------------------------------------------------------------------------
+
+/** Default lease TTL (ms) when the caller omits `ttl_ms`. */
+export const LEASE_DEFAULT_TTL_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// Cache TTLs (seconds)
+// ---------------------------------------------------------------------------
+
+/** Short-lived cache TTL — 1 minute. Used for short analytics periods. */
+export const CACHE_TTL_SHORT_S = 60;
+
+/** Medium cache TTL — 3 minutes. */
+export const CACHE_TTL_MEDIUM_S = 180;
+
+/** Long cache TTL — 5 minutes. Used for long analytics periods. */
+export const CACHE_TTL_LONG_S = 300;
+
+/** TTL for conversation-count cache entries — 1 minute. */
+export const CACHE_COUNT_TTL_S = 60;
+
+// ---------------------------------------------------------------------------
+// Retention / Scheduled cleanup
+// ---------------------------------------------------------------------------
+
+/** Maximum conversations deleted per batch in the retention cleanup job. */
+export const RETENTION_BATCH_SIZE = 500;
+
+/**
+ * Per-invocation time budget (ms) for the retention cleanup scheduled handler.
+ * Keeps us safely under the Workers 30s wall-clock limit.
+ */
+export const RETENTION_TIME_BUDGET_MS = 25_000;
+
+// ---------------------------------------------------------------------------
+// Time
+// ---------------------------------------------------------------------------
+
+/** Milliseconds per day — used when converting `retention_days`/ranges to cutoffs. */
+export const MS_PER_DAY = 86_400_000;

--- a/packages/api/src/lib/helpers.ts
+++ b/packages/api/src/lib/helpers.ts
@@ -3,6 +3,7 @@ import type { Context } from "hono";
 import type { z } from "zod";
 import { conversations } from "../db/schema";
 import type { Bindings, Variables } from "../types";
+import { CACHE_COUNT_TTL_S } from "./config";
 
 export type AppContext = Context<{ Bindings: Bindings; Variables: Variables }>;
 
@@ -143,7 +144,9 @@ export async function getCachedCount(
   const count = await fetchFn();
 
   if (cache) {
-    c.executionCtx.waitUntil(cache.put(cacheKey, JSON.stringify(count), { expirationTtl: 60 }));
+    c.executionCtx.waitUntil(
+      cache.put(cacheKey, JSON.stringify(count), { expirationTtl: CACHE_COUNT_TTL_S }),
+    );
   }
 
   return count;

--- a/packages/api/src/routes/analytics.ts
+++ b/packages/api/src/routes/analytics.ts
@@ -1,6 +1,7 @@
 import { and, eq, gte, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { conversations, messages, organizations, projects } from "../db/schema";
+import { MS_PER_DAY } from "../lib/config";
 import { errorResponse } from "../lib/helpers";
 import type { Bindings, Variables } from "../types";
 
@@ -53,7 +54,7 @@ app.get("/:id/analytics", async (c) => {
 
   const rangeParam = c.req.query("range") ?? "30d";
   const days = RANGE_DAYS[rangeParam] ?? 30;
-  const cutoff = Date.now() - days * 86_400_000;
+  const cutoff = Date.now() - days * MS_PER_DAY;
 
   // Build cache key
   const cacheKey = `analytics:public:${projectId}:${rangeParam}`;

--- a/packages/api/src/services/analytics.ts
+++ b/packages/api/src/services/analytics.ts
@@ -5,15 +5,12 @@
 import { and, eq, gte, inArray, lte, sql } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { conversations, conversationTags } from "../db/schema";
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-/** Cache TTL values (in seconds) */
-const CACHE_TTL_SHORT = 60; // 1 minute - for short time ranges
-const CACHE_TTL_MEDIUM = 180; // 3 minutes - for medium time ranges
-const CACHE_TTL_LONG = 300; // 5 minutes - for long time ranges
+import {
+  CACHE_TTL_LONG_S as CACHE_TTL_LONG,
+  CACHE_TTL_MEDIUM_S as CACHE_TTL_MEDIUM,
+  CACHE_TTL_SHORT_S as CACHE_TTL_SHORT,
+  MS_PER_DAY,
+} from "../lib/config";
 
 /** Valid metric types for timeseries */
 export const VALID_METRICS = ["conversations", "messages", "tokens", "cost"] as const;
@@ -89,7 +86,7 @@ function hashString(str: string): string {
  * Get TTL based on time range - shorter ranges get shorter cache times.
  */
 export function getTtlForPeriod(start: number, end: number): number {
-  const days = (end - start) / 86_400_000;
+  const days = (end - start) / MS_PER_DAY;
   if (days <= 1) return CACHE_TTL_SHORT;
   if (days <= 7) return CACHE_TTL_SHORT;
   if (days <= 30) return CACHE_TTL_MEDIUM;
@@ -110,7 +107,7 @@ export function parseTimestamp(raw: string | undefined): number | undefined {
  */
 export function defaultPeriod(): AnalyticsPeriod {
   const end = Date.now();
-  const start = end - 30 * 86_400_000;
+  const start = end - 30 * MS_PER_DAY;
   return { start, end };
 }
 

--- a/packages/api/src/services/leases.ts
+++ b/packages/api/src/services/leases.ts
@@ -1,9 +1,8 @@
 import { and, desc, eq, gt, isNull } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { stateLeases } from "../db/schema";
+import { LEASE_DEFAULT_TTL_MS } from "../lib/config";
 import { generateId } from "../lib/id";
-
-const DEFAULT_LEASE_TTL_MS = 60_000;
 
 export interface LeaseResponse {
   id: string;
@@ -38,7 +37,7 @@ export async function createLease(
   projectId: string,
   stateKey: string,
   holder: string,
-  ttlMs = DEFAULT_LEASE_TTL_MS,
+  ttlMs = LEASE_DEFAULT_TTL_MS,
 ): Promise<{ lease?: LeaseResponse; error?: LeaseError }> {
   const now = Date.now();
   const [active] = await db
@@ -92,7 +91,7 @@ export async function renewLease(
   db: DrizzleD1Database,
   projectId: string,
   leaseId: string,
-  ttlMs = DEFAULT_LEASE_TTL_MS,
+  ttlMs = LEASE_DEFAULT_TTL_MS,
 ): Promise<{ lease?: LeaseResponse; error?: LeaseError }> {
   const now = Date.now();
   const [lease] = await db

--- a/packages/api/src/services/public-analytics.ts
+++ b/packages/api/src/services/public-analytics.ts
@@ -1,15 +1,12 @@
 import { and, eq, gte, inArray, lte, sql } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { conversations, conversationTags } from "../db/schema";
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-// Cache TTL values (in seconds)
-const CACHE_TTL_SHORT = 60; // 1 minute - for short time ranges
-const CACHE_TTL_MEDIUM = 180; // 3 minutes - for medium time ranges
-const CACHE_TTL_LONG = 300; // 5 minutes - for long time ranges
+import {
+  CACHE_TTL_LONG_S as CACHE_TTL_LONG,
+  CACHE_TTL_MEDIUM_S as CACHE_TTL_MEDIUM,
+  CACHE_TTL_SHORT_S as CACHE_TTL_SHORT,
+  MS_PER_DAY,
+} from "../lib/config";
 
 const VALID_METRICS = ["conversations", "messages", "tokens"] as const;
 const VALID_GRANULARITIES = ["day", "week", "month"] as const;
@@ -52,7 +49,7 @@ export function hashString(str: string): string {
 
 /** Get TTL based on time range - shorter ranges get shorter cache times. */
 export function getTtlForPeriod(start: number, end: number): number {
-  const days = (end - start) / 86_400_000;
+  const days = (end - start) / MS_PER_DAY;
   if (days <= 1) return CACHE_TTL_SHORT;
   if (days <= 7) return CACHE_TTL_SHORT;
   if (days <= 30) return CACHE_TTL_MEDIUM;
@@ -69,7 +66,7 @@ export function parseTimestamp(raw: string | undefined): number | undefined {
 /** Default period: last 30 days. Returns [start, end]. */
 export function defaultPeriod(): [number, number] {
   const end = Date.now();
-  const start = end - 30 * 86_400_000;
+  const start = end - 30 * MS_PER_DAY;
   return [start, end];
 }
 

--- a/packages/api/src/services/retention.ts
+++ b/packages/api/src/services/retention.ts
@@ -1,9 +1,7 @@
 import { and, eq, inArray, isNotNull, lt } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { conversations, conversationTags, messages, projects } from "../db/schema";
-
-const BATCH_SIZE = 500;
-const TIME_BUDGET_MS = 25_000;
+import { MS_PER_DAY, RETENTION_BATCH_SIZE, RETENTION_TIME_BUDGET_MS } from "../lib/config";
 
 interface RetentionResult {
   projectId: string;
@@ -38,7 +36,7 @@ export async function cleanupExpiredConversations(
 
   for (const project of projectsWithRetention) {
     const projectStart = Date.now();
-    if (projectStart - start > TIME_BUDGET_MS) {
+    if (projectStart - start > RETENTION_TIME_BUDGET_MS) {
       console.warn(
         JSON.stringify({
           level: "warn",
@@ -51,20 +49,20 @@ export async function cleanupExpiredConversations(
     }
 
     const retentionDays = project.retentionDays as number;
-    const cutoff = Date.now() - retentionDays * 86_400_000;
+    const cutoff = Date.now() - retentionDays * MS_PER_DAY;
     let totalDeleted = 0;
     let batchCount = 0;
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
-      if (Date.now() - start > TIME_BUDGET_MS) break;
+      if (Date.now() - start > RETENTION_TIME_BUDGET_MS) break;
 
       // Fetch a batch of expired conversation IDs
       const expired = await db
         .select({ id: conversations.id })
         .from(conversations)
         .where(and(eq(conversations.projectId, project.id), lt(conversations.updatedAt, cutoff)))
-        .limit(BATCH_SIZE);
+        .limit(RETENTION_BATCH_SIZE);
 
       if (expired.length === 0) break;
 
@@ -80,8 +78,8 @@ export async function cleanupExpiredConversations(
       totalDeleted += ids.length;
       batchCount++;
 
-      // If we got fewer than BATCH_SIZE, this was the last batch
-      if (expired.length < BATCH_SIZE) break;
+      // If we got fewer than RETENTION_BATCH_SIZE, this was the last batch
+      if (expired.length < RETENTION_BATCH_SIZE) break;
     }
 
     results.push({

--- a/packages/api/src/services/v2-conversations.ts
+++ b/packages/api/src/services/v2-conversations.ts
@@ -5,6 +5,7 @@
 import { and, asc, desc, eq, gt, lt, sql } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { conversations, conversationTags, messages } from "../db/schema";
+import { CACHE_COUNT_TTL_S } from "../lib/config";
 import { generateId } from "../lib/id";
 import { serializeMetadata } from "../lib/serialization";
 
@@ -288,7 +289,7 @@ export async function listConversations(
     count = countResult?.count ?? 0;
 
     if (cache) {
-      await cache.put(cacheKey, JSON.stringify(count), { expirationTtl: 60 });
+      await cache.put(cacheKey, JSON.stringify(count), { expirationTtl: CACHE_COUNT_TTL_S });
     }
   }
 


### PR DESCRIPTION
## What
Introduces `packages/api/src/lib/config.ts` as the single authoritative home for tunable runtime constants, and rewires the call sites to import from it:
- Lease default TTL (`LEASE_DEFAULT_TTL_MS`)
- Cache TTLs (`CACHE_TTL_SHORT_S` / `MEDIUM` / `LONG`, `CACHE_COUNT_TTL_S`)
- Retention job batch size + per-invocation time budget (`RETENTION_BATCH_SIZE`, `RETENTION_TIME_BUDGET_MS`)
- `MS_PER_DAY` (replacing scattered `86_400_000` literals)

Every constant is the genuine source — no shadow copies left hardcoded elsewhere. Auth and rate-limit constants are **deliberately left next to their security-critical logic** (protected code, human-gated) and not centralized here.

## Why
Backlog **DEHARD-1** — de-hardcode & portability. Centralizing tunables makes them discoverable and changeable in one place, a prerequisite for later config/self-host work.

## Risk & rollback
- Risk: 🟢 none — pure refactor, every value is byte-identical; no runtime behavior change.
- Rollback: revert this PR.

## Verification
- [x] biome clean (`packages/api/src/`)
- [x] tsc 0 errors
- [x] vitest **280/280** (unchanged from baseline)
- [ ] dashboard build (n/a — no dashboard change)

🤖 Autonomous overnight PR. Co-authored per repo convention.