### PR TITLE
feat(dashboard): SEO meta + sitemap for marketing pages (LP-4)

### DIFF
--- a/packages/dashboard/public/sitemap.xml
+++ b/packages/dashboard/public/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://agentstate.app/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://agentstate.app/docs</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://agentstate.app/brand</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+</urlset>

--- a/packages/dashboard/src/layouts/MarketingLayout.astro
+++ b/packages/dashboard/src/layouts/MarketingLayout.astro
@@ -6,14 +6,25 @@ import Logo from "../components/logo.astro";
 import RevealScript from "../components/reveal-script.astro";
 import ThemeScript from "../components/theme-script.astro";
 
+const SITE = "https://agentstate.app";
+const DEFAULT_OG_IMAGE = `${SITE}/brand/agentstate-logo.png`;
+
 interface Props {
   title?: string;
   description?: string;
+  /** Absolute URL for og:image. Defaults to the AgentState logo PNG. */
+  ogImage?: string;
+  /** Canonical path (e.g. "/docs"). Defaults to Astro.url.pathname. */
+  canonical?: string;
 }
 const {
-  title = "AgentState — the state layer for AI agents",
-  description = "Store conversations, UI messages and graph state behind one API. Drop-in adapters for every framework you already use.",
+  title = "AgentState — State & coordination layer for AI agent fleets",
+  description = "Stop reinventing distributed state. AgentState gives your agent fleet five primitives — state, leases, claims, tokens, and conversations — behind one API.",
+  ogImage = DEFAULT_OG_IMAGE,
+  canonical,
 } = Astro.props;
+
+const canonicalUrl = new URL(canonical ?? Astro.url.pathname, SITE).href;
 ---
 <!doctype html>
 <html lang="en" class="dark">
@@ -22,6 +33,23 @@ const {
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>{title}</title>
     <meta name="description" content={description} />
+    <link rel="canonical" href={canonicalUrl} />
+    <!-- OpenGraph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="AgentState" />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:image" content={ogImage} />
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={ogImage} />
+    <!-- Favicons -->
+    <link rel="icon" href="/favicon.ico" sizes="any" />
+    <link rel="icon" href="/icon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png" />
     <ThemeScript />
   </head>
   <body class="min-h-screen bg-base text-fg-2">

--- a/packages/dashboard/src/pages/brand.astro
+++ b/packages/dashboard/src/pages/brand.astro
@@ -104,7 +104,8 @@ const iconAssets = [
 
 <MarketingLayout
   title="Brand — AgentState"
-  description="AgentState identity: three stacked state layers — one persistent memory hub serving many agent runtimes."
+  description="AgentState brand assets: logos in SVG and PNG, color tokens, typography, and usage guidelines. Download or hotlink any asset."
+  canonical="/brand"
 >
   <main>
     <!-- header -->

--- a/packages/dashboard/src/pages/docs.astro
+++ b/packages/dashboard/src/pages/docs.astro
@@ -87,7 +87,8 @@ await store.saveChat({ chatId, messages });`;
 ---
 <MarketingLayout
   title="Docs — AgentState"
-  description="Persist agent state in two minutes. Store conversations, UI messages and graph checkpoints behind one REST API."
+  description="Persist agent state in two minutes. Install the SDK, grab a project key, and store your first conversation with a single API call."
+  canonical="/docs"
 >
   <main>
     <div class="mx-auto grid max-w-[1040px] gap-10 px-5 py-12 pb-24 lg:grid-cols-[210px_minmax(0,1fr)] xl:grid-cols-[210px_minmax(0,1fr)_180px]">

--- a/packages/dashboard/src/pages/index.astro
+++ b/packages/dashboard/src/pages/index.astro
@@ -4,7 +4,11 @@ import Card from "../components/ui/card.astro";
 // biome-ignore lint/correctness/noUnusedImports: Astro component imports are used in the template below
 import MarketingLayout from "../layouts/MarketingLayout.astro";
 ---
-<MarketingLayout>
+<MarketingLayout
+  title="AgentState — State & coordination layer for AI agent fleets"
+  description="Stop reinventing distributed state. AgentState gives your agent fleet five primitives — state, leases, claims, tokens, and conversations — behind one API."
+  canonical="/"
+>
   <main>
     <!-- hero -->
     <section data-reveal class="mx-auto max-w-[1040px] px-5 pt-24 pb-16 sm:pt-32">


### PR DESCRIPTION
## What
Adds proper SEO/social meta to the public marketing pages and a sitemap.

- `MarketingLayout` now accepts `title`/`description`/`ogImage`/`canonical` props and emits: `<title>`, meta description, **OpenGraph** (`og:title/description/type/url/image/site_name`), **Twitter Card** (`summary_large_image`), `<link rel="canonical">`, and favicons/apple-touch-icon. Defaults updated to the "State & coordination layer for AI agent fleets" positioning.
- Unique `<title>` + description per page: home, **"Docs — AgentState"**, **"Brand — AgentState"**.
- New `public/sitemap.xml` (`/`, `/docs`, `/brand`).
- `robots.txt` deliberately **left untouched** — Cloudflare serves a managed content-signal robots.txt at the edge; a static one would override it.

## Why
Backlog **LP-4** — SEO pass (growth surface). The pages had a stale title/description, no social/canonical meta, and `sitemap.xml` 404'd.

## Risk & rollback
- Risk: 🟢 additive `<head>` meta + one static file; no body/layout change, no new deps. All referenced og:image/icon assets verified present in `public/brand`.
- Rollback: revert this PR.

## Verification
- [x] dashboard build (13 pages)
- [x] built HTML carries `og:title`/`og:image`/`twitter:card`/`canonical` (verified in `out/index.html`)
- [x] unique titles per page; sitemap emitted to `out/sitemap.xml`
- [x] og:image + apple-touch-icon assets exist
- Note: og:image currently reuses the logo PNG; a dedicated 1200×630 social card is a nice future enhancement (non-blocking).

🤖 Autonomous overnight PR. Co-authored per repo convention.