### PR TITLE
chore(dashboard): clean up lint-debt suppressions (QUAL-2)

### DIFF
--- a/packages/dashboard/src/components/dashboard/conversations/conversations-page.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/conversations-page.tsx
@@ -74,7 +74,6 @@ function ConversationsContent() {
       {loadingProjects && (
         <div className="flex flex-col gap-3">
           {[0, 1, 2].map((i) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton cards
             <div
               key={i}
               className="flex items-center gap-4 rounded-[var(--radius-lg)] border border-edge bg-panel p-4"

--- a/packages/dashboard/src/components/dashboard/loading-states/_table-skeleton.tsx
+++ b/packages/dashboard/src/components/dashboard/loading-states/_table-skeleton.tsx
@@ -21,7 +21,6 @@ export function TableSkeleton({ rows = 5, columns = 5 }: TableSkeletonProps) {
       <thead>
         <tr className="border-b border-edge bg-panel">
           {repeat(columns, (j) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: Static skeleton content, index is acceptable
             <th key={j} className="px-4 py-2.5">
               <div
                 className="h-3.5 w-full animate-pulse rounded bg-edge"
@@ -35,7 +34,6 @@ export function TableSkeleton({ rows = 5, columns = 5 }: TableSkeletonProps) {
         {repeat2(rows, () => (
           <tr>
             {repeat(columns, (j) => (
-              // biome-ignore lint/suspicious/noArrayIndexKey: Static skeleton content, index is acceptable
               <td key={j} className="px-4 py-3.5">
                 <div
                   className="h-3.5 animate-pulse rounded bg-edge"

--- a/packages/dashboard/src/components/dashboard/project/_keys-tab.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_keys-tab.tsx
@@ -54,7 +54,6 @@ function KeyNameForm({
           }
         }}
         placeholder="e.g. Production"
-        // biome-ignore lint/a11y/noAutofocus: inline create form should focus on open
         autoFocus
         mono
         className="min-w-0 flex-1"

--- a/packages/dashboard/src/pages/dashboard/settings/organizations/index.astro
+++ b/packages/dashboard/src/pages/dashboard/settings/organizations/index.astro
@@ -1,5 +1,7 @@
 ---
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import { OrganizationsListPage } from "@/components/dashboard/organizations/list/organizations-list-page";
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import DashboardLayout from "@/layouts/DashboardLayout.astro";
 ---
 

--- a/packages/dashboard/src/pages/dashboard/settings/organizations/members.astro
+++ b/packages/dashboard/src/pages/dashboard/settings/organizations/members.astro
@@ -1,5 +1,7 @@
 ---
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import { MembersPage } from "@/components/dashboard/organizations/members/members-page";
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import DashboardLayout from "@/layouts/DashboardLayout.astro";
 ---
 

--- a/packages/dashboard/src/pages/dashboard/traces.astro
+++ b/packages/dashboard/src/pages/dashboard/traces.astro
@@ -1,5 +1,7 @@
 ---
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import { TracesPage } from "@/components/dashboard/traces/traces-page";
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import DashboardLayout from "@/layouts/DashboardLayout.astro";
 ---
 

--- a/packages/dashboard/src/pages/docs.astro
+++ b/packages/dashboard/src/pages/docs.astro
@@ -1,8 +1,11 @@
 ---
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import Card from "../components/ui/card.astro";
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import MarketingLayout from "../layouts/MarketingLayout.astro";
 
 // Section nav groups (mono labels). IDs map to headings in <article>.
+// biome-ignore lint/correctness/noUnusedVariables: used in the template below
 const navGroups: { group: string; items: [id: string, label: string][] }[] = [
   {
     group: "Getting started",
@@ -26,6 +29,7 @@ const navGroups: { group: string; items: [id: string, label: string][] }[] = [
 ];
 
 // Right TOC — same anchors in document order.
+// biome-ignore lint/correctness/noUnusedVariables: used in the template below
 const onThisPage: [id: string, label: string][] = [
   ["quickstart", "Quickstart"],
   ["auth", "Authentication"],
@@ -41,6 +45,7 @@ const methodTone: Record<string, "pos" | "accent" | "warn" | "neg"> = {
   DELETE: "neg",
 };
 
+// biome-ignore lint/correctness/noUnusedVariables: used in the template below
 const conversationEndpoints: [string, string, string][] = [
   ["POST", "/api/v1/conversations", "Create conversation with optional messages"],
   ["GET", "/api/v1/conversations/:id", "Get — use ?include=messages for the full thread"],
@@ -49,12 +54,14 @@ const conversationEndpoints: [string, string, string][] = [
   ["DELETE", "/api/v1/conversations/:id", "Delete conversation"],
 ];
 
+// biome-ignore lint/correctness/noUnusedVariables: used in the template below
 const analyticsEndpoints: [string, string, string][] = [
   ["GET", "/api/v1/analytics/summary", "Usage summary — volume, tokens, cost"],
   ["GET", "/api/v1/analytics/timeseries", "Time-series for conversations & messages"],
   ["GET", "/api/v1/analytics/tags", "Breakdown by tag"],
 ];
 
+// biome-ignore lint/correctness/noUnusedVariables: used in the template below
 const quickCode = `npm i @agentstate/sdk
 
 import { AgentState } from "@agentstate/sdk";
@@ -64,10 +71,12 @@ const conv = await state.createConversation({
   messages: [{ role: "user", content: "Hello" }],
 });`;
 
+// biome-ignore lint/correctness/noUnusedVariables: used in the template below
 const authCode = `# every request carries a bearer key (starts with as_live_)
 curl https://agentstate.app/api/v1/conversations \\
   -H "Authorization: Bearer as_live_your_key"`;
 
+// biome-ignore lint/correctness/noUnusedVariables: used in the template below
 function methodColor(m: string): string {
   const t = methodTone[m];
   if (t === "pos") return "text-pos";
@@ -76,6 +85,7 @@ function methodColor(m: string): string {
   return "text-accent";
 }
 
+// biome-ignore lint/correctness/noUnusedVariables: used in the template below
 const adapterCode = `import { AgentState } from "@agentstate/sdk";
 import { createAISDKChatStore } from "@agentstate/sdk/ai-sdk";
 

--- a/packages/dashboard/src/styles/global.css
+++ b/packages/dashboard/src/styles/global.css
@@ -341,9 +341,9 @@
     transform: none;
     animation: none;
   }
-  /* biome-ignore lint/complexity/noImportantStyles: must override inline animation styles for reduced-motion users */
   .as-dash,
   .as-pulse {
+    /* biome-ignore lint/complexity/noImportantStyles: must override inline animation styles for reduced-motion users */
     animation: none !important;
   }
 }


### PR DESCRIPTION
## What
Silences recurring biome warnings in the dashboard **without changing any rendered output**:
- Removes 4 ineffective JSX `biome-ignore` comments (biome reported them as having no effect).
- Fixes the `global.css` reduced-motion override: moves the `noImportantStyles` ignore to immediately precede `animation: none !important` so it actually suppresses. The `!important` is **kept** — it's a legitimate reduced-motion accessibility rule.
- Adds honest `biome-ignore: used in the template below` to genuine **Astro frontmatter false-positives** (docs.astro vars + the Page/Layout imports in traces.astro and the org settings pages). Biome can't see Astro template usage.

## Why
Backlog **QUAL-2** — remove dead code / unused-export noise. Verified every "unused" symbol IS referenced in its template (so they're false-positives, not dead code) — the safe fix is a targeted ignore, not deletion.

## Risk & rollback
- Risk: 🟢 comments only — zero runtime/output change. Build passes (13 pages); nothing rendered was removed. Dashboard biome warnings **68 → 48**.
- Rollback: revert this PR.

## Verification
- [x] dashboard build (13 pages)
- [x] biome warnings 68 → 48, no new errors
- [x] each removed/ignored symbol confirmed referenced in its template

🤖 Autonomous overnight PR. Co-authored per repo convention.