### PR TITLE
chore(dashboard): silence import false-positives on app pages (QUAL-2)

### DIFF
--- a/packages/dashboard/src/pages/dashboard/analytics.astro
+++ b/packages/dashboard/src/pages/dashboard/analytics.astro
@@ -1,5 +1,7 @@
 ---
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import { AnalyticsPage } from "@/components/dashboard/analytics/analytics-page";
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import DashboardLayout from "@/layouts/DashboardLayout.astro";
 ---
 

--- a/packages/dashboard/src/pages/dashboard/conversations.astro
+++ b/packages/dashboard/src/pages/dashboard/conversations.astro
@@ -1,5 +1,7 @@
 ---
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import { ConversationsPage } from "@/components/dashboard/conversations/conversations-page";
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import DashboardLayout from "@/layouts/DashboardLayout.astro";
 ---
 

--- a/packages/dashboard/src/pages/dashboard/domains.astro
+++ b/packages/dashboard/src/pages/dashboard/domains.astro
@@ -1,5 +1,7 @@
 ---
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import { DomainsPage } from "@/components/dashboard/domains/domains-page";
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import DashboardLayout from "@/layouts/DashboardLayout.astro";
 ---
 

--- a/packages/dashboard/src/pages/dashboard/index.astro
+++ b/packages/dashboard/src/pages/dashboard/index.astro
@@ -1,5 +1,7 @@
 ---
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import { ProjectsPage } from "@/components/dashboard/projects/projects-page";
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import DashboardLayout from "@/layouts/DashboardLayout.astro";
 ---
 

--- a/packages/dashboard/src/pages/dashboard/integrate.astro
+++ b/packages/dashboard/src/pages/dashboard/integrate.astro
@@ -1,5 +1,7 @@
 ---
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import { IntegratePage } from "@/components/dashboard/integrate/integrate-page";
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import DashboardLayout from "@/layouts/DashboardLayout.astro";
 ---
 

--- a/packages/dashboard/src/pages/dashboard/project.astro
+++ b/packages/dashboard/src/pages/dashboard/project.astro
@@ -1,5 +1,7 @@
 ---
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import { ProjectPage } from "@/components/dashboard/project/project-page";
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import DashboardLayout from "@/layouts/DashboardLayout.astro";
 ---
 

--- a/packages/dashboard/src/pages/dashboard/settings/organizations/create.astro
+++ b/packages/dashboard/src/pages/dashboard/settings/organizations/create.astro
@@ -1,5 +1,7 @@
 ---
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import { CreateOrgPage } from "@/components/dashboard/organizations/create/create-org-page";
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
 import DashboardLayout from "@/layouts/DashboardLayout.astro";
 ---
 


### PR DESCRIPTION
## What
Adds honest `// biome-ignore lint/correctness/noUnusedImports: used in the template below` to the page-component + `DashboardLayout` imports on the seven dashboard app pages (analytics, conversations, domains, index, integrate, project, create-org).

## Why
Backlog **QUAL-2** (follow-up to #213). Biome can't see Astro template usage, so it flags these imports as unused — but each is rendered in the page's `<DashboardLayout><XPage client:only="react" /></DashboardLayout>` template. The recurring warnings spam the pre-push hook output. Verified each import is referenced; annotated rather than deleted.

## Risk & rollback
- Risk: 🟢 comments only — zero output/behavior change. Build 13 pages. These 7 files now lint clean.
- Rollback: revert this PR.

## Verification
- [x] dashboard build (13 pages)
- [x] all 7 app pages → 0 biome warnings
- [x] each import confirmed used in its template

🤖 Autonomous overnight PR. Co-authored per repo convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Resolved linting warnings across dashboard pages to improve build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->