### PR TITLE
feat(dashboard): per-project stats + filter in projects table

### DIFF
--- a/packages/api/src/services/projects.ts
+++ b/packages/api/src/services/projects.ts
@@ -46,6 +46,10 @@ export interface ProjectListItem {
   slug: string;
   created_at: number;
   key_count: number;
+  conversation_count: number;
+  message_count: number;
+  total_tokens: number;
+  last_activity_at: number | null;
 }
 
 export interface ConversationListItem {
@@ -206,21 +210,65 @@ export async function listProjects(
     return [];
   }
 
-  const rows = await db
+  const baseRows = await db
     .select({
       id: projects.id,
       org_id: projects.orgId,
       name: projects.name,
       slug: projects.slug,
       created_at: projects.createdAt,
-      key_count: sql<number>`count(${apiKeys.id})`.as("key_count"),
     })
     .from(projects)
-    .leftJoin(apiKeys, and(eq(apiKeys.projectId, projects.id), isNull(apiKeys.revokedAt)))
-    .where(eq(projects.orgId, org.id))
-    .groupBy(projects.id);
+    .where(eq(projects.orgId, org.id));
 
-  return rows;
+  if (baseRows.length === 0) {
+    return [];
+  }
+
+  const projectIds = baseRows.map((r) => r.id);
+
+  // Active key counts, grouped by project.
+  const keyRows = await db
+    .select({
+      projectId: apiKeys.projectId,
+      key_count: sql<number>`count(*)`.as("key_count"),
+    })
+    .from(apiKeys)
+    .where(and(inArray(apiKeys.projectId, projectIds), isNull(apiKeys.revokedAt)))
+    .groupBy(apiKeys.projectId);
+
+  // Per-project conversation aggregates. Conversations already store rolled-up
+  // message_count/token_count/updated_at, so no message-table join is needed.
+  // Aggregated in a separate query (not joined with keys) to avoid the
+  // cartesian-product inflation a multi-table GROUP BY would cause.
+  const convRows = await db
+    .select({
+      projectId: conversations.projectId,
+      conversation_count: sql<number>`count(*)`.as("conversation_count"),
+      message_count: sql<number>`coalesce(sum(${conversations.messageCount}), 0)`.as(
+        "message_count",
+      ),
+      total_tokens: sql<number>`coalesce(sum(${conversations.tokenCount}), 0)`.as("total_tokens"),
+      last_activity_at: sql<number | null>`max(${conversations.updatedAt})`.as("last_activity_at"),
+    })
+    .from(conversations)
+    .where(inArray(conversations.projectId, projectIds))
+    .groupBy(conversations.projectId);
+
+  const keyCountByProject = new Map(keyRows.map((r) => [r.projectId, r.key_count]));
+  const convStatsByProject = new Map(convRows.map((r) => [r.projectId, r]));
+
+  return baseRows.map((row) => {
+    const stats = convStatsByProject.get(row.id);
+    return {
+      ...row,
+      key_count: keyCountByProject.get(row.id) ?? 0,
+      conversation_count: stats?.conversation_count ?? 0,
+      message_count: stats?.message_count ?? 0,
+      total_tokens: stats?.total_tokens ?? 0,
+      last_activity_at: stats?.last_activity_at ?? null,
+    };
+  });
 }
 
 /**

--- a/packages/api/test/projects.test.ts
+++ b/packages/api/test/projects.test.ts
@@ -84,6 +84,10 @@ interface ProjectWithKeys extends Project {
 
 interface ProjectListItem extends Project {
   key_count: number;
+  conversation_count: number;
+  message_count: number;
+  total_tokens: number;
+  last_activity_at: number | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -311,6 +315,63 @@ describe("Projects (/api/v1/projects)", () => {
       expect(found).toBeDefined();
       // Should have at least the auto-created "Default" key
       expect(found!.key_count).toBeGreaterThanOrEqual(1);
+    });
+
+    it("reports zeroed aggregate stats for a project with no conversations", async () => {
+      const slug = `stats-zero-${Date.now()}`;
+      const createRes = await createProject({ name: "Stats Zero", slug });
+      const created = await createRes.json<{ project: Project; api_key: ApiKeyCreated }>();
+
+      const res = await SELF.fetch("http://localhost/api/v1/projects", {
+        headers: dashboardHeaders(),
+      });
+      const body = await res.json<{ data: ProjectListItem[] }>();
+      const found = body.data.find((p) => p.id === created.project.id);
+
+      expect(found).toBeDefined();
+      expect(found!.conversation_count).toBe(0);
+      expect(found!.message_count).toBe(0);
+      expect(found!.total_tokens).toBe(0);
+      expect(found!.last_activity_at).toBeNull();
+    });
+
+    it("aggregates conversation/message/token stats and last activity", async () => {
+      const slug = `stats-agg-${Date.now()}`;
+      const createRes = await createProject({ name: "Stats Agg", slug });
+      const created = await createRes.json<{ project: Project; api_key: ApiKeyCreated }>();
+      const key = created.api_key.key;
+
+      // Two conversations, 3 messages and 30 tokens total, created via the
+      // project's own API key (Bearer auth).
+      await SELF.fetch("http://localhost/v1/conversations", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [
+            { role: "user", content: "Hi", token_count: 5 },
+            { role: "assistant", content: "Hello", token_count: 10 },
+          ],
+        }),
+      });
+      await SELF.fetch("http://localhost/v1/conversations", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [{ role: "user", content: "Solo", token_count: 15 }],
+        }),
+      });
+
+      const res = await SELF.fetch("http://localhost/api/v1/projects", {
+        headers: dashboardHeaders(),
+      });
+      const body = await res.json<{ data: ProjectListItem[] }>();
+      const found = body.data.find((p) => p.id === created.project.id);
+
+      expect(found).toBeDefined();
+      expect(found!.conversation_count).toBe(2);
+      expect(found!.message_count).toBe(3);
+      expect(found!.total_tokens).toBe(30);
+      expect(found!.last_activity_at).toBeGreaterThan(0);
     });
 
     it("ignores the org_id query param (session org is authoritative)", async () => {

--- a/packages/dashboard/src/components/dashboard/projects/_projects-table.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/_projects-table.tsx
@@ -1,7 +1,9 @@
 import type { ProjectListItem } from "@agentstate/shared";
 import { Folder } from "@phosphor-icons/react";
 import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import {
   Table,
   TableBody,
@@ -10,6 +12,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { timeAgo } from "@/lib/format";
 
 type Project = ProjectListItem;
 
@@ -17,66 +20,122 @@ interface ProjectsTableProps {
   projects: Project[];
 }
 
+const TOTAL_COLUMNS = 7;
+
 /**
- * ProjectsTable - Plain table displaying the list of projects with click navigation.
+ * ProjectsTable - Projects list with per-project stats and a name/slug filter.
  *
- * Features:
- * - Clickable rows with keyboard navigation (Enter)
- * - Project name and slug (mono)
- * - API key count (mono, tabular-nums)
- * - Created date (mono, tabular-nums)
+ * Columns: name + slug, conversations, messages, tokens, keys, last activity,
+ * created. Secondary columns hide progressively on smaller viewports. Rows are
+ * clickable (and keyboard-navigable) and open the project detail page.
  */
 export function ProjectsTable({ projects }: ProjectsTableProps) {
   const router = useRouter();
+  const [query, setQuery] = useState("");
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return projects;
+    return projects.filter(
+      (p) => p.name.toLowerCase().includes(q) || p.slug.toLowerCase().includes(q),
+    );
+  }, [projects, query]);
+
+  const open = (slug: string) => router.push(`/dashboard/project/?slug=${slug}`);
 
   return (
-    <Table responsive>
-      <TableHeader>
-        <TableRow>
-          <TableHead>Name</TableHead>
-          <TableHead align="right" className="hidden sm:table-cell">
-            Keys
-          </TableHead>
-          <TableHead align="right" className="hidden sm:table-cell">
-            Created
-          </TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {projects.map((project) => (
-          <TableRow
-            key={project.id}
-            clickable
-            onClick={() => router.push(`/dashboard/project/?slug=${project.slug}`)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                router.push(`/dashboard/project/?slug=${project.slug}`);
-              }
-            }}
-            tabIndex={0}
-            aria-label={`Open ${project.name}`}
-          >
-            <TableCell>
-              <div className="flex items-center gap-3">
-                <span className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius)] border border-edge bg-panel2 text-fg-3">
-                  <Folder className="size-4" aria-hidden="true" />
-                </span>
-                <div className="flex min-w-0 flex-col gap-0.5">
-                  <span className="truncate text-[13.5px] font-medium text-fg">{project.name}</span>
-                  <span className="as-mono-sm text-fg-4">{project.slug}</span>
-                </div>
-              </div>
-            </TableCell>
-            <TableCell align="right" className="hidden sm:table-cell">
-              <Badge tone="default">{project.key_count ?? 0}</Badge>
-            </TableCell>
-            <TableCell align="right" mono className="hidden sm:table-cell">
-              {new Date(project.created_at).toLocaleDateString()}
-            </TableCell>
+    <div className="flex flex-col gap-3">
+      <Input
+        type="search"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Filter projects by name or slug…"
+        aria-label="Filter projects"
+        className="sm:max-w-xs"
+      />
+
+      <Table responsive>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead align="right" className="hidden sm:table-cell">
+              Conversations
+            </TableHead>
+            <TableHead align="right" className="hidden lg:table-cell">
+              Messages
+            </TableHead>
+            <TableHead align="right" className="hidden sm:table-cell">
+              Tokens
+            </TableHead>
+            <TableHead align="right" className="hidden lg:table-cell">
+              Keys
+            </TableHead>
+            <TableHead align="right" className="hidden md:table-cell">
+              Last activity
+            </TableHead>
+            <TableHead align="right" className="hidden xl:table-cell">
+              Created
+            </TableHead>
           </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+        </TableHeader>
+        <TableBody>
+          {filtered.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={TOTAL_COLUMNS} className="text-center text-fg-4">
+                No projects match “{query}”.
+              </TableCell>
+            </TableRow>
+          ) : (
+            filtered.map((project) => (
+              <TableRow
+                key={project.id}
+                clickable
+                onClick={() => open(project.slug)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    open(project.slug);
+                  }
+                }}
+                tabIndex={0}
+                aria-label={`Open ${project.name}`}
+              >
+                <TableCell>
+                  <div className="flex items-center gap-3">
+                    <span className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius)] border border-edge bg-panel2 text-fg-3">
+                      <Folder className="size-4" aria-hidden="true" />
+                    </span>
+                    <div className="flex min-w-0 flex-col gap-0.5">
+                      <span className="truncate text-[13.5px] font-medium text-fg">
+                        {project.name}
+                      </span>
+                      <span className="as-mono-sm text-fg-4">{project.slug}</span>
+                    </div>
+                  </div>
+                </TableCell>
+                <TableCell align="right" mono className="hidden sm:table-cell">
+                  {project.conversation_count.toLocaleString()}
+                </TableCell>
+                <TableCell align="right" mono className="hidden lg:table-cell">
+                  {project.message_count.toLocaleString()}
+                </TableCell>
+                <TableCell align="right" mono className="hidden sm:table-cell">
+                  {project.total_tokens.toLocaleString()}
+                </TableCell>
+                <TableCell align="right" className="hidden lg:table-cell">
+                  <Badge tone="default">{project.key_count ?? 0}</Badge>
+                </TableCell>
+                <TableCell align="right" mono className="hidden md:table-cell text-fg-3">
+                  {project.last_activity_at ? timeAgo(project.last_activity_at) : "—"}
+                </TableCell>
+                <TableCell align="right" mono className="hidden xl:table-cell text-fg-3">
+                  {new Date(project.created_at).toLocaleDateString()}
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
   );
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -161,6 +161,14 @@ export interface ApiKeyCreatedResponse extends ApiKeyResponse {
 export interface ProjectListItem extends ProjectResponse {
   org_id: string;
   key_count: number;
+  /** Number of conversations in the project. */
+  conversation_count: number;
+  /** Total messages across all conversations in the project. */
+  message_count: number;
+  /** Total tokens across all conversations in the project. */
+  total_tokens: number;
+  /** Most recent conversation update time (Unix ms), or null if no conversations. */
+  last_activity_at: number | null;
 }
 
 // Project detail (GET /v1/projects/:id, GET /v1/projects/by-slug/:slug)


### PR DESCRIPTION
## What
The projects list table now shows **per-project stats** and has a **filter** input:
- New columns: **Conversations**, **Messages**, **Tokens**, **Last activity** (alongside existing Keys + Created).
- A name/slug **filter box** above the table (client-side), with an empty-match state.
- Secondary columns hide progressively on smaller viewports; the table stays horizontally scrollable.

## Why
Requested: surface more information about each project at a glance, and make a long list filterable. ("requests/HTTP count" was requested too but isn't tracked anywhere yet — no request log table — so it's omitted rather than faked.)

## How
- **API** (`services/projects.ts`): `listProjects` now returns `conversation_count`, `message_count`, `total_tokens`, `last_activity_at`. The `conversations` table already stores rolled-up `message_count`/`token_count`/`updated_at`, so stats come from a single grouped query over conversations — kept **separate** from the key-count query to avoid the cartesian-product inflation a multi-table `GROUP BY` would cause. Results merged in JS.
- **shared**: `ProjectListItem` gains the four fields (consumed by the dashboard).
- **dashboard**: `_projects-table.tsx` adds the columns + filter; reuses `timeAgo` and the existing `Input`/`Badge`/`Table` primitives.

## Tests
- New API tests: zeroed stats for an empty project (verifies `coalesce`/null handling) and correct aggregation (2 conversations / 3 messages / 30 tokens / last_activity set) created via the project's own key.
- Full suite green: **282 tests**, biome clean, tsc 0 (api + shared + dashboard), dashboard build 13 pages.

## Risk / Rollback
- **Low–medium.** Additive only — no schema change, no migration, no auth/billing touch. Read path adds one extra grouped query on the dashboard projects list (bounded by projects-per-org).
- Rollback: revert this commit; `ProjectListItem` consumers tolerate the extra fields.

## Visual verification
Both the table and sidebar live behind the Clerk auth gate, which isn't capturable in headless CI here (no test session / no Playwright installed — consistent with prior runs that only screenshotted public pages). Verified via build + full typecheck + the new data-layer tests + isolated component render (see comment). Reviewer/author can confirm on the preview deploy.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
* Projects list now displays conversation count, message count, total tokens consumed, and last activity timestamp for each project.
* Added search/filter functionality to the projects table to find projects by name.
* Expanded projects table columns to show activity metrics and last activity date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->