### PR TITLE
fix(dashboard): primary-button contrast + secondary nav links

### DIFF
--- a/packages/dashboard/src/components/analytics/time-range-select.tsx
+++ b/packages/dashboard/src/components/analytics/time-range-select.tsx
@@ -25,7 +25,7 @@ export function TimeRangeSelect({ value, onChange }: TimeRangeSelectProps) {
           onClick={() => onChange(r.value)}
           className={`min-h-[34px] px-3 font-mono text-[12px] transition-colors ${
             value === r.value
-              ? "bg-fg text-base"
+              ? "bg-fg text-[var(--color-base)]"
               : "bg-panel text-fg-3 hover:bg-panel2 hover:text-fg"
           }`}
         >

--- a/packages/dashboard/src/components/app-shell.tsx
+++ b/packages/dashboard/src/components/app-shell.tsx
@@ -2,6 +2,7 @@
 
 import { SignIn, UserButton, useAuth, useUser } from "@clerk/react";
 import {
+  ArrowUpRight,
   BookOpen,
   ChartLine,
   ChatCircle,
@@ -67,11 +68,10 @@ function useStatePath() {
   return p;
 }
 
-// Every navigable URL, used to resolve the single active item via longest-prefix match.
-const allNavUrls = [
-  ...navGroups.flatMap((g) => g.items.map((i) => i.url)),
-  ...secondaryItems.map((i) => i.url),
-];
+// Primary nav URLs only — used to resolve the single active item via longest-prefix
+// match. secondaryItems (Docs/Home) are plain external-style links that are never
+// highlighted, so they are intentionally excluded.
+const allNavUrls = navGroups.flatMap((g) => g.items.map((i) => i.url));
 
 function normalizePath(path: string): string {
   const trimmed = path.replace(/\/+$/, "");
@@ -164,6 +164,40 @@ function Gate({ children }: { children: ReactNode }) {
   return <>{children}</>;
 }
 
+/**
+ * Secondary links (Docs, Home) leave the dashboard app, so they render as plain
+ * muted links with an external-link affordance — never highlighted as active —
+ * and are pinned to the bottom of the sidebar.
+ */
+function SecondaryLinks({ onNavigate }: { onNavigate?: () => void }) {
+  return (
+    <div className="mx-3 mt-6 border-t border-edge-soft pt-3 pb-1">
+      <div className="space-y-0.5">
+        {secondaryItems.map((it) => {
+          const Icon = it.icon;
+          return (
+            <a
+              key={it.url}
+              href={it.url}
+              onClick={onNavigate}
+              className="group flex min-h-[32px] items-center gap-2.5 rounded-[var(--radius)] px-3 py-1.5 text-[13px] text-fg-4 transition-colors hover:bg-panel2 hover:text-fg-2"
+            >
+              <Icon size={15} weight="regular" />
+              <span>{it.title}</span>
+              <ArrowUpRight
+                size={12}
+                weight="bold"
+                className="ml-auto opacity-0 transition-opacity group-hover:opacity-70"
+                aria-hidden="true"
+              />
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 function SidebarInner({
   activeUrl,
   onNavigate,
@@ -172,14 +206,10 @@ function SidebarInner({
   onNavigate?: () => void;
 }) {
   return (
-    <div className="flex-1 overflow-auto py-4">
+    <div className="flex flex-1 flex-col overflow-auto py-4">
       <NavList groups={navGroups} activeUrl={activeUrl} onNavigate={onNavigate} />
-      <div className="mx-3 mt-5 border-t border-edge-soft pt-3">
-        <NavList
-          groups={[{ label: "", items: secondaryItems }]}
-          activeUrl={activeUrl}
-          onNavigate={onNavigate}
-        />
+      <div className="mt-auto">
+        <SecondaryLinks onNavigate={onNavigate} />
       </div>
     </div>
   );

--- a/packages/dashboard/src/components/ui/button.astro
+++ b/packages/dashboard/src/components/ui/button.astro
@@ -11,7 +11,7 @@ const { variant = "secondary", href, class: cls = "", ...rest } = Astro.props;
 const base =
   "inline-flex min-h-[40px] items-center justify-center gap-1.5 rounded-[var(--radius)] px-4 py-2.5 text-[13px] font-medium transition-[background-color,color,border-color,transform] duration-150 active:scale-[0.96] disabled:opacity-50 disabled:pointer-events-none disabled:active:scale-100";
 const variants: Record<NonNullable<Props["variant"]>, string> = {
-  primary: "bg-fg text-base hover:opacity-90",
+  primary: "bg-fg text-[var(--color-base)] hover:opacity-90",
   secondary: "border border-edge text-fg hover:bg-panel2",
   ghost: "text-fg-3 hover:text-fg hover:bg-panel2",
   danger: "border border-neg/40 bg-neg/10 text-neg hover:bg-neg/20",

--- a/packages/dashboard/src/components/ui/button.tsx
+++ b/packages/dashboard/src/components/ui/button.tsx
@@ -17,7 +17,7 @@ const base =
   "inline-flex items-center justify-center gap-1.5 rounded-[var(--radius)] font-medium transition-[background-color,color,border-color,transform] duration-150 active:scale-[0.96] disabled:opacity-50 disabled:pointer-events-none disabled:active:scale-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-base";
 
 const variants: Record<Variant, string> = {
-  primary: "bg-fg text-base hover:opacity-90",
+  primary: "bg-fg text-[var(--color-base)] hover:opacity-90",
   secondary: "border border-edge text-fg hover:bg-panel2",
   ghost: "text-fg-3 hover:text-fg hover:bg-panel2",
   danger: "border border-neg/40 bg-neg/10 text-neg hover:bg-neg/20",

--- a/packages/dashboard/src/layouts/MarketingLayout.astro
+++ b/packages/dashboard/src/layouts/MarketingLayout.astro
@@ -81,7 +81,7 @@ const canonicalUrl = new URL(canonical ?? Astro.url.pathname, SITE).href;
                   d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" /></svg></span
             >
           </button>
-          <a href="/dashboard" class="rounded-[var(--radius)] bg-fg px-3.5 py-1.5 text-[13px] font-medium text-base hover:opacity-90">Open dashboard</a>
+          <a href="/dashboard" class="rounded-[var(--radius)] bg-fg px-3.5 py-1.5 text-[13px] font-medium text-[var(--color-base)] hover:opacity-90">Open dashboard</a>
         </div>
       </div>
     </header>

--- a/packages/dashboard/src/pages/brand.astro
+++ b/packages/dashboard/src/pages/brand.astro
@@ -351,7 +351,7 @@ const iconAssets = [
         <Logo size={32} class="mx-auto text-fg" />
         <h2 class="mt-5 text-[28px] font-semibold tracking-[-0.03em] text-fg sm:text-[32px]">One mark. Many runtimes.</h2>
         <p class="mx-auto mt-4 max-w-[460px] text-fg-3">Persistent state for every agent framework — behind one small API.</p>
-        <a href="/dashboard" class="mt-8 inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-fg px-5 py-2.5 text-[14px] font-medium text-base hover:opacity-90">Open dashboard →</a>
+        <a href="/dashboard" class="mt-8 inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-fg px-5 py-2.5 text-[14px] font-medium text-[var(--color-base)] hover:opacity-90">Open dashboard →</a>
       </div>
     </section>
 

--- a/packages/dashboard/src/pages/docs.astro
+++ b/packages/dashboard/src/pages/docs.astro
@@ -152,7 +152,7 @@ await store.saveChat({ chatId, messages });`;
             href="https://github.com/duyet/agentstate"
             target="_blank"
             rel="noreferrer"
-            class="inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-fg px-4 py-2 text-[13px] font-medium text-base hover:opacity-90"
+            class="inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-fg px-4 py-2 text-[13px] font-medium text-[var(--color-base)] hover:opacity-90"
           >
             GitHub ↗
           </a>

--- a/packages/dashboard/src/pages/index.astro
+++ b/packages/dashboard/src/pages/index.astro
@@ -21,7 +21,7 @@ import MarketingLayout from "../layouts/MarketingLayout.astro";
           You're building AI agents — not a distributed systems backend. Stop reinventing state management, locking, delegation, and history storage. AgentState gives your fleet five primitives and a single API call.
         </p>
         <div class="mt-9 flex flex-wrap items-center gap-3">
-          <a href="/dashboard" class="inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-fg px-5 py-2.5 text-[14px] font-medium text-base hover:opacity-90">Get a free key →</a>
+          <a href="/dashboard" class="inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-fg px-5 py-2.5 text-[14px] font-medium text-[var(--color-base)] hover:opacity-90">Get a free key →</a>
           <a href="/docs" class="inline-flex items-center gap-1.5 rounded-[var(--radius)] border border-edge px-5 py-2.5 text-[14px] text-fg hover:bg-panel2">Read the docs</a>
         </div>
         <p class="mt-5 text-[12.5px] text-fg-4">Open source · free to start · no credit card</p>
@@ -207,7 +207,7 @@ const conv = await client.createConversation({
       <div class="mx-auto max-w-[680px] px-5">
         <h2 class="text-[30px] font-semibold tracking-[-0.03em] text-fg sm:text-[36px]">Ship the agent,<br />not the backend.</h2>
         <p class="mx-auto mt-4 max-w-[460px] text-fg-3">Spin up a project, grab a key, and persist your first session in two minutes. No credit card required.</p>
-        <a href="/dashboard" class="mt-8 inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-fg px-5 py-2.5 text-[14px] font-medium text-base hover:opacity-90">Get a free key →</a>
+        <a href="/dashboard" class="mt-8 inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-fg px-5 py-2.5 text-[14px] font-medium text-[var(--color-base)] hover:opacity-90">Get a free key →</a>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## What
1. **Fixes low-contrast primary buttons in both themes.** The "New Project" button (dashboard) and "Get a free key" / "Open dashboard" CTAs (landing) had nearly-invisible text in both light and dark mode.
2. **Restyles sidebar Docs/Home as plain external-style links** — muted, with an external-link arrow on hover, never highlighted as active, pinned to the bottom of the sidebar.

## Why
- `text-base` was used as a *color* alongside `bg-fg`, but in Tailwind v4 `text-base` is a **font-size** utility (the `--text-base` size token), not the `--color-base` color. The text color silently fell back to the inherited muted body color → poor contrast in both themes (user-reported).
- Docs/Home navigate *out* of the dashboard app; they shouldn't read as active nav destinations.

## How
- Replaced all 8 `text-base` color usages with `text-[var(--color-base)]` (button.tsx, button.astro, time-range-select.tsx, MarketingLayout.astro, index.astro ×2, brand.astro, docs.astro).
- `app-shell.tsx`: removed secondaryItems from active-URL resolution; new `SecondaryLinks` component (muted + `ArrowUpRight` affordance, no active state), pinned to sidebar bottom via `mt-auto`.

## Visual verification
Confirmed on the **public landing page** (not auth-gated) via headless screenshot: CTA buttons now render crisp white-on-dark. The dashboard "New Project" button uses the identical `primary` variant, so it's covered by the same change. (Authed dashboard pages aren't headlessly capturable here; the Docs/Home restyle is plain presentation logic.)

## Risk / Rollback
- **Low.** Presentation-only; no API/schema/auth. Fresh hashed JS also busts any stale dashboard bundle (relevant to the separate sidebar-highlight cache report).
- Rollback: revert this commit.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>