### PR TITLE
feat(dashboard): in-app org member management (remove, role change, revoke)

### DIFF
--- a/packages/dashboard/src/components/dashboard/organizations/members/_members-list.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_members-list.tsx
@@ -1,5 +1,6 @@
 import { UserIcon } from "@phosphor-icons/react";
 import * as React from "react";
+import type { Role } from "./_components";
 import { MemberCell } from "./_member-cell";
 import { type Column, MemberListCard } from "./_member-list-card";
 import { RoleBadge } from "./_role-badge";
@@ -16,9 +17,26 @@ export interface MembersListProps {
     } | null;
   } | null> | null;
   readonly count?: number;
+  /** Whether the current user can manage members (org admin). */
+  readonly canManage?: boolean;
+  /** The current user's own membership id — actions are hidden on their own row. */
+  readonly currentMembershipId?: string | null;
+  /** Membership id with an in-flight action (disables its controls). */
+  readonly pendingId?: string | null;
+  readonly onRemoveMember?: (id: string) => void;
+  readonly onUpdateRole?: (id: string, role: Role) => void;
 }
 
-export function MembersList({ isLoading, members, count }: MembersListProps) {
+export function MembersList({
+  isLoading,
+  members,
+  count,
+  canManage = false,
+  currentMembershipId = null,
+  pendingId = null,
+  onRemoveMember,
+  onUpdateRole,
+}: MembersListProps) {
   const memberData = React.useMemo(
     () =>
       members
@@ -38,7 +56,13 @@ export function MembersList({ isLoading, members, count }: MembersListProps) {
     {
       key: "name",
       label: "Member",
-      render: (row) => <MemberCell name={row.name} email={row.email} iconType="user" />,
+      render: (row) => (
+        <MemberCell
+          name={row.id === currentMembershipId ? `${row.name} (You)` : row.name}
+          email={row.email}
+          iconType="user"
+        />
+      ),
     },
     {
       key: "role",
@@ -46,6 +70,40 @@ export function MembersList({ isLoading, members, count }: MembersListProps) {
       render: (row) => <RoleBadge role={row.role} />,
     },
   ];
+
+  // Admins get an actions column to change a member's role or remove them.
+  // The current user's own row is left action-free to avoid self-lockout.
+  if (canManage) {
+    columns.push({
+      key: "actions",
+      label: "",
+      render: (row) => {
+        if (row.id === currentMembershipId) return null;
+        const isAdmin = row.role === "org:admin";
+        const busy = pendingId === row.id;
+        return (
+          <div className="flex items-center justify-end gap-3">
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => onUpdateRole?.(row.id, isAdmin ? "org:member" : "org:admin")}
+              className="text-[12.5px] text-fg-3 transition-colors hover:text-fg disabled:opacity-50"
+            >
+              {isAdmin ? "Make member" : "Make admin"}
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => onRemoveMember?.(row.id)}
+              className="text-[12.5px] text-fg-3 transition-colors hover:text-neg disabled:opacity-50"
+            >
+              Remove
+            </button>
+          </div>
+        );
+      },
+    });
+  }
 
   return (
     <MemberListCard

--- a/packages/dashboard/src/components/dashboard/organizations/members/_pending-invitations-list.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_pending-invitations-list.tsx
@@ -11,6 +11,10 @@ export interface _PendingInvitationsListProps {
     readonly status: string;
   }> | null;
   readonly count?: number;
+  /** Whether the current user can revoke invitations (org admin). */
+  readonly canManage?: boolean;
+  /** Invitation id with an in-flight action (disables its control). */
+  readonly pendingId?: string | null;
   readonly onRevokeInvitation: (id: string) => void;
 }
 
@@ -18,6 +22,8 @@ export function _PendingInvitationsList({
   isLoading,
   invitations,
   count,
+  canManage = false,
+  pendingId = null,
   onRevokeInvitation,
 }: _PendingInvitationsListProps) {
   type Invitation = NonNullable<typeof invitations>[number];
@@ -38,20 +44,27 @@ export function _PendingInvitationsList({
         />
       ),
     },
-    {
+  ];
+
+  // Only admins can revoke; non-admins see the list without the action.
+  if (canManage) {
+    columns.push({
       key: "actions",
       label: "",
       render: (row) => (
-        <button
-          type="button"
-          onClick={() => onRevokeInvitation(row.id)}
-          className="text-[12.5px] text-fg-3 transition-colors hover:text-neg"
-        >
-          Revoke
-        </button>
+        <div className="flex justify-end">
+          <button
+            type="button"
+            disabled={pendingId === row.id}
+            onClick={() => onRevokeInvitation(row.id)}
+            className="text-[12.5px] text-fg-3 transition-colors hover:text-neg disabled:opacity-50"
+          >
+            Revoke
+          </button>
+        </div>
       ),
-    },
-  ];
+    });
+  }
 
   return (
     <MemberListCard

--- a/packages/dashboard/src/components/dashboard/organizations/members/_use-member-actions.ts
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_use-member-actions.ts
@@ -1,0 +1,99 @@
+import * as React from "react";
+import { toast } from "sonner";
+import type { Role } from "./_components";
+
+interface ClerkError {
+  errors?: Array<{ message?: string }>;
+}
+
+interface MembershipResource {
+  id: string;
+  destroy: () => Promise<unknown>;
+  update: (params: { role: Role }) => Promise<unknown>;
+}
+
+interface InvitationResource {
+  id: string;
+  revoke: () => Promise<unknown>;
+}
+
+interface Paginated<T> {
+  data?: T[] | null;
+  revalidate?: () => Promise<void>;
+}
+
+function clerkMessage(err: unknown, fallback: string): string {
+  const e = err as ClerkError;
+  return e?.errors?.[0]?.message ?? fallback;
+}
+
+/**
+ * Member-management actions backed by Clerk's client SDK. Each action looks up
+ * the live Clerk resource by id and calls its mutator, then revalidates the
+ * list. Clerk enforces admin-only authorization server-side, so these are safe
+ * to expose — the UI only hides them for non-admins as a courtesy.
+ *
+ * `pendingId` is the id of the row with an in-flight action (for disabling).
+ */
+export function useMemberActions(
+  memberships: Paginated<MembershipResource> | null | undefined,
+  invitations: Paginated<InvitationResource> | null | undefined,
+) {
+  const [pendingId, setPendingId] = React.useState<string | null>(null);
+
+  const removeMember = React.useCallback(
+    async (id: string) => {
+      const membership = memberships?.data?.find((m) => m.id === id);
+      if (!membership) return;
+      setPendingId(id);
+      try {
+        await membership.destroy();
+        await memberships?.revalidate?.();
+        toast.success("Member removed");
+      } catch (err) {
+        toast.error(clerkMessage(err, "Failed to remove member"));
+      } finally {
+        setPendingId(null);
+      }
+    },
+    [memberships],
+  );
+
+  const updateRole = React.useCallback(
+    async (id: string, role: Role) => {
+      const membership = memberships?.data?.find((m) => m.id === id);
+      if (!membership) return;
+      setPendingId(id);
+      try {
+        await membership.update({ role });
+        await memberships?.revalidate?.();
+        toast.success("Role updated");
+      } catch (err) {
+        toast.error(clerkMessage(err, "Failed to update role"));
+      } finally {
+        setPendingId(null);
+      }
+    },
+    [memberships],
+  );
+
+  const revokeInvitation = React.useCallback(
+    async (id: string) => {
+      const invitation = invitations?.data?.find((i) => i.id === id);
+      if (!invitation) return;
+      setPendingId(id);
+      try {
+        await invitation.revoke();
+        await invitations?.revalidate?.();
+        toast.success("Invitation revoked");
+      } catch (err) {
+        toast.error(clerkMessage(err, "Failed to revoke invitation"));
+      } finally {
+        setPendingId(null);
+      }
+    },
+    [invitations],
+  );
+
+  return { removeMember, updateRole, revokeInvitation, pendingId };
+}

--- a/packages/dashboard/src/components/dashboard/organizations/members/members-content.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/members-content.tsx
@@ -1,7 +1,6 @@
 import { useOrganization, useOrganizationList, useUser } from "@clerk/react";
 import { useSearchParams } from "next/navigation";
 import * as React from "react";
-import { toast } from "sonner";
 import { Card } from "@/components/ui/card";
 import {
   _MembersSkeleton,
@@ -11,6 +10,7 @@ import {
   MembersList,
 } from "./_components";
 import { useInviteMember } from "./_use-invite-member";
+import { useMemberActions } from "./_use-member-actions";
 
 // =============================================================================
 // Main Page
@@ -24,6 +24,7 @@ export function MembersContent() {
   const {
     isLoaded: isOrgLoaded,
     organization,
+    membership,
     memberships,
     invitations,
   } = useOrganization({
@@ -52,10 +53,14 @@ export function MembersContent() {
   }, [orgParam, setActive, isOrgListLoaded, organization?.id]);
 
   const { inviteMember, isInviting } = useInviteMember(organization, invitations);
+  const { removeMember, updateRole, revokeInvitation, pendingId } = useMemberActions(
+    memberships,
+    invitations,
+  );
 
-  const handleRevokeInvitation = React.useCallback(async (_invitationId: string) => {
-    toast.info("To revoke invitations, use the Clerk Dashboard");
-  }, []);
+  // Only org admins may manage members; the UI hides actions for everyone else
+  // (Clerk independently enforces this server-side).
+  const isAdmin = membership?.role === "org:admin";
 
   // Loading state
   if (!isUserLoaded || !isOrgListLoaded || !isOrgLoaded) {
@@ -90,12 +95,19 @@ export function MembersContent() {
         isLoading={memberships?.isLoading ?? false}
         members={memberships?.data ?? null}
         count={memberships?.count}
+        canManage={isAdmin}
+        currentMembershipId={membership?.id ?? null}
+        pendingId={pendingId}
+        onRemoveMember={removeMember}
+        onUpdateRole={updateRole}
       />
       <_PendingInvitationsList
         isLoading={invitations?.isLoading ?? false}
         invitations={invitations?.data ?? null}
         count={invitations?.count}
-        onRevokeInvitation={handleRevokeInvitation}
+        canManage={isAdmin}
+        pendingId={pendingId}
+        onRevokeInvitation={revokeInvitation}
       />
     </div>
   );


### PR DESCRIPTION
## What
Org admins can now **manage members in-app**: change a member's role (member ↔ admin), remove a member, and revoke a pending invitation. Previously the page was read-only and revoke punted to the Clerk Dashboard.

## Why
You asked to add members, manage roles, and accept/reject membership — all via Clerk. Invite + listing already existed; this fills the management gap (phase 1 of the org work).

## How
- New `useMemberActions` hook wraps Clerk's client SDK: looks up the live membership/invitation resource by id and calls `destroy()` / `update({ role })` / `revoke()`, then revalidates and toasts. Tracks a per-row `pendingId` to disable controls mid-flight.
- Members list: admin-only actions column (Make admin/member, Remove); hidden on the current user's own row to prevent self-lockout (and Clerk blocks removing the last admin).
- Pending invitations: real revoke, admin-only.
- **No backend/auth changes** — Clerk authorizes every action server-side (admins only). Org data is already scoped to the session's active org, so members see shared org content.

## Scope note
This is **phase 1** (membership management). **Phase 2** — enforcing role-based *permissions* on specific actions (e.g., only admins create/delete projects) — touches authorization code and needs a permission matrix; tracked separately for review.

## Risk / Rollback
- **Low.** Dashboard-only, client SDK; no API/schema/auth-middleware changes. tsc 0, biome clean, build 13 pages.
- Authed members page isn't headlessly screenshottable here (Clerk gate); verified via typecheck + build + review.
- Rollback: revert this commit.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>