### PR TITLE
fix(dashboard): dialogs, traces auth, markdown, project sort + global sidebar project scope

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -13,6 +13,7 @@ import analyticsPublicRouter from "./routes/analytics-public";
 import conversationsRouter from "./routes/conversations";
 import domainsRouter from "./routes/domains";
 import keysRouter from "./routes/keys";
+import projectTracesRouter from "./routes/project-traces";
 import projectsRouter from "./routes/projects";
 import tagsRouter from "./routes/tags";
 // V2-only features — new capabilities with no v1 equivalent
@@ -140,6 +141,9 @@ app.route("/api/projects", keysRouter);
 
 // Analytics: /api/v1/projects/:id/analytics
 app.route("/api/v1/projects", analyticsRouter);
+
+// Traces (Clerk-authed dashboard view): /api/v1/projects/:id/traces
+app.route("/api/v1/projects", projectTracesRouter);
 
 // Tags: handles /api/v1/conversations/:id/tags and /api/v1/tags
 // NOTE: router.use("*", apiKeyAuth) applies to /api/v1/* — keep after scoped routes

--- a/packages/api/src/routes/project-traces.ts
+++ b/packages/api/src/routes/project-traces.ts
@@ -1,0 +1,96 @@
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { conversations, organizations, projects } from "../db/schema";
+import { errorResponse, parseLimitParam, parseOrderParam } from "../lib/helpers";
+import * as tracesService from "../services/traces";
+import type { Bindings, Variables } from "../types";
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+// ---------------------------------------------------------------------------
+// GET /:id/traces — List traces for a project (Clerk-authed)
+// ---------------------------------------------------------------------------
+
+app.get("/:id/traces", async (c) => {
+  const db = c.get("db");
+  const projectId = c.req.param("id");
+
+  // Resolve the session Clerk org id to the internal org id, then verify the
+  // project belongs to that org (mirrors analytics.ts pattern).
+  const clerkOrgId = c.get("orgId");
+  const [org] = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.clerkOrgId, clerkOrgId ?? ""))
+    .limit(1);
+  const [project] = await db
+    .select({ orgId: projects.orgId })
+    .from(projects)
+    .where(eq(projects.id, projectId))
+    .limit(1);
+  if (!project || !org || project.orgId !== org.id) {
+    return errorResponse(c, "NOT_FOUND", "Project not found", 404);
+  }
+
+  const limit = parseLimitParam(c.req.query("limit"));
+  const cursor = c.req.query("cursor");
+  const order = parseOrderParam(c.req.query("order"));
+
+  const result = await tracesService.listTraces(db, projectId, {
+    limit,
+    cursor: cursor ?? undefined,
+    order,
+  });
+
+  return c.json(result);
+});
+
+// ---------------------------------------------------------------------------
+// GET /:id/traces/:traceId — Get trace detail (Clerk-authed)
+// ---------------------------------------------------------------------------
+
+app.get("/:id/traces/:traceId", async (c) => {
+  const db = c.get("db");
+  const projectId = c.req.param("id");
+  const traceId = c.req.param("traceId");
+
+  // Resolve the session Clerk org id to the internal org id, then verify the
+  // project belongs to that org (mirrors analytics.ts pattern).
+  const clerkOrgId = c.get("orgId");
+  const [org] = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.clerkOrgId, clerkOrgId ?? ""))
+    .limit(1);
+  const [project] = await db
+    .select({ orgId: projects.orgId })
+    .from(projects)
+    .where(eq(projects.id, projectId))
+    .limit(1);
+  if (!project || !org || project.orgId !== org.id) {
+    return errorResponse(c, "NOT_FOUND", "Project not found", 404);
+  }
+
+  // Verify the trace belongs to this project
+  const [conv] = await db
+    .select({ projectId: conversations.projectId })
+    .from(conversations)
+    .where(eq(conversations.id, traceId))
+    .limit(1);
+  if (!conv || conv.projectId !== projectId) {
+    return errorResponse(c, "NOT_FOUND", "Trace not found", 404);
+  }
+
+  const result = await tracesService.getTraceTree(db, traceId);
+  if (!result) {
+    return errorResponse(c, "NOT_FOUND", "Trace not found", 404);
+  }
+
+  return c.json(result);
+});
+
+export default app;

--- a/packages/dashboard/src/components/app-shell.tsx
+++ b/packages/dashboard/src/components/app-shell.tsx
@@ -4,8 +4,10 @@ import { SignIn, UserButton, useAuth, useUser } from "@clerk/react";
 import {
   ArrowUpRight,
   BookOpen,
+  CaretDown,
   ChartLine,
   ChatCircle,
+  Folder,
   Gear,
   GitBranch,
   House,
@@ -20,6 +22,7 @@ import {
 import { useTheme } from "next-themes";
 import { type ReactNode, useEffect, useState } from "react";
 import { LogoMark } from "@/components/logo-mark";
+import { ProjectScopeProvider, useProjectScope } from "@/components/project-scope";
 
 interface NavItem {
   title: string;
@@ -215,6 +218,57 @@ function SidebarInner({
   );
 }
 
+/**
+ * SidebarProjectScope — the active-project switcher under the logo. Reads/writes
+ * the shared ProjectScope so it controls every project-scoped page at once.
+ */
+function SidebarProjectScope() {
+  const { projects, selectedProjectId, setSelectedProjectId, loadingProjects } = useProjectScope();
+
+  if (loadingProjects) {
+    return (
+      <div className="border-b border-edge-soft px-3 py-2.5">
+        <div className="h-9 animate-pulse rounded-[var(--radius)] bg-panel2" />
+      </div>
+    );
+  }
+
+  if (projects.length === 0) return null;
+
+  return (
+    <div className="border-b border-edge-soft px-3 py-2.5">
+      <label htmlFor="sidebar-project-scope" className="sr-only">
+        Active project
+      </label>
+      <div className="relative">
+        <Folder
+          size={14}
+          className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-fg-4"
+          aria-hidden
+        />
+        <select
+          id="sidebar-project-scope"
+          aria-label="Active project"
+          value={selectedProjectId}
+          onChange={(e) => setSelectedProjectId(e.target.value)}
+          className="h-9 w-full appearance-none rounded-[var(--radius)] border border-edge bg-panel pl-8 pr-8 text-[13px] text-fg transition-colors hover:bg-panel2 focus-visible:bg-panel2 focus-visible:outline-none"
+        >
+          {projects.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+        <CaretDown
+          size={13}
+          className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-fg-4"
+          aria-hidden
+        />
+      </div>
+    </div>
+  );
+}
+
 export function AppShell({ children }: { children: ReactNode }) {
   const pathname = useActivePath();
   const activeUrl = resolveActiveUrl(pathname);
@@ -244,87 +298,91 @@ export function AppShell({ children }: { children: ReactNode }) {
 
   return (
     <Gate>
-      <div className="flex min-h-[100dvh] bg-base">
-        {/* sidebar (desktop) */}
-        <aside className="hidden w-[244px] shrink-0 border-r border-edge lg:flex lg:flex-col">
-          <div className="flex h-14 items-center gap-2.5 border-b border-edge-soft px-5">
-            <a href="/dashboard" className="flex items-center gap-2 text-fg">
-              <LogoMark size={20} />
-              <span className="text-[14.5px] font-semibold tracking-tight">AgentState</span>
-            </a>
-          </div>
-          <SidebarInner activeUrl={activeUrl} />
-        </aside>
-
-        {/* drawer (mobile) */}
-        <div
-          className={`fixed inset-0 z-40 lg:hidden ${menuOpen ? "" : "pointer-events-none"}`}
-          aria-hidden={!menuOpen}
-        >
-          <button
-            type="button"
-            tabIndex={-1}
-            aria-label="Close menu"
-            onClick={() => setMenuOpen(false)}
-            className={`absolute inset-0 cursor-default bg-black/50 transition-opacity duration-200 ${
-              menuOpen ? "opacity-100" : "opacity-0"
-            }`}
-          />
-          <aside
-            className={`absolute left-0 top-0 flex h-full w-[260px] max-w-[82vw] flex-col border-r border-edge bg-base transition-transform duration-200 ${
-              menuOpen ? "translate-x-0" : "-translate-x-full"
-            }`}
-          >
-            <div className="flex h-14 items-center justify-between gap-2.5 border-b border-edge-soft px-5">
+      <ProjectScopeProvider>
+        <div className="flex min-h-[100dvh] bg-base">
+          {/* sidebar (desktop) */}
+          <aside className="hidden w-[244px] shrink-0 border-r border-edge lg:flex lg:flex-col">
+            <div className="flex h-14 items-center gap-2.5 border-b border-edge-soft px-5">
               <a href="/dashboard" className="flex items-center gap-2 text-fg">
                 <LogoMark size={20} />
                 <span className="text-[14.5px] font-semibold tracking-tight">AgentState</span>
               </a>
-              <button
-                type="button"
-                onClick={() => setMenuOpen(false)}
-                aria-label="Close menu"
-                className="grid size-8 place-items-center rounded-[var(--radius)] text-fg-3 transition-[background-color,color] hover:bg-panel2 hover:text-fg"
-              >
-                <X size={18} />
-              </button>
             </div>
-            <SidebarInner activeUrl={activeUrl} onNavigate={() => setMenuOpen(false)} />
+            <SidebarProjectScope />
+            <SidebarInner activeUrl={activeUrl} />
           </aside>
-        </div>
 
-        {/* main */}
-        <div className="flex min-w-0 flex-1 flex-col">
-          <header className="sticky top-0 z-10 flex h-14 items-center gap-3 border-b border-edge bg-base/85 px-5 backdrop-blur sm:px-7">
+          {/* drawer (mobile) */}
+          <div
+            className={`fixed inset-0 z-40 lg:hidden ${menuOpen ? "" : "pointer-events-none"}`}
+            aria-hidden={!menuOpen}
+          >
             <button
               type="button"
-              onClick={() => setMenuOpen(true)}
-              aria-label="Open menu"
-              className="grid size-8 shrink-0 place-items-center rounded-[var(--radius)] text-fg-3 transition-[background-color,color] hover:bg-panel2 hover:text-fg lg:hidden"
+              tabIndex={-1}
+              aria-label="Close menu"
+              onClick={() => setMenuOpen(false)}
+              className={`absolute inset-0 cursor-default bg-black/50 transition-opacity duration-200 ${
+                menuOpen ? "opacity-100" : "opacity-0"
+              }`}
+            />
+            <aside
+              className={`absolute left-0 top-0 flex h-full w-[260px] max-w-[82vw] flex-col border-r border-edge bg-base transition-transform duration-200 ${
+                menuOpen ? "translate-x-0" : "-translate-x-full"
+              }`}
             >
-              <List size={18} />
-            </button>
-            <Breadcrumb pathname={pathname} />
-            <div className="ml-auto flex items-center gap-2">
+              <div className="flex h-14 items-center justify-between gap-2.5 border-b border-edge-soft px-5">
+                <a href="/dashboard" className="flex items-center gap-2 text-fg">
+                  <LogoMark size={20} />
+                  <span className="text-[14.5px] font-semibold tracking-tight">AgentState</span>
+                </a>
+                <button
+                  type="button"
+                  onClick={() => setMenuOpen(false)}
+                  aria-label="Close menu"
+                  className="grid size-8 place-items-center rounded-[var(--radius)] text-fg-3 transition-[background-color,color] hover:bg-panel2 hover:text-fg"
+                >
+                  <X size={18} />
+                </button>
+              </div>
+              <SidebarProjectScope />
+              <SidebarInner activeUrl={activeUrl} onNavigate={() => setMenuOpen(false)} />
+            </aside>
+          </div>
+
+          {/* main */}
+          <div className="flex min-w-0 flex-1 flex-col">
+            <header className="sticky top-0 z-10 flex h-14 items-center gap-3 border-b border-edge bg-base/85 px-5 backdrop-blur sm:px-7">
               <button
                 type="button"
-                onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-                aria-label="Toggle color theme"
-                className="grid size-8 place-items-center rounded-[var(--radius)] border border-edge text-fg-3 transition-[background-color,color] hover:bg-panel2 hover:text-fg"
+                onClick={() => setMenuOpen(true)}
+                aria-label="Open menu"
+                className="grid size-8 shrink-0 place-items-center rounded-[var(--radius)] text-fg-3 transition-[background-color,color] hover:bg-panel2 hover:text-fg lg:hidden"
               >
-                {theme === "dark" ? <Moon size={18} /> : <Sun size={18} />}
+                <List size={18} />
               </button>
-              {user && (
-                <span className="hidden text-[13px] text-fg-3 sm:inline">
-                  {user.fullName ?? user.primaryEmailAddress?.emailAddress}
-                </span>
-              )}
-              <UserButton />
-            </div>
-          </header>
-          <main className="flex-1 pt-7 pb-20 lg:pt-8">{children}</main>
+              <Breadcrumb pathname={pathname} />
+              <div className="ml-auto flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+                  aria-label="Toggle color theme"
+                  className="grid size-8 place-items-center rounded-[var(--radius)] border border-edge text-fg-3 transition-[background-color,color] hover:bg-panel2 hover:text-fg"
+                >
+                  {theme === "dark" ? <Moon size={18} /> : <Sun size={18} />}
+                </button>
+                {user && (
+                  <span className="hidden text-[13px] text-fg-3 sm:inline">
+                    {user.fullName ?? user.primaryEmailAddress?.emailAddress}
+                  </span>
+                )}
+                <UserButton />
+              </div>
+            </header>
+            <main className="flex-1 pt-7 pb-20 lg:pt-8">{children}</main>
+          </div>
         </div>
-      </div>
+      </ProjectScopeProvider>
     </Gate>
   );
 }

--- a/packages/dashboard/src/components/dashboard/analytics/_analytics-header.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_analytics-header.tsx
@@ -1,45 +1,17 @@
-import type { ProjectResponse } from "@agentstate/shared";
 import { type TimeRange, TimeRangeSelect } from "@/components/analytics/time-range-select";
 import { PageHeader } from "@/components/dashboard/page-header";
 
 interface AnalyticsHeaderProps {
-  projects: ProjectResponse[];
-  selectedProjectId: string;
-  onProjectChange: (projectId: string) => void;
   range: TimeRange;
   onRangeChange: (range: TimeRange) => void;
 }
 
-export function AnalyticsHeader({
-  projects,
-  selectedProjectId,
-  onProjectChange,
-  range,
-  onRangeChange,
-}: AnalyticsHeaderProps) {
+export function AnalyticsHeader({ range, onRangeChange }: AnalyticsHeaderProps) {
   return (
     <PageHeader
       title="Analytics"
       description="Usage metrics and activity for your project."
-      actions={
-        <>
-          {projects.length > 1 && (
-            <select
-              aria-label="Select project"
-              value={selectedProjectId}
-              onChange={(e) => onProjectChange(e.target.value)}
-              className="min-h-[40px] w-[180px] rounded-[var(--radius)] border border-edge bg-panel px-3 text-[13px] text-fg outline-none transition-colors hover:bg-panel2 focus-visible:border-accent"
-            >
-              {projects.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.name}
-                </option>
-              ))}
-            </select>
-          )}
-          <TimeRangeSelect value={range} onChange={onRangeChange} />
-        </>
-      }
+      actions={<TimeRangeSelect value={range} onChange={onRangeChange} />}
     />
   );
 }

--- a/packages/dashboard/src/components/dashboard/analytics/analytics-page-content.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/analytics-page-content.tsx
@@ -1,7 +1,8 @@
-import type { AnalyticsResponse, ProjectResponse } from "@agentstate/shared";
+import type { AnalyticsResponse } from "@agentstate/shared";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import type { TimeRange } from "@/components/analytics/time-range-select";
+import { useProjectScope } from "@/components/project-scope";
 import { api } from "@/lib/api";
 import { AnalyticsContent } from "./_analytics-content";
 import { AnalyticsEmpty } from "./_analytics-empty";
@@ -13,53 +14,36 @@ import { AnalyticsLoading } from "./_analytics-loading";
 // ---------------------------------------------------------------------------
 
 export function AnalyticsPageContent() {
-  const [projects, setProjects] = useState<ProjectResponse[]>([]);
-  const [selectedProjectId, setSelectedProjectId] = useState("");
+  // The active project comes from the sidebar-driven global scope.
+  const { projects, selectedProjectId, loadingProjects } = useProjectScope();
   const [range, setRange] = useState<TimeRange>("30d");
   const [data, setData] = useState<AnalyticsResponse | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [loadingAnalytics, setLoadingAnalytics] = useState(false);
 
-  // Fetch projects
-  useEffect(() => {
-    api<{ data: ProjectResponse[] }>("/v1/projects")
-      .then((res) => {
-        setProjects(res.data);
-        if (res.data.length > 0) {
-          setSelectedProjectId(res.data[0].id);
-        }
-      })
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load data"))
-      .finally(() => setLoading(false));
-  }, []);
-
-  // Fetch analytics when project or range changes
+  // Fetch analytics when the active project or range changes
   useEffect(() => {
     if (!selectedProjectId) return;
-    setLoading(true);
+    setLoadingAnalytics(true);
     api<AnalyticsResponse>(`/v1/projects/${selectedProjectId}/analytics?range=${range}`)
       .then(setData)
       .catch((e) => {
         setData(null);
         toast.error(e instanceof Error ? e.message : "Failed to load analytics");
       })
-      .finally(() => setLoading(false));
+      .finally(() => setLoadingAnalytics(false));
   }, [selectedProjectId, range]);
+
+  const loading = loadingProjects || loadingAnalytics;
 
   return (
     <div className="flex flex-col gap-6 px-4 lg:px-6">
-      <AnalyticsHeader
-        projects={projects}
-        selectedProjectId={selectedProjectId}
-        onProjectChange={setSelectedProjectId}
-        range={range}
-        onRangeChange={setRange}
-      />
+      <AnalyticsHeader range={range} onRangeChange={setRange} />
 
       {loading && <AnalyticsLoading hasData={!!data} />}
 
       {data && <AnalyticsContent data={data} />}
 
-      {!loading && projects.length === 0 && <AnalyticsEmpty />}
+      {!loadingProjects && projects.length === 0 && <AnalyticsEmpty />}
     </div>
   );
 }

--- a/packages/dashboard/src/components/dashboard/conversations/_components.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/_components.tsx
@@ -11,8 +11,8 @@ export type {
 } from "./_messages-panel";
 export { MessageRow, MessagesPanel, RoleBadge } from "./_messages-panel";
 
-export type { _EmptyProjectsProps, _ProjectSelectorProps } from "./_project-selectors";
-export { _EmptyProjects, _ProjectSelector } from "./_project-selectors";
+export type { _EmptyProjectsProps } from "./_project-selectors";
+export { _EmptyProjects } from "./_project-selectors";
 
 export { CONVERSATIONS_EMPTY_STATE, getConversationsColumns } from "./_table-columns";
 export type { Message } from "./_use-messages";

--- a/packages/dashboard/src/components/dashboard/conversations/_messages-panel.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/_messages-panel.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
+import { Markdown } from "@/components/ui/markdown";
 import { formatDate } from "@/lib/format";
 import { type Message, useMessages } from "./_use-messages";
 
@@ -23,9 +24,7 @@ export function MessageRow({ msg }: { msg: Message }) {
         <RoleBadge role={msg.role} />
       </div>
       <div className="min-w-0 flex-1">
-        <p className="whitespace-pre-wrap break-words text-[12.5px] leading-relaxed text-fg-2">
-          {displayed}
-        </p>
+        <Markdown content={displayed} className="break-words text-[12.5px]" />
         {truncated && (
           <button
             type="button"

--- a/packages/dashboard/src/components/dashboard/conversations/_project-selectors.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/_project-selectors.tsx
@@ -1,45 +1,6 @@
-import type { ProjectResponse } from "@agentstate/shared";
 import { ChatCircle } from "@phosphor-icons/react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-
-export interface _ProjectSelectorProps {
-  projects: ProjectResponse[];
-  selectedProjectId: string;
-  onSelectProject: (id: string) => void;
-}
-
-export function _ProjectSelector({
-  projects,
-  selectedProjectId,
-  onSelectProject,
-}: _ProjectSelectorProps) {
-  if (projects.length <= 1) return null;
-
-  return (
-    <div className="flex items-center gap-2.5">
-      <label
-        htmlFor="project-select"
-        className="shrink-0 font-mono text-[10.5px] uppercase tracking-[0.12em] text-fg-4"
-      >
-        Project
-      </label>
-      <select
-        id="project-select"
-        aria-label="Select project"
-        value={selectedProjectId}
-        onChange={(e) => onSelectProject(e.target.value)}
-        className="h-[36px] w-[200px] rounded-[var(--radius)] border border-edge bg-panel px-3 font-mono text-[12px] text-fg transition-colors hover:bg-panel2 focus-visible:bg-panel2 focus-visible:outline-none"
-      >
-        {projects.map((p) => (
-          <option key={p.id} value={p.id}>
-            {p.name}
-          </option>
-        ))}
-      </select>
-    </div>
-  );
-}
 
 export interface _EmptyProjectsProps {
   onCreateProject: () => void;

--- a/packages/dashboard/src/components/dashboard/conversations/_use-conversations-data.ts
+++ b/packages/dashboard/src/components/dashboard/conversations/_use-conversations-data.ts
@@ -1,6 +1,7 @@
 import type { ConversationResponse, ProjectResponse } from "@agentstate/shared";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { useProjectScope } from "@/components/project-scope";
 import { api } from "@/lib/api";
 
 export type Conversation = ConversationResponse & { project_id: string };
@@ -15,7 +16,6 @@ interface UseConversationsDataState {
 }
 
 interface UseConversationsDataActions {
-  setSelectedProjectId: (id: string) => void;
   appendConversations: (newConversations: Conversation[]) => void;
   setHasMore: (value: boolean) => void;
 }
@@ -23,28 +23,13 @@ interface UseConversationsDataActions {
 export type UseConversationsDataResult = UseConversationsDataState & UseConversationsDataActions;
 
 export function useConversationsData(): UseConversationsDataResult {
-  const [projects, setProjects] = useState<ProjectResponse[]>([]);
-  const [selectedProjectId, setSelectedProjectId] = useState<string>("");
+  // The active project comes from the sidebar-driven global scope.
+  const { projects, selectedProjectId, loadingProjects } = useProjectScope();
   const [conversations, setConversations] = useState<Conversation[]>([]);
-  const [loadingProjects, setLoadingProjects] = useState(true);
   const [loadingConversations, setLoadingConversations] = useState(false);
   const [hasMore, setHasMore] = useState(true);
 
-  // Fetch projects on mount
-  useEffect(() => {
-    setLoadingProjects(true);
-    api<{ data: ProjectResponse[] }>("/v1/projects")
-      .then((res) => {
-        setProjects(res.data);
-        if (res.data.length > 0) {
-          setSelectedProjectId(res.data[0].id);
-        }
-      })
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load data"))
-      .finally(() => setLoadingProjects(false));
-  }, []);
-
-  // Fetch conversations when selected project changes
+  // Fetch conversations when the active project changes
   useEffect(() => {
     if (!selectedProjectId) return;
     setLoadingConversations(true);
@@ -70,7 +55,6 @@ export function useConversationsData(): UseConversationsDataResult {
     loadingProjects,
     loadingConversations,
     hasMore,
-    setSelectedProjectId,
     appendConversations,
     setHasMore,
   };

--- a/packages/dashboard/src/components/dashboard/conversations/conversations-page.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/conversations-page.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { AppShell } from "@/components/app-shell";
 import { Providers } from "@/components/providers";
 import { Button } from "@/components/ui/button";
-import { _ConversationsTable, _EmptyProjects, _ProjectSelector } from "./_components";
+import { _ConversationsTable, _EmptyProjects } from "./_components";
 import { useConversationsData, useConversationsPagination } from "./_hooks";
 
 function PageHeader({
@@ -33,7 +33,6 @@ function ConversationsContent() {
     loadingProjects,
     loadingConversations,
     hasMore,
-    setSelectedProjectId,
     appendConversations,
     setHasMore,
   } = useConversationsData();
@@ -50,24 +49,17 @@ function ConversationsContent() {
   const handleCreateProject = useCallback(() => {
     window.location.assign("/dashboard");
   }, []);
-  const handleSelectProject = useCallback(
-    (id: string) => setSelectedProjectId(id),
-    [setSelectedProjectId],
-  );
 
   const showLoadMore = hasMore && conversations.length > 0;
 
   return (
-    <div className="px-4 lg:px-6">
+    <div className="px-5 sm:px-7">
       <PageHeader
         title="Conversations"
-        description="Browse conversation history across all projects."
-        actions={
-          <_ProjectSelector
-            projects={projects}
-            selectedProjectId={selectedProjectId}
-            onSelectProject={handleSelectProject}
-          />
+        description={
+          selectedProject
+            ? `Browse conversation history for ${selectedProject.name}.`
+            : "Browse conversation history."
         }
       />
 

--- a/packages/dashboard/src/components/dashboard/project/_delete-confirmation.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_delete-confirmation.tsx
@@ -4,7 +4,7 @@ import { Trash } from "@phosphor-icons/react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Dialog, DialogContent, DialogFooter, DialogTrigger } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogFooter } from "@/components/ui/dialog";
 
 interface DeleteConfirmationProps {
   projectName: string;
@@ -41,12 +41,10 @@ export function DeleteConfirmation({
               and API keys.
             </p>
           </div>
-          <DialogTrigger asChild>
-            <Button variant="danger" className="w-fit" onClick={() => setOpen(true)}>
-              <Trash size={16} aria-hidden />
-              Delete project
-            </Button>
-          </DialogTrigger>
+          <Button variant="danger" className="w-fit" onClick={() => setOpen(true)}>
+            <Trash size={16} aria-hidden />
+            Delete project
+          </Button>
         </div>
       </Card>
 

--- a/packages/dashboard/src/components/dashboard/project/_retention-settings.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_retention-settings.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Dialog, DialogContent, DialogFooter, DialogTrigger } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogFooter } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { api } from "@/lib/api";
 
@@ -61,12 +61,14 @@ export function RetentionSettings({ project, onUpdated }: RetentionSettingsProps
           infinite retention.
         </p>
       </div>
+      <Button variant="secondary" className="w-fit" onClick={() => setOpen(true)}>
+        Change
+      </Button>
+      <div className="flex items-center gap-3 text-[13px] text-fg-3">
+        <span>Current: {currentDisplay}</span>
+      </div>
+
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogTrigger asChild>
-          <Button variant="secondary" onClick={() => setOpen(true)}>
-            Change
-          </Button>
-        </DialogTrigger>
         <DialogContent
           title="Change retention period"
           description="Conversations older than this will be permanently deleted daily at 3 AM UTC."
@@ -100,9 +102,6 @@ export function RetentionSettings({ project, onUpdated }: RetentionSettingsProps
           </DialogFooter>
         </DialogContent>
       </Dialog>
-      <div className="flex items-center gap-3 text-[13px] text-fg-3">
-        <span>Current: {currentDisplay}</span>
-      </div>
     </Card>
   );
 }

--- a/packages/dashboard/src/components/dashboard/projects/_projects-table.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/_projects-table.tsx
@@ -1,5 +1,5 @@
 import type { ProjectListItem } from "@agentstate/shared";
-import { Folder } from "@phosphor-icons/react";
+import { CaretDown, CaretUp, Folder } from "@phosphor-icons/react";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
@@ -13,6 +13,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { timeAgo } from "@/lib/format";
+import { cn } from "@/lib/utils";
 
 type Project = ProjectListItem;
 
@@ -21,6 +22,79 @@ interface ProjectsTableProps {
 }
 
 const TOTAL_COLUMNS = 7;
+
+type SortKey =
+  | "name"
+  | "conversation_count"
+  | "message_count"
+  | "total_tokens"
+  | "key_count"
+  | "last_activity_at"
+  | "created_at";
+
+type SortDir = "asc" | "desc";
+
+/** Comparable value for a project under the active sort key. */
+function sortValue(p: Project, key: SortKey): number | string {
+  switch (key) {
+    case "name":
+      return p.name.toLowerCase();
+    case "created_at":
+      return new Date(p.created_at).getTime();
+    case "last_activity_at":
+      return p.last_activity_at ?? 0;
+    case "key_count":
+      return p.key_count ?? 0;
+    default:
+      return p[key];
+  }
+}
+
+/** Sortable column header — toggles direction when re-clicked. */
+function SortHead({
+  label,
+  sortKey: key,
+  activeKey,
+  dir,
+  onSort,
+  align = "left",
+  className,
+}: {
+  label: string;
+  sortKey: SortKey;
+  activeKey: SortKey;
+  dir: SortDir;
+  onSort: (key: SortKey) => void;
+  align?: "left" | "right";
+  className?: string;
+}) {
+  const active = activeKey === key;
+  return (
+    <TableHead
+      align={align}
+      className={className}
+      aria-sort={active ? (dir === "asc" ? "ascending" : "descending") : "none"}
+    >
+      <button
+        type="button"
+        onClick={() => onSort(key)}
+        className={cn(
+          "inline-flex items-center gap-1 uppercase tracking-[0.12em] transition-colors hover:text-fg",
+          active ? "text-fg-2" : "text-fg-4",
+          align === "right" && "flex-row-reverse",
+        )}
+      >
+        {label}
+        {active &&
+          (dir === "asc" ? (
+            <CaretUp size={10} weight="bold" aria-hidden />
+          ) : (
+            <CaretDown size={10} weight="bold" aria-hidden />
+          ))}
+      </button>
+    </TableHead>
+  );
+}
 
 /**
  * ProjectsTable - Projects list with per-project stats and a name/slug filter.
@@ -32,6 +106,18 @@ const TOTAL_COLUMNS = 7;
 export function ProjectsTable({ projects }: ProjectsTableProps) {
   const router = useRouter();
   const [query, setQuery] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("last_activity_at");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  const toggleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      // Names read best A→Z; counts and dates most-useful high→low first.
+      setSortDir(key === "name" ? "asc" : "desc");
+    }
+  };
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -40,6 +126,18 @@ export function ProjectsTable({ projects }: ProjectsTableProps) {
       (p) => p.name.toLowerCase().includes(q) || p.slug.toLowerCase().includes(q),
     );
   }, [projects, query]);
+
+  const sorted = useMemo(() => {
+    const factor = sortDir === "asc" ? 1 : -1;
+    return [...filtered].sort((a, b) => {
+      const av = sortValue(a, sortKey);
+      const bv = sortValue(b, sortKey);
+      if (typeof av === "string" && typeof bv === "string") {
+        return av.localeCompare(bv) * factor;
+      }
+      return ((av as number) - (bv as number)) * factor;
+    });
+  }, [filtered, sortKey, sortDir]);
 
   const open = (slug: string) => router.push(`/dashboard/project/?slug=${slug}`);
 
@@ -57,36 +155,78 @@ export function ProjectsTable({ projects }: ProjectsTableProps) {
       <Table responsive>
         <TableHeader>
           <TableRow>
-            <TableHead>Name</TableHead>
-            <TableHead align="right" className="hidden sm:table-cell">
-              Conversations
-            </TableHead>
-            <TableHead align="right" className="hidden lg:table-cell">
-              Messages
-            </TableHead>
-            <TableHead align="right" className="hidden sm:table-cell">
-              Tokens
-            </TableHead>
-            <TableHead align="right" className="hidden lg:table-cell">
-              Keys
-            </TableHead>
-            <TableHead align="right" className="hidden md:table-cell">
-              Last activity
-            </TableHead>
-            <TableHead align="right" className="hidden xl:table-cell">
-              Created
-            </TableHead>
+            <SortHead
+              label="Name"
+              sortKey="name"
+              activeKey={sortKey}
+              dir={sortDir}
+              onSort={toggleSort}
+            />
+            <SortHead
+              label="Conversations"
+              sortKey="conversation_count"
+              activeKey={sortKey}
+              dir={sortDir}
+              onSort={toggleSort}
+              align="right"
+              className="hidden sm:table-cell"
+            />
+            <SortHead
+              label="Messages"
+              sortKey="message_count"
+              activeKey={sortKey}
+              dir={sortDir}
+              onSort={toggleSort}
+              align="right"
+              className="hidden lg:table-cell"
+            />
+            <SortHead
+              label="Tokens"
+              sortKey="total_tokens"
+              activeKey={sortKey}
+              dir={sortDir}
+              onSort={toggleSort}
+              align="right"
+              className="hidden sm:table-cell"
+            />
+            <SortHead
+              label="Keys"
+              sortKey="key_count"
+              activeKey={sortKey}
+              dir={sortDir}
+              onSort={toggleSort}
+              align="right"
+              className="hidden lg:table-cell"
+            />
+            <SortHead
+              label="Last activity"
+              sortKey="last_activity_at"
+              activeKey={sortKey}
+              dir={sortDir}
+              onSort={toggleSort}
+              align="right"
+              className="hidden md:table-cell"
+            />
+            <SortHead
+              label="Created"
+              sortKey="created_at"
+              activeKey={sortKey}
+              dir={sortDir}
+              onSort={toggleSort}
+              align="right"
+              className="hidden xl:table-cell"
+            />
           </TableRow>
         </TableHeader>
         <TableBody>
-          {filtered.length === 0 ? (
+          {sorted.length === 0 ? (
             <TableRow>
               <TableCell colSpan={TOTAL_COLUMNS} className="text-center text-fg-4">
                 No projects match “{query}”.
               </TableCell>
             </TableRow>
           ) : (
-            filtered.map((project) => (
+            sorted.map((project) => (
               <TableRow
                 key={project.id}
                 clickable

--- a/packages/dashboard/src/components/dashboard/traces/traces-page.tsx
+++ b/packages/dashboard/src/components/dashboard/traces/traces-page.tsx
@@ -3,6 +3,8 @@ import { useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { AppShell } from "@/components/app-shell";
+import { _EmptyProjects } from "@/components/dashboard/conversations/_components";
+import { useProjectScope } from "@/components/project-scope";
 import { Providers } from "@/components/providers";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -53,6 +55,30 @@ function formatDate(ts: number): string {
     hour: "2-digit",
     minute: "2-digit",
   });
+}
+
+// ---------------------------------------------------------------------------
+// PageHeader (matches conversations layout)
+// ---------------------------------------------------------------------------
+
+function PageHeader({
+  title,
+  description,
+  actions,
+}: {
+  title: string;
+  description: string;
+  actions?: React.ReactNode;
+}) {
+  return (
+    <header className="mb-[22px] flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <div className="flex max-w-2xl flex-col gap-1.5">
+        <h1 className="text-[26px] tracking-tight text-fg">{title}</h1>
+        <p className="text-[14.5px] leading-6 text-fg-3">{description}</p>
+      </div>
+      {actions && <div className="flex flex-wrap items-center gap-2 sm:justify-end">{actions}</div>}
+    </header>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -158,29 +184,37 @@ function TracesContent() {
   const searchParams = useSearchParams();
   const selectedId = searchParams.get("id");
 
+  // The active project comes from the sidebar-driven global scope.
+  const { projects, selectedProjectId, loadingProjects } = useProjectScope();
+
   // Trace list
   const [traces, setTraces] = useState<TraceItem[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
 
   useEffect(() => {
+    if (!selectedProjectId) return;
     setLoading(true);
-    api<{ data: TraceItem[]; has_more: boolean }>("/v1/conversations/traces?limit=50")
+    setTraces([]);
+    setHasMore(false);
+    api<{ data: TraceItem[]; has_more: boolean }>(
+      `/v1/projects/${selectedProjectId}/traces?limit=50`,
+    )
       .then((res) => {
         setTraces(res.data);
         setHasMore(res.has_more);
       })
       .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load traces"))
       .finally(() => setLoading(false));
-  }, []);
+  }, [selectedProjectId]);
 
   const loadMore = useCallback(() => {
-    if (loadingMore || !hasMore || traces.length === 0) return;
+    if (loadingMore || !hasMore || traces.length === 0 || !selectedProjectId) return;
     const cursor = traces[traces.length - 1].created_at.toString();
     setLoadingMore(true);
     api<{ data: TraceItem[]; has_more: boolean }>(
-      `/v1/conversations/traces?limit=50&cursor=${cursor}`,
+      `/v1/projects/${selectedProjectId}/traces?limit=50&cursor=${cursor}`,
     )
       .then((res) => {
         setTraces((prev) => [...prev, ...res.data]);
@@ -188,23 +222,23 @@ function TracesContent() {
       })
       .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load more"))
       .finally(() => setLoadingMore(false));
-  }, [loadingMore, hasMore, traces]);
+  }, [loadingMore, hasMore, traces, selectedProjectId]);
 
   // Trace detail
   const [detail, setDetail] = useState<TraceDetailResponse | null>(null);
   const [loadingDetail, setLoadingDetail] = useState(false);
 
   useEffect(() => {
-    if (!selectedId) {
+    if (!selectedId || !selectedProjectId) {
       setDetail(null);
       return;
     }
     setLoadingDetail(true);
-    api<TraceDetailResponse>(`/v1/conversations/traces/${selectedId}`)
+    api<TraceDetailResponse>(`/v1/projects/${selectedProjectId}/traces/${selectedId}`)
       .then(setDetail)
       .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load trace detail"))
       .finally(() => setLoadingDetail(false));
-  }, [selectedId]);
+  }, [selectedId, selectedProjectId]);
 
   // Compute trace timeline bounds for waterfall bars
   const observations = detail?.observations ?? [];
@@ -218,146 +252,172 @@ function TracesContent() {
       : 0;
   const traceDuration = traceEnd > traceStart ? traceEnd - traceStart : 0;
 
+  const handleCreateProject = useCallback(() => window.location.assign("/dashboard"), []);
+
   return (
-    <div className="px-4 py-6 lg:px-7">
-      <header className="mb-[22px] flex flex-col gap-1.5">
-        <h1 className="text-[26px] tracking-tight text-fg">Traces</h1>
-        <p className="text-[14.5px] leading-6 text-fg-3">LLM execution traces and observability.</p>
-      </header>
+    <div className="px-5 sm:px-7">
+      <PageHeader title="Traces" description="LLM execution traces and observability." />
 
-      {/* Traces table */}
-      <div className="overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-panel">
-        <div className="overflow-x-auto">
-          <table className="w-full border-collapse">
-            <thead>
-              <tr className="border-b border-edge">
-                <th className="w-[40%] px-3 py-2 text-left">
-                  <ColLabel>Title</ColLabel>
-                </th>
-                <th className="px-3 py-2 text-left">
-                  <ColLabel>Observations</ColLabel>
-                </th>
-                <th className="px-3 py-2 text-left">
-                  <ColLabel>Tokens</ColLabel>
-                </th>
-                <th className="px-3 py-2 text-left">
-                  <ColLabel>Cost</ColLabel>
-                </th>
-                <th className="px-3 py-2 text-left">
-                  <ColLabel>Created</ColLabel>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {loading &&
-                ROW_SKEL.map((k) => (
-                  <tr key={k} className="border-b border-edge-soft">
-                    <td colSpan={5} className="px-3 py-2">
-                      <div className="h-4 w-full animate-pulse rounded-[var(--radius)] bg-panel2" />
-                    </td>
-                  </tr>
-                ))}
-              {!loading && traces.length === 0 && (
-                <tr>
-                  <td colSpan={5} className="py-8 text-center text-[13px] text-fg-4">
-                    No traces found.
-                  </td>
-                </tr>
-              )}
-              {traces.map((t) => {
-                const isActive = selectedId === t.id;
-                return (
-                  <tr
-                    key={t.id}
-                    className={`cursor-pointer border-b border-edge-soft text-[13px] transition-[background-color] duration-150 hover:bg-panel2 ${
-                      isActive ? "bg-panel2" : ""
-                    }`}
-                    onClick={() => {
-                      const url = new URL(window.location.href);
-                      if (isActive) {
-                        url.searchParams.delete("id");
-                      } else {
-                        url.searchParams.set("id", t.id);
-                      }
-                      window.history.pushState({}, "", url.toString());
-                      window.dispatchEvent(new PopStateEvent("popstate"));
-                    }}
-                  >
-                    <td className="px-3 py-2 font-medium text-fg">
-                      {t.title ?? <span className="text-fg-4">Untitled</span>}
-                    </td>
-                    <td className="num px-3 py-2 text-fg-2">{t.message_count}</td>
-                    <td className="num px-3 py-2 text-fg-2">{formatTokens(t.total_tokens)}</td>
-                    <td className="num px-3 py-2 text-fg-2">
-                      {formatCost(t.total_cost_microdollars)}
-                    </td>
-                    <td className="num px-3 py-2 text-fg-3">{formatDate(t.created_at)}</td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      {hasMore && (
-        <div className="mt-3 flex justify-center">
-          <Button variant="secondary" disabled={loadingMore} onClick={loadMore}>
-            {loadingMore ? "Loading..." : "Load more"}
-          </Button>
+      {loadingProjects && (
+        <div className="flex flex-col gap-3">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="flex items-center gap-4 rounded-[var(--radius-lg)] border border-edge bg-panel p-4"
+            >
+              <div className="size-10 shrink-0 animate-pulse rounded-[var(--radius)] bg-edge" />
+              <div className="flex flex-1 flex-col gap-2">
+                <div className="h-4 w-32 animate-pulse rounded bg-edge" />
+                <div className="h-3 w-24 animate-pulse rounded bg-edge" />
+              </div>
+            </div>
+          ))}
         </div>
       )}
 
-      {/* Trace detail waterfall */}
-      {selectedId && (
-        <div className="mt-6">
-          <div className="mb-3 flex items-center gap-2">
-            <h2 className="text-[14px] font-semibold text-fg">Trace Detail</h2>
-            {detail && (
-              <span className="font-mono text-[12px] text-fg-4">{detail.title ?? detail.id}</span>
-            )}
+      {!loadingProjects && projects.length === 0 && (
+        <_EmptyProjects onCreateProject={handleCreateProject} />
+      )}
+
+      {!loadingProjects && projects.length > 0 && (
+        <>
+          {/* Traces table */}
+          <div className="overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-panel">
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr className="border-b border-edge">
+                    <th className="w-[40%] px-3 py-2 text-left">
+                      <ColLabel>Title</ColLabel>
+                    </th>
+                    <th className="px-3 py-2 text-left">
+                      <ColLabel>Observations</ColLabel>
+                    </th>
+                    <th className="px-3 py-2 text-left">
+                      <ColLabel>Tokens</ColLabel>
+                    </th>
+                    <th className="px-3 py-2 text-left">
+                      <ColLabel>Cost</ColLabel>
+                    </th>
+                    <th className="px-3 py-2 text-left">
+                      <ColLabel>Created</ColLabel>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {loading &&
+                    ROW_SKEL.map((k) => (
+                      <tr key={k} className="border-b border-edge-soft">
+                        <td colSpan={5} className="px-3 py-2">
+                          <div className="h-4 w-full animate-pulse rounded-[var(--radius)] bg-panel2" />
+                        </td>
+                      </tr>
+                    ))}
+                  {!loading && traces.length === 0 && (
+                    <tr>
+                      <td colSpan={5} className="py-8 text-center text-[13px] text-fg-4">
+                        No traces found.
+                      </td>
+                    </tr>
+                  )}
+                  {traces.map((t) => {
+                    const isActive = selectedId === t.id;
+                    return (
+                      <tr
+                        key={t.id}
+                        className={`cursor-pointer border-b border-edge-soft text-[13px] transition-[background-color] duration-150 hover:bg-panel2 ${
+                          isActive ? "bg-panel2" : ""
+                        }`}
+                        onClick={() => {
+                          const url = new URL(window.location.href);
+                          if (isActive) {
+                            url.searchParams.delete("id");
+                          } else {
+                            url.searchParams.set("id", t.id);
+                          }
+                          window.history.pushState({}, "", url.toString());
+                          window.dispatchEvent(new PopStateEvent("popstate"));
+                        }}
+                      >
+                        <td className="px-3 py-2 font-medium text-fg">
+                          {t.title ?? <span className="text-fg-4">Untitled</span>}
+                        </td>
+                        <td className="num px-3 py-2 text-fg-2">{t.message_count}</td>
+                        <td className="num px-3 py-2 text-fg-2">{formatTokens(t.total_tokens)}</td>
+                        <td className="num px-3 py-2 text-fg-2">
+                          {formatCost(t.total_cost_microdollars)}
+                        </td>
+                        <td className="num px-3 py-2 text-fg-3">{formatDate(t.created_at)}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
           </div>
 
-          {loadingDetail && (
-            <div className="space-y-2">
-              {DETAIL_SKEL.map((k) => (
-                <div
-                  key={k}
-                  className="h-6 w-full animate-pulse rounded-[var(--radius)] bg-panel2"
-                />
-              ))}
+          {hasMore && (
+            <div className="mt-3 flex justify-center">
+              <Button variant="secondary" disabled={loadingMore} onClick={loadMore}>
+                {loadingMore ? "Loading..." : "Load more"}
+              </Button>
             </div>
           )}
 
-          {!loadingDetail && detail && (
-            <div className="overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-panel">
-              {/* Column headers */}
-              <div className="flex items-center gap-2 border-b border-edge px-3 py-1.5">
-                <ColLabel className="w-[40%]">Type</ColLabel>
-                <span className="flex-1" />
-                <ColLabel className="w-28">Timeline</ColLabel>
-                <ColLabel className="w-12 text-right">Duration</ColLabel>
-                <ColLabel className="w-14 text-right">Tokens</ColLabel>
-                <ColLabel className="w-14 text-right">Cost</ColLabel>
+          {/* Trace detail waterfall */}
+          {selectedId && (
+            <div className="mt-6">
+              <div className="mb-3 flex items-center gap-2">
+                <h2 className="text-[14px] font-semibold text-fg">Trace Detail</h2>
+                {detail && (
+                  <span className="font-mono text-[12px] text-fg-4">
+                    {detail.title ?? detail.id}
+                  </span>
+                )}
               </div>
-              {observations.length > 0 ? (
-                observations.map((obs) => (
-                  <ObservationRow
-                    key={obs.id}
-                    obs={obs}
-                    depth={0}
-                    traceStart={traceStart}
-                    traceDuration={traceDuration}
-                  />
-                ))
-              ) : (
-                <div className="py-6 text-center text-[13px] text-fg-4">
-                  No observations in this trace.
+
+              {loadingDetail && (
+                <div className="space-y-2">
+                  {DETAIL_SKEL.map((k) => (
+                    <div
+                      key={k}
+                      className="h-6 w-full animate-pulse rounded-[var(--radius)] bg-panel2"
+                    />
+                  ))}
+                </div>
+              )}
+
+              {!loadingDetail && detail && (
+                <div className="overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-panel">
+                  {/* Column headers */}
+                  <div className="flex items-center gap-2 border-b border-edge px-3 py-1.5">
+                    <ColLabel className="w-[40%]">Type</ColLabel>
+                    <span className="flex-1" />
+                    <ColLabel className="w-28">Timeline</ColLabel>
+                    <ColLabel className="w-12 text-right">Duration</ColLabel>
+                    <ColLabel className="w-14 text-right">Tokens</ColLabel>
+                    <ColLabel className="w-14 text-right">Cost</ColLabel>
+                  </div>
+                  {observations.length > 0 ? (
+                    observations.map((obs) => (
+                      <ObservationRow
+                        key={obs.id}
+                        obs={obs}
+                        depth={0}
+                        traceStart={traceStart}
+                        traceDuration={traceDuration}
+                      />
+                    ))
+                  ) : (
+                    <div className="py-6 text-center text-[13px] text-fg-4">
+                      No observations in this trace.
+                    </div>
+                  )}
                 </div>
               )}
             </div>
           )}
-        </div>
+        </>
       )}
     </div>
   );

--- a/packages/dashboard/src/components/project-scope.tsx
+++ b/packages/dashboard/src/components/project-scope.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import type { ProjectResponse } from "@agentstate/shared";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+
+const STORAGE_KEY = "agentstate:active-project";
+
+interface ProjectScopeValue {
+  projects: ProjectResponse[];
+  loadingProjects: boolean;
+  selectedProjectId: string;
+  selectedProject: ProjectResponse | undefined;
+  setSelectedProjectId: (id: string) => void;
+}
+
+const ProjectScopeContext = createContext<ProjectScopeValue | null>(null);
+
+function readStored(): string | null {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeStored(id: string): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, id);
+  } catch {
+    // Private mode / storage disabled — selection just won't persist.
+  }
+}
+
+/**
+ * ProjectScopeProvider — single source of truth for the dashboard's active
+ * project. Fetches the project list once, restores the last selection from
+ * localStorage (falling back to the first project), and exposes a setter that
+ * persists. Project-scoped pages (conversations, traces, analytics) read from
+ * this instead of maintaining their own selector, so the sidebar switcher
+ * controls them all.
+ */
+export function ProjectScopeProvider({ children }: { children: ReactNode }) {
+  const [projects, setProjects] = useState<ProjectResponse[]>([]);
+  const [loadingProjects, setLoadingProjects] = useState(true);
+  const [selectedProjectId, setSelectedProjectIdState] = useState<string>("");
+
+  const setSelectedProjectId = useCallback((id: string) => {
+    setSelectedProjectIdState(id);
+    writeStored(id);
+  }, []);
+
+  useEffect(() => {
+    setLoadingProjects(true);
+    api<{ data: ProjectResponse[] }>("/v1/projects")
+      .then((res) => {
+        setProjects(res.data);
+        if (res.data.length === 0) return;
+        const stored = readStored();
+        const valid = stored && res.data.some((p) => p.id === stored);
+        setSelectedProjectIdState(valid ? (stored as string) : res.data[0].id);
+      })
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load projects"))
+      .finally(() => setLoadingProjects(false));
+  }, []);
+
+  const value = useMemo<ProjectScopeValue>(
+    () => ({
+      projects,
+      loadingProjects,
+      selectedProjectId,
+      selectedProject: projects.find((p) => p.id === selectedProjectId),
+      setSelectedProjectId,
+    }),
+    [projects, loadingProjects, selectedProjectId, setSelectedProjectId],
+  );
+
+  return <ProjectScopeContext.Provider value={value}>{children}</ProjectScopeContext.Provider>;
+}
+
+export function useProjectScope(): ProjectScopeValue {
+  const ctx = useContext(ProjectScopeContext);
+  if (!ctx) {
+    throw new Error("useProjectScope must be used within a ProjectScopeProvider");
+  }
+  return ctx;
+}

--- a/packages/dashboard/src/pages/docs.astro
+++ b/packages/dashboard/src/pages/docs.astro
@@ -11,6 +11,7 @@ const navGroups: { group: string; items: [id: string, label: string][] }[] = [
     group: "Getting started",
     items: [
       ["overview", "Overview"],
+      ["agent-prompt", "Use with your AI agent"],
       ["quickstart", "Quickstart"],
       ["auth", "Authentication"],
     ],
@@ -31,6 +32,7 @@ const navGroups: { group: string; items: [id: string, label: string][] }[] = [
 // Right TOC — same anchors in document order.
 // biome-ignore lint/correctness/noUnusedVariables: used in the template below
 const onThisPage: [id: string, label: string][] = [
+  ["agent-prompt", "Use with your AI agent"],
   ["quickstart", "Quickstart"],
   ["auth", "Authentication"],
   ["conversations", "Conversations"],
@@ -75,6 +77,19 @@ const conv = await state.createConversation({
 const authCode = `# every request carries a bearer key (starts with as_live_)
 curl https://agentstate.app/api/v1/conversations \\
   -H "Authorization: Bearer as_live_your_key"`;
+
+// biome-ignore lint/correctness/noUnusedVariables: used in the template below
+const agentPromptCode = `I want to integrate AgentState (a conversation-history database-as-a-service for AI agents) into this project.
+
+First, discover the API by reading:
+- https://agentstate.app/llms.txt
+- https://agentstate.app/agents.md
+- https://agentstate.app/openapi.json
+
+Then help me: create a project, generate an API key, and store + retrieve conversation history using the REST API at https://agentstate.app/api/v1. Use the snake_case JSON contract and Bearer API-key auth described in those docs.`;
+
+// biome-ignore lint/correctness/noUnusedVariables: used in the template below
+const installSkillCode = `npx skills add duyet/agentstate`;
 
 // biome-ignore lint/correctness/noUnusedVariables: used in the template below
 function methodColor(m: string): string {
@@ -162,6 +177,46 @@ await store.saveChat({ chatId, messages });`;
           >
             Open dashboard
           </a>
+        </div>
+
+        <!-- Use with your AI agent -->
+        <h2 id="agent-prompt" class="mt-12 mb-1.5 scroll-mt-20 text-[22px] font-semibold tracking-[-0.02em] text-fg">Use with your AI agent</h2>
+        <p class="mt-2 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
+          Copy this prompt into Claude Code, Cursor, or any coding agent. It will discover the API and wire up AgentState for you.
+        </p>
+        <div class="mt-3.5 overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-[#0c0c0e]">
+          <div class="flex h-9 items-center justify-between border-b border-edge-soft px-4">
+            <span class="font-mono text-[11px] text-fg-4">agent-prompt.txt</span>
+            <button
+              type="button"
+              data-copy-text={agentPromptCode}
+              class="inline-flex items-center gap-1.5 rounded-[var(--radius)] px-2 py-0.5 font-mono text-[11px] text-fg-4 transition-colors hover:bg-white/5 hover:text-fg"
+              aria-label="Copy prompt to clipboard"
+            >
+              <span data-copy-label>Copy</span>
+            </button>
+          </div>
+          <pre class="overflow-auto bg-[#0c0c0e] p-4 font-mono text-[12.5px] leading-[1.75] text-zinc-300"><code>{agentPromptCode}</code></pre>
+        </div>
+
+        <!-- Install the skill -->
+        <h3 class="mt-8 mb-1 text-[16px] font-semibold tracking-[-0.01em] text-fg">Install the skill</h3>
+        <p class="mt-1.5 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
+          Install the AgentState skill so your agent always knows how to use the API.
+        </p>
+        <div class="mt-3 overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-[#0c0c0e]">
+          <div class="flex h-9 items-center justify-between border-b border-edge-soft px-4">
+            <span class="font-mono text-[11px] text-fg-4">terminal</span>
+            <button
+              type="button"
+              data-copy-text={installSkillCode}
+              class="inline-flex items-center gap-1.5 rounded-[var(--radius)] px-2 py-0.5 font-mono text-[11px] text-fg-4 transition-colors hover:bg-white/5 hover:text-fg"
+              aria-label="Copy install command to clipboard"
+            >
+              <span data-copy-label>Copy</span>
+            </button>
+          </div>
+          <pre class="overflow-auto bg-[#0c0c0e] p-4 font-mono text-[12.5px] leading-[1.75] text-zinc-300"><code>{installSkillCode}</code></pre>
         </div>
 
         <!-- Quickstart -->
@@ -291,7 +346,7 @@ await store.saveChat({ chatId, messages });`;
     // Scrollspy: mark the section nearest the viewport top as current in both nav and TOC.
     const navLinks = document.querySelectorAll<HTMLAnchorElement>("[data-nav]");
     const tocLinks = document.querySelectorAll<HTMLAnchorElement>("[data-toc]");
-    const sections = ["overview", "quickstart", "auth", "conversations", "ai-sdk", "analytics"]
+    const sections = ["overview", "agent-prompt", "quickstart", "auth", "conversations", "ai-sdk", "analytics"]
       .map((id) => document.getElementById(id))
       .filter((el): el is HTMLElement => el !== null);
 
@@ -321,5 +376,21 @@ await store.saveChat({ chatId, messages });`;
       { rootMargin: "-80px 0px -70% 0px" },
     );
     for (const s of sections) observer.observe(s);
+
+    // Copy-to-clipboard for [data-copy-text] buttons.
+    document.addEventListener("click", (e) => {
+      const btn = (e.target as Element).closest<HTMLElement>("[data-copy-text]");
+      if (!btn) return;
+      const text = btn.getAttribute("data-copy-text") ?? "";
+      const label = btn.querySelector("[data-copy-label]");
+      if (navigator.clipboard?.writeText) {
+        navigator.clipboard.writeText(text).then(() => {
+          if (label) {
+            label.textContent = "Copied";
+            setTimeout(() => { label.textContent = "Copy"; }, 1500);
+          }
+        }).catch(() => {});
+      }
+    });
   </script>
 </MarketingLayout>


### PR DESCRIPTION
Batch of dashboard fixes + the new global project scope.

## Changes
| Area | What |
| ---- | ---- |
| **Delete/retention dialogs** | Removed misused `DialogTrigger` that spawned a phantom "icon + label only" modal. Retention's Change button was nested in a closed Dialog and never rendered — fixed. |
| **Conversations markdown** | Global `/dashboard/conversations` message rows now render markdown via the shared `ui/markdown` (react-markdown + remark-gfm), matching the project Data tab. |
| **Conversations padding** | `px-4 lg:px-6` → `px-5 sm:px-7`, aligned with the breadcrumb header and sidebar. |
| **Projects sort** | Sortable column headers on `/dashboard/` (default: most recently active), `aria-sort` + caret. |
| **Traces "Unauthorized"** | New Clerk-authed, org-scoped routes `GET /api/v1/projects/:id/traces[/:traceId]` (project + trace ownership verified, fails closed). Page rewired off the API-key route. |
| **Global project scope** | New `ProjectScopeProvider` (localStorage-persisted) + a switcher under the sidebar logo — single source of truth for the active project. Conversations / Traces / Analytics read from it; per-page dropdowns removed. |
| **Docs** | Copyable agent-discovery prompt (`/llms.txt`, `/agents.md`, `/openapi.json`) + `npx skills add duyet/agentstate`. |

## Verification
- Dashboard: biome clean; `astro check` clean (only pre-existing `brand.astro` errors remain, untouched).
- API: `tsc` clean, biome clean, **282/282 tests pass**. Traces auth reviewed — no cross-org/cross-project leakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)