### PR TITLE
feat(api): scoped API keys foundation (permissions + enforcement)

### DIFF
--- a/packages/api/drizzle/0007_whole_meggan.sql
+++ b/packages/api/drizzle/0007_whole_meggan.sql
@@ -1,0 +1,48 @@
+CREATE TABLE `oauth_authorization_codes` (
+	`id` text PRIMARY KEY NOT NULL,
+	`code_hash` text NOT NULL,
+	`client_id` text NOT NULL,
+	`project_id` text NOT NULL,
+	`org_id` text,
+	`user_id` text,
+	`scopes` text NOT NULL,
+	`redirect_uri` text NOT NULL,
+	`code_challenge` text NOT NULL,
+	`code_challenge_method` text DEFAULT 'S256' NOT NULL,
+	`resource` text,
+	`expires_at` integer NOT NULL,
+	`consumed_at` integer,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `oauth_authorization_codes_code_hash_idx` ON `oauth_authorization_codes` (`code_hash`);--> statement-breakpoint
+CREATE INDEX `oauth_authorization_codes_expires_at_idx` ON `oauth_authorization_codes` (`expires_at`);--> statement-breakpoint
+CREATE TABLE `oauth_clients` (
+	`id` text PRIMARY KEY NOT NULL,
+	`client_secret_hash` text,
+	`client_name` text NOT NULL,
+	`redirect_uris` text NOT NULL,
+	`grant_types` text DEFAULT '["authorization_code","refresh_token"]' NOT NULL,
+	`token_endpoint_auth_method` text DEFAULT 'none' NOT NULL,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `oauth_clients_created_at_idx` ON `oauth_clients` (`created_at`);--> statement-breakpoint
+CREATE TABLE `oauth_refresh_tokens` (
+	`id` text PRIMARY KEY NOT NULL,
+	`token_hash` text NOT NULL,
+	`client_id` text NOT NULL,
+	`project_id` text NOT NULL,
+	`access_token_id` text,
+	`scopes` text NOT NULL,
+	`expires_at` integer,
+	`rotated_at` integer,
+	`revoked_at` integer,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `oauth_refresh_tokens_token_hash_idx` ON `oauth_refresh_tokens` (`token_hash`);--> statement-breakpoint
+CREATE INDEX `oauth_refresh_tokens_client_id_idx` ON `oauth_refresh_tokens` (`client_id`);--> statement-breakpoint
+ALTER TABLE `api_keys` ADD `scopes` text;

--- a/packages/api/drizzle/meta/0007_snapshot.json
+++ b/packages/api/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,2278 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1f389746-8125-4ee4-800c-0f9f085d61d4",
+  "prevId": "d096b0f1-f648-426c-ac58-d850aeb7053e",
+  "tables": {
+    "agent_states": {
+      "name": "agent_states",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "latest_sequence": {
+          "name": "latest_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_states_project_id_state_key_idx": {
+          "name": "agent_states_project_id_state_key_idx",
+          "columns": [
+            "project_id",
+            "state_key"
+          ],
+          "isUnique": true
+        },
+        "agent_states_project_id_agent_id_idx": {
+          "name": "agent_states_project_id_agent_id_idx",
+          "columns": [
+            "project_id",
+            "agent_id"
+          ],
+          "isUnique": false
+        },
+        "agent_states_project_id_updated_at_idx": {
+          "name": "agent_states_project_id_updated_at_idx",
+          "columns": [
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "agent_states_project_id_latest_sequence_idx": {
+          "name": "agent_states_project_id_latest_sequence_idx",
+          "columns": [
+            "project_id",
+            "latest_sequence"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_states_project_id_projects_id_fk": {
+          "name": "agent_states_project_id_projects_id_fk",
+          "tableFrom": "agent_states",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_idx": {
+          "name": "api_keys_key_hash_idx",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": false
+        },
+        "api_keys_project_id_idx": {
+          "name": "api_keys_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "capability_tokens": {
+      "name": "capability_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "capability_tokens_key_hash_idx": {
+          "name": "capability_tokens_key_hash_idx",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": false
+        },
+        "capability_tokens_project_id_idx": {
+          "name": "capability_tokens_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "capability_tokens_project_id_projects_id_fk": {
+          "name": "capability_tokens_project_id_projects_id_fk",
+          "tableFrom": "capability_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "claim_evidence": {
+      "name": "claim_evidence",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "json_path": {
+          "name": "json_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expected_value": {
+          "name": "expected_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "claim_evidence_project_id_claim_id_idx": {
+          "name": "claim_evidence_project_id_claim_id_idx",
+          "columns": [
+            "project_id",
+            "claim_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "claim_evidence_project_id_projects_id_fk": {
+          "name": "claim_evidence_project_id_projects_id_fk",
+          "tableFrom": "claim_evidence",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claim_evidence_claim_id_claims_id_fk": {
+          "name": "claim_evidence_claim_id_claims_id_fk",
+          "tableFrom": "claim_evidence",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "claim_verification_runs": {
+      "name": "claim_verification_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "claim_verification_runs_project_id_claim_id_idx": {
+          "name": "claim_verification_runs_project_id_claim_id_idx",
+          "columns": [
+            "project_id",
+            "claim_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "claim_verification_runs_project_id_projects_id_fk": {
+          "name": "claim_verification_runs_project_id_projects_id_fk",
+          "tableFrom": "claim_verification_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claim_verification_runs_claim_id_claims_id_fk": {
+          "name": "claim_verification_runs_claim_id_claims_id_fk",
+          "tableFrom": "claim_verification_runs",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "claims": {
+      "name": "claims",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "claims_project_id_created_at_idx": {
+          "name": "claims_project_id_created_at_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "claims_project_id_subject_idx": {
+          "name": "claims_project_id_subject_idx",
+          "columns": [
+            "project_id",
+            "subject_type",
+            "subject_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "claims_project_id_projects_id_fk": {
+          "name": "claims_project_id_projects_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversation_tags": {
+      "name": "conversation_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "conversation_tags_conversation_id_tag_idx": {
+          "name": "conversation_tags_conversation_id_tag_idx",
+          "columns": [
+            "conversation_id",
+            "tag"
+          ],
+          "isUnique": true
+        },
+        "conversation_tags_tag_idx": {
+          "name": "conversation_tags_tag_idx",
+          "columns": [
+            "tag"
+          ],
+          "isUnique": false
+        },
+        "conversation_tags_tag_conversation_id_idx": {
+          "name": "conversation_tags_tag_conversation_id_idx",
+          "columns": [
+            "tag",
+            "conversation_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "conversation_tags_conversation_id_conversations_id_fk": {
+          "name": "conversation_tags_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_tags",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_microdollars": {
+          "name": "total_cost_microdollars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "conversations_project_id_idx": {
+          "name": "conversations_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "conversations_project_id_created_at_idx": {
+          "name": "conversations_project_id_created_at_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "conversations_project_id_external_id_idx": {
+          "name": "conversations_project_id_external_id_idx",
+          "columns": [
+            "project_id",
+            "external_id"
+          ],
+          "isUnique": false
+        },
+        "conversations_project_id_updated_at_idx": {
+          "name": "conversations_project_id_updated_at_idx",
+          "columns": [
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "conversations_project_id_external_id_unique_idx": {
+          "name": "conversations_project_id_external_id_unique_idx",
+          "columns": [
+            "project_id",
+            "external_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "conversations_project_id_projects_id_fk": {
+          "name": "conversations_project_id_projects_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_domains": {
+      "name": "custom_domains",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "custom_domains_domain_unique": {
+          "name": "custom_domains_domain_unique",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": true
+        },
+        "custom_domains_project_id_idx": {
+          "name": "custom_domains_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "custom_domains_verification_status_idx": {
+          "name": "custom_domains_verification_status_idx",
+          "columns": [
+            "verification_status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "custom_domains_project_id_projects_id_fk": {
+          "name": "custom_domains_project_id_projects_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "idempotency_keys": {
+      "name": "idempotency_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idempotency_keys_project_id_key_idx": {
+          "name": "idempotency_keys_project_id_key_idx",
+          "columns": [
+            "project_id",
+            "key"
+          ],
+          "isUnique": true
+        },
+        "idempotency_keys_project_id_created_at_idx": {
+          "name": "idempotency_keys_project_id_created_at_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "idempotency_keys_project_id_projects_id_fk": {
+          "name": "idempotency_keys_project_id_projects_id_fk",
+          "tableFrom": "idempotency_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_microdollars": {
+          "name": "cost_microdollars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "observation_type": {
+          "name": "observation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_idx": {
+          "name": "messages_conversation_id_idx",
+          "columns": [
+            "conversation_id"
+          ],
+          "isUnique": false
+        },
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            "conversation_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "messages_parent_message_id_idx": {
+          "name": "messages_parent_message_id_idx",
+          "columns": [
+            "parent_message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'S256'"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_authorization_codes_code_hash_idx": {
+          "name": "oauth_authorization_codes_code_hash_idx",
+          "columns": [
+            "code_hash"
+          ],
+          "isUnique": true
+        },
+        "oauth_authorization_codes_expires_at_idx": {
+          "name": "oauth_authorization_codes_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_project_id_projects_id_fk": {
+          "name": "oauth_authorization_codes_project_id_projects_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_clients": {
+      "name": "oauth_clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"authorization_code\",\"refresh_token\"]'"
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_clients_created_at_idx": {
+          "name": "oauth_clients_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token_id": {
+          "name": "access_token_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_token_hash_idx": {
+          "name": "oauth_refresh_tokens_token_hash_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "oauth_refresh_tokens_client_id_idx": {
+          "name": "oauth_refresh_tokens_client_id_idx",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_project_id_projects_id_fk": {
+          "name": "oauth_refresh_tokens_project_id_projects_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_clerk_org_id_unique": {
+          "name": "organizations_clerk_org_id_unique",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_org_id_slug_idx": {
+          "name": "projects_org_id_slug_idx",
+          "columns": [
+            "org_id",
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "projects_org_id_organizations_id_fk": {
+          "name": "projects_org_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "projects_retention_days_range_check": {
+          "name": "projects_retention_days_range_check",
+          "value": "\"projects\".\"retention_days\" IS NULL OR (\"projects\".\"retention_days\" BETWEEN 1 AND 3650)"
+        }
+      }
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_key_window_idx": {
+          "name": "rate_limits_key_window_idx",
+          "columns": [
+            "api_key_hash",
+            "window_start"
+          ],
+          "isUnique": true
+        },
+        "rate_limits_window_start_idx": {
+          "name": "rate_limits_window_start_idx",
+          "columns": [
+            "window_start"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "state_events": {
+      "name": "state_events",
+      "columns": {
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "state_events_id_idx": {
+          "name": "state_events_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "state_events_project_id_sequence_idx": {
+          "name": "state_events_project_id_sequence_idx",
+          "columns": [
+            "project_id",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "state_events_project_id_state_key_idx": {
+          "name": "state_events_project_id_state_key_idx",
+          "columns": [
+            "project_id",
+            "state_key"
+          ],
+          "isUnique": false
+        },
+        "state_events_project_id_created_at_idx": {
+          "name": "state_events_project_id_created_at_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "state_events_project_id_projects_id_fk": {
+          "name": "state_events_project_id_projects_id_fk",
+          "tableFrom": "state_events",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "state_leases": {
+      "name": "state_leases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "holder": {
+          "name": "holder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "renewed_at": {
+          "name": "renewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "state_leases_project_id_state_key_idx": {
+          "name": "state_leases_project_id_state_key_idx",
+          "columns": [
+            "project_id",
+            "state_key"
+          ],
+          "isUnique": false
+        },
+        "state_leases_project_id_expires_at_idx": {
+          "name": "state_leases_project_id_expires_at_idx",
+          "columns": [
+            "project_id",
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "state_leases_project_id_projects_id_fk": {
+          "name": "state_leases_project_id_projects_id_fk",
+          "tableFrom": "state_leases",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "state_snapshots": {
+      "name": "state_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "state_snapshots_project_id_state_key_sequence_idx": {
+          "name": "state_snapshots_project_id_state_key_sequence_idx",
+          "columns": [
+            "project_id",
+            "state_key",
+            "sequence"
+          ],
+          "isUnique": true
+        },
+        "state_snapshots_project_id_sequence_idx": {
+          "name": "state_snapshots_project_id_sequence_idx",
+          "columns": [
+            "project_id",
+            "sequence"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "state_snapshots_project_id_projects_id_fk": {
+          "name": "state_snapshots_project_id_projects_id_fk",
+          "tableFrom": "state_snapshots",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "state_tags": {
+      "name": "state_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "state_tags_project_id_state_key_tag_idx": {
+          "name": "state_tags_project_id_state_key_tag_idx",
+          "columns": [
+            "project_id",
+            "state_key",
+            "tag"
+          ],
+          "isUnique": true
+        },
+        "state_tags_project_id_tag_idx": {
+          "name": "state_tags_project_id_tag_idx",
+          "columns": [
+            "project_id",
+            "tag"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "state_tags_project_id_projects_id_fk": {
+          "name": "state_tags_project_id_projects_id_fk",
+          "tableFrom": "state_tags",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhooks": {
+      "name": "webhooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhooks_project_id_idx": {
+          "name": "webhooks_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "webhooks_project_id_active_idx": {
+          "name": "webhooks_project_id_active_idx",
+          "columns": [
+            "project_id",
+            "active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webhooks_project_id_projects_id_fk": {
+          "name": "webhooks_project_id_projects_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1780918260609,
       "tag": "0006_free_mantis",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1781779218292,
+      "tag": "0007_whole_meggan",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -59,6 +59,8 @@ export const apiKeys = sqliteTable(
     name: text("name").notNull(),
     keyPrefix: text("key_prefix").notNull(),
     keyHash: text("key_hash").notNull(),
+    // JSON array of permission scopes. NULL = full access (legacy / unscoped keys).
+    scopes: text("scopes"),
     lastUsedAt: integer("last_used_at"),
     createdAt: integer("created_at").notNull(),
     revokedAt: integer("revoked_at"),
@@ -542,6 +544,96 @@ export const claimVerificationRuns = sqliteTable(
 );
 
 // ---------------------------------------------------------------------------
+// oauth_clients
+// ---------------------------------------------------------------------------
+//
+// OAuth 2.1 clients registered via Dynamic Client Registration (RFC 7591) so
+// MCP clients (Claude, Cursor, …) can connect without manual setup.
+
+export const oauthClients = sqliteTable(
+  "oauth_clients",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => nanoid()), // serves as client_id
+    // SHA-256 of client_secret for confidential clients; NULL for public clients.
+    clientSecretHash: text("client_secret_hash"),
+    clientName: text("client_name").notNull(),
+    redirectUris: text("redirect_uris").notNull(), // JSON array of exact-match URIs
+    grantTypes: text("grant_types").notNull().default('["authorization_code","refresh_token"]'),
+    tokenEndpointAuthMethod: text("token_endpoint_auth_method").notNull().default("none"),
+    createdAt: integer("created_at").notNull(),
+  },
+  (table) => [index("oauth_clients_created_at_idx").on(table.createdAt)],
+);
+
+// ---------------------------------------------------------------------------
+// oauth_authorization_codes
+// ---------------------------------------------------------------------------
+//
+// Short-lived, single-use authorization codes (PKCE S256). Bound to client,
+// redirect URI, project, granting user, scopes, and resource.
+
+export const oauthAuthorizationCodes = sqliteTable(
+  "oauth_authorization_codes",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => nanoid()),
+    codeHash: text("code_hash").notNull(), // SHA-256 of the issued code
+    clientId: text("client_id").notNull(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    orgId: text("org_id"),
+    userId: text("user_id"), // Clerk user id that granted consent
+    scopes: text("scopes").notNull(), // JSON array
+    redirectUri: text("redirect_uri").notNull(),
+    codeChallenge: text("code_challenge").notNull(),
+    codeChallengeMethod: text("code_challenge_method").notNull().default("S256"),
+    resource: text("resource"),
+    expiresAt: integer("expires_at").notNull(),
+    consumedAt: integer("consumed_at"),
+    createdAt: integer("created_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("oauth_authorization_codes_code_hash_idx").on(table.codeHash),
+    index("oauth_authorization_codes_expires_at_idx").on(table.expiresAt),
+  ],
+);
+
+// ---------------------------------------------------------------------------
+// oauth_refresh_tokens
+// ---------------------------------------------------------------------------
+//
+// Rotating refresh tokens (OAuth 2.1 requires rotation for public clients).
+// The companion access token is stored as a capability_tokens row.
+
+export const oauthRefreshTokens = sqliteTable(
+  "oauth_refresh_tokens",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => nanoid()),
+    tokenHash: text("token_hash").notNull(), // SHA-256 of the issued refresh token
+    clientId: text("client_id").notNull(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    accessTokenId: text("access_token_id"), // -> capability_tokens.id
+    scopes: text("scopes").notNull(), // JSON array
+    expiresAt: integer("expires_at"),
+    rotatedAt: integer("rotated_at"), // set when this token is rotated out
+    revokedAt: integer("revoked_at"),
+    createdAt: integer("created_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("oauth_refresh_tokens_token_hash_idx").on(table.tokenHash),
+    index("oauth_refresh_tokens_client_id_idx").on(table.clientId),
+  ],
+);
+
+// ---------------------------------------------------------------------------
 // Select types (rows returned from DB)
 // ---------------------------------------------------------------------------
 
@@ -564,6 +656,9 @@ export type StateLease = InferSelectModel<typeof stateLeases>;
 export type Claim = InferSelectModel<typeof claims>;
 export type ClaimEvidence = InferSelectModel<typeof claimEvidence>;
 export type ClaimVerificationRun = InferSelectModel<typeof claimVerificationRuns>;
+export type OAuthClient = InferSelectModel<typeof oauthClients>;
+export type OAuthAuthorizationCode = InferSelectModel<typeof oauthAuthorizationCodes>;
+export type OAuthRefreshToken = InferSelectModel<typeof oauthRefreshTokens>;
 
 // ---------------------------------------------------------------------------
 // Insert types (rows passed to .insert())
@@ -588,3 +683,6 @@ export type NewStateLease = InferInsertModel<typeof stateLeases>;
 export type NewClaim = InferInsertModel<typeof claims>;
 export type NewClaimEvidence = InferInsertModel<typeof claimEvidence>;
 export type NewClaimVerificationRun = InferInsertModel<typeof claimVerificationRuns>;
+export type NewOAuthClient = InferInsertModel<typeof oauthClients>;
+export type NewOAuthAuthorizationCode = InferInsertModel<typeof oauthAuthorizationCodes>;
+export type NewOAuthRefreshToken = InferInsertModel<typeof oauthRefreshTokens>;

--- a/packages/api/src/lib/api-key.ts
+++ b/packages/api/src/lib/api-key.ts
@@ -7,7 +7,7 @@ import { generateApiKey, generateId } from "./id";
  * @returns Object containing the key ID, raw key (for one-time display to user),
  *          database insert values, and convenience fields (prefix, timestamp).
  */
-export async function buildApiKey(projectId: string, name: string) {
+export async function buildApiKey(projectId: string, name: string, scopes?: string[]) {
   const rawKey = generateApiKey();
   const hash = await hashApiKey(rawKey);
   const prefix = rawKey.substring(0, 12);
@@ -23,6 +23,8 @@ export async function buildApiKey(projectId: string, name: string) {
       name,
       keyPrefix: prefix,
       keyHash: hash,
+      // null = full access (legacy/unscoped); a non-empty list = restricted key.
+      scopes: scopes && scopes.length > 0 ? JSON.stringify(scopes) : null,
       createdAt: now,
     },
     prefix,

--- a/packages/api/src/lib/scopes.ts
+++ b/packages/api/src/lib/scopes.ts
@@ -1,0 +1,101 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// API key / OAuth permission scopes
+// ---------------------------------------------------------------------------
+//
+// Canonical resource:action permission set shared by API keys and OAuth-issued
+// access tokens. Regular `as_live_` keys created before scopes existed (and any
+// key created without an explicit scope list) are treated as full access via the
+// `*` wildcard, so enforcement is backward-compatible.
+//
+// The existing capability-token scopes (state:*, lease:write, claim:write) are a
+// subset of this set, so capability tokens keep working unchanged.
+
+/** Concrete, grantable scopes. */
+export const API_SCOPES = [
+  "conversations:read",
+  "conversations:write",
+  "state:read",
+  "state:write",
+  "state:watch",
+  "leases:write",
+  "claims:write",
+  "analytics:read",
+  "webhooks:write",
+  "domains:write",
+  "keys:read",
+  "keys:write",
+] as const;
+
+export type ApiScope = (typeof API_SCOPES)[number];
+
+/** Wildcard granting every scope. */
+export const WILDCARD_SCOPE = "*";
+
+/** Full-access scope set applied to legacy / unscoped keys. */
+export const FULL_ACCESS: readonly string[] = [WILDCARD_SCOPE];
+
+/** Distinct resource prefixes (e.g. "state", "conversations") for resource wildcards. */
+const RESOURCES = Array.from(new Set(API_SCOPES.map((s) => s.split(":")[0])));
+
+const RESOURCE_WILDCARD = /^([a-z]+):\*$/;
+
+/**
+ * Is `scope` something a user may grant? Accepts a concrete scope, the global
+ * wildcard `*`, or a per-resource wildcard like `state:*`.
+ */
+export function isGrantableScope(scope: string): boolean {
+  if (scope === WILDCARD_SCOPE) return true;
+  if ((API_SCOPES as readonly string[]).includes(scope)) return true;
+  const match = RESOURCE_WILDCARD.exec(scope);
+  return match !== null && RESOURCES.includes(match[1]);
+}
+
+/** Zod schema for a single grantable scope string. */
+export const GrantableScopeSchema = z.string().refine(isGrantableScope, {
+  message: `invalid scope; allowed: "${WILDCARD_SCOPE}", ${API_SCOPES.join(", ")}, or <resource>:*`,
+});
+
+/**
+ * Does the granted scope set satisfy a single required scope?
+ * Honors the global `*` wildcard and per-resource `resource:*` wildcards.
+ */
+export function scopeSatisfies(granted: readonly string[], required: string): boolean {
+  if (granted.includes(WILDCARD_SCOPE)) return true;
+  if (granted.includes(required)) return true;
+  const resource = required.split(":")[0];
+  return granted.includes(`${resource}:*`);
+}
+
+/**
+ * Are ALL required scopes satisfied by the granted set? Used for delegation:
+ * a key may only mint a child key whose scopes are a subset of its own.
+ */
+export function scopesSatisfyAll(granted: readonly string[], required: readonly string[]): boolean {
+  return required.every((scope) => scopeSatisfies(granted, scope));
+}
+
+/**
+ * Parse a JSON-encoded scopes column into a string array.
+ * Returns [] for null/invalid input (callers treat [] as full access).
+ */
+export function parseScopesJson(value: string | null | undefined): string[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((s): s is string => typeof s === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Resolve the effective scope set for an API key row. A null/absent column means
+ * a legacy or unscoped key → full access. An explicit list is honored as-is
+ * (an explicit empty list grants nothing — it never silently becomes full access).
+ */
+export function effectiveKeyScopes(scopesColumn: string | null | undefined): string[] {
+  if (scopesColumn == null) return [...FULL_ACCESS];
+  return parseScopesJson(scopesColumn);
+}

--- a/packages/api/src/lib/validation.ts
+++ b/packages/api/src/lib/validation.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { GrantableScopeSchema } from "./scopes";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -107,6 +108,12 @@ export type AddTagsInput = z.infer<typeof AddTagsSchema>;
 
 export const CreateApiKeySchema = z.object({
   name: z.string().min(1, "name is required").max(255),
+  /**
+   * Optional permission scopes for the new key. Omit for a full-access key
+   * (back-compat). When creating via another key (API / MCP), each requested
+   * scope must be a subset of the caller's own scopes — enforced in the route.
+   */
+  scopes: z.array(GrantableScopeSchema).min(1, "at least one scope is required").max(64).optional(),
 });
 export type CreateApiKeyInput = z.infer<typeof CreateApiKeySchema>;
 

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -3,6 +3,7 @@ import { createMiddleware } from "hono/factory";
 import { apiKeys } from "../db/schema";
 import { hashApiKey } from "../lib/crypto";
 import { errorResponse } from "../lib/helpers";
+import { effectiveKeyScopes, FULL_ACCESS } from "../lib/scopes";
 import type { Bindings, Variables } from "../types";
 
 /**
@@ -20,6 +21,31 @@ const authFailure = async (c: any, startedAt: number): Promise<Response> => {
   return errorResponse(c, "UNAUTHORIZED", "Unauthorized", 401);
 };
 
+/**
+ * Parse a cached auth entry. Current entries are JSON `{ projectId, scopes }`.
+ * Legacy entries are a bare projectId string and are treated as full access.
+ */
+function parseCacheValue(raw: string): { projectId: string; scopes: string[] } {
+  try {
+    const obj = JSON.parse(raw);
+    if (
+      obj &&
+      typeof obj === "object" &&
+      typeof obj.projectId === "string" &&
+      Array.isArray(obj.scopes)
+    ) {
+      // Honor the cached scope list exactly (an empty list grants nothing).
+      return {
+        projectId: obj.projectId,
+        scopes: obj.scopes.filter((s: unknown): s is string => typeof s === "string"),
+      };
+    }
+  } catch {
+    // Not JSON — a legacy plain-string projectId entry (full access).
+  }
+  return { projectId: raw, scopes: [...FULL_ACCESS] };
+}
+
 export const apiKeyAuth = createMiddleware<{ Bindings: Bindings; Variables: Variables }>(
   async (c, next) => {
     const startedAt = performance.now();
@@ -34,15 +60,14 @@ export const apiKeyAuth = createMiddleware<{ Bindings: Bindings; Variables: Vari
     // Try KV cache first if available
     if (key && c.env.AUTH_CACHE) {
       const cacheKey = `auth:hash:${hash}`;
-      const cachedProjectId = await c.env.AUTH_CACHE.get(cacheKey, "text");
-      if (cachedProjectId) {
-        c.set("projectId", cachedProjectId);
+      const cached = await c.env.AUTH_CACHE.get(cacheKey, "text");
+      if (cached) {
+        const { projectId, scopes } = parseCacheValue(cached);
+        c.set("projectId", projectId);
         c.set("apiKeyHash", hash);
         c.set("authType", "api_key");
-        c.set("capabilityScopes", []);
+        c.set("capabilityScopes", scopes);
 
-        // Fire-and-forget last_used_at update — do not await to avoid blocking
-        // We don't have the apiKey.id here, but the cache hit means the key is valid
         // Skip the DB update for cache hits to avoid the query
         await next();
         return;
@@ -51,7 +76,12 @@ export const apiKeyAuth = createMiddleware<{ Bindings: Bindings; Variables: Vari
 
     // Cache miss or cache unavailable — query DB
     const [apiKey] = await db
-      .select({ id: apiKeys.id, projectId: apiKeys.projectId, revokedAt: apiKeys.revokedAt })
+      .select({
+        id: apiKeys.id,
+        projectId: apiKeys.projectId,
+        revokedAt: apiKeys.revokedAt,
+        scopes: apiKeys.scopes,
+      })
       .from(apiKeys)
       .where(and(eq(apiKeys.keyHash, hash), isNull(apiKeys.revokedAt)))
       .limit(1);
@@ -60,23 +90,27 @@ export const apiKeyAuth = createMiddleware<{ Bindings: Bindings; Variables: Vari
       return authFailure(c, startedAt);
     }
 
-    // Populate KV cache for next request (5 minute TTL = 300 seconds).
-    // NOTE: the cache-hit path above authorizes WITHOUT a DB check, so a
-    // revoked key would remain valid until its entry expires. Revoke paths
-    // (routes/keys.ts, routes/projects.ts) therefore
-    // delete the `auth:hash:${hash}` entry on revoke to close that window.
+    // Resolve effective scopes: explicit list, else full access (legacy keys).
+    const scopes = effectiveKeyScopes(apiKey.scopes);
+
+    // Populate KV cache for next request (5 minute TTL = 300 seconds). The value
+    // carries projectId + scopes so the cache-hit path can authorize AND enforce
+    // scopes without a DB check.
+    // NOTE: the cache-hit path above authorizes WITHOUT a DB check, so a revoked
+    // key would remain valid until its entry expires. Revoke paths
+    // (routes/keys.ts, routes/projects.ts) delete the `auth:hash:${hash}` entry
+    // on revoke to close that window.
     if (c.env.AUTH_CACHE) {
       const cacheKey = `auth:hash:${hash}`;
+      const cacheValue = JSON.stringify({ projectId: apiKey.projectId, scopes });
       // Fire-and-forget cache write — don't block the request
-      c.executionCtx.waitUntil(
-        c.env.AUTH_CACHE.put(cacheKey, apiKey.projectId, { expirationTtl: 300 }),
-      );
+      c.executionCtx.waitUntil(c.env.AUTH_CACHE.put(cacheKey, cacheValue, { expirationTtl: 300 }));
     }
 
     c.set("projectId", apiKey.projectId);
     c.set("apiKeyHash", hash);
     c.set("authType", "api_key");
-    c.set("capabilityScopes", []);
+    c.set("capabilityScopes", scopes);
 
     // Fire-and-forget last_used_at update — do not await to avoid blocking
     c.executionCtx.waitUntil(

--- a/packages/api/src/middleware/require-scope.ts
+++ b/packages/api/src/middleware/require-scope.ts
@@ -1,0 +1,22 @@
+import { createMiddleware } from "hono/factory";
+import { errorResponse } from "../lib/helpers";
+import { scopeSatisfies } from "../lib/scopes";
+import type { Bindings, Variables } from "../types";
+
+/**
+ * Enforce that the authenticated credential (API key or capability/OAuth token)
+ * holds the required scope. Must run AFTER an auth middleware that sets
+ * `capabilityScopes` on the context (apiKeyAuth / scopedAuth).
+ *
+ * Legacy / unscoped keys resolve to the `*` wildcard upstream, so they satisfy
+ * every scope and remain backward-compatible.
+ */
+export function requireScope(scope: string) {
+  return createMiddleware<{ Bindings: Bindings; Variables: Variables }>(async (c, next) => {
+    const granted = c.get("capabilityScopes") ?? [];
+    if (!scopeSatisfies(granted, scope)) {
+      return errorResponse(c, "FORBIDDEN", `Missing required scope: ${scope}`, 403);
+    }
+    await next();
+  });
+}

--- a/packages/api/src/middleware/scoped-auth.ts
+++ b/packages/api/src/middleware/scoped-auth.ts
@@ -3,6 +3,7 @@ import { createMiddleware } from "hono/factory";
 import { apiKeys, capabilityTokens } from "../db/schema";
 import { hashApiKey } from "../lib/crypto";
 import { errorResponse } from "../lib/helpers";
+import { effectiveKeyScopes, parseScopesJson, scopeSatisfies } from "../lib/scopes";
 import type { Bindings, Variables } from "../types";
 
 const AUTH_FAILURE_MIN_MS = 300;
@@ -16,15 +17,6 @@ async function authFailure(c: any, startedAt: number): Promise<Response> {
   const remainingMs = Math.max(0, AUTH_FAILURE_MIN_MS - (performance.now() - startedAt));
   await new Promise((resolve) => setTimeout(resolve, remainingMs));
   return errorResponse(c, "UNAUTHORIZED", "Unauthorized", 401);
-}
-
-function parseScopes(value: string): string[] {
-  try {
-    const scopes = JSON.parse(value);
-    return Array.isArray(scopes) ? scopes.filter((scope) => typeof scope === "string") : [];
-  } catch {
-    return [];
-  }
 }
 
 export function scopedAuth(options: ScopedAuthOptions) {
@@ -65,8 +57,8 @@ export function scopedAuth(options: ScopedAuthOptions) {
 
       if (!token) return authFailure(c, startedAt);
 
-      const scopes = parseScopes(token.scopes);
-      if (!scopes.includes(options.scope)) {
+      const scopes = parseScopesJson(token.scopes);
+      if (!scopeSatisfies(scopes, options.scope)) {
         return errorResponse(c, "FORBIDDEN", "Capability token does not have required scope", 403);
       }
 
@@ -87,17 +79,24 @@ export function scopedAuth(options: ScopedAuthOptions) {
     if (queryToken) return authFailure(c, startedAt);
 
     const [apiKey] = await db
-      .select({ id: apiKeys.id, projectId: apiKeys.projectId })
+      .select({ id: apiKeys.id, projectId: apiKeys.projectId, scopes: apiKeys.scopes })
       .from(apiKeys)
       .where(and(eq(apiKeys.keyHash, hash), isNull(apiKeys.revokedAt)))
       .limit(1);
 
     if (!apiKey) return authFailure(c, startedAt);
 
+    // Regular API keys are scope-checked too: legacy/unscoped keys resolve to the
+    // `*` wildcard and satisfy every scope, preserving backward compatibility.
+    const scopes = effectiveKeyScopes(apiKey.scopes);
+    if (!scopeSatisfies(scopes, options.scope)) {
+      return errorResponse(c, "FORBIDDEN", `Missing required scope: ${options.scope}`, 403);
+    }
+
     c.set("projectId", apiKey.projectId);
     c.set("apiKeyHash", hash);
     c.set("authType", "api_key");
-    c.set("capabilityScopes", []);
+    c.set("capabilityScopes", scopes);
     c.executionCtx.waitUntil(
       db.update(apiKeys).set({ lastUsedAt: Date.now() }).where(eq(apiKeys.id, apiKey.id)),
     );

--- a/packages/api/src/routes/ai.ts
+++ b/packages/api/src/routes/ai.ts
@@ -4,6 +4,7 @@ import { conversations, messages } from "../db/schema";
 import { loadConversation, notFound } from "../lib/helpers";
 import { apiKeyAuth } from "../middleware/auth";
 import { rateLimitMiddleware } from "../middleware/rate-limit";
+import { requireScope } from "../middleware/require-scope";
 import { generateFollowUps, generateTitle, generateTitleAndFollowUps } from "../services/ai";
 import type { Bindings, Variables } from "../types";
 
@@ -13,7 +14,7 @@ router.use("*", apiKeyAuth);
 router.use("*", rateLimitMiddleware);
 
 // POST /:id/generate-title — first 20 messages are enough for title context
-router.post("/:id/generate-title", async (c) => {
+router.post("/:id/generate-title", requireScope("conversations:write"), async (c) => {
   const db = c.get("db");
   const id = c.req.param("id");
   const conversation = await loadConversation(c, id);
@@ -41,7 +42,7 @@ router.post("/:id/generate-title", async (c) => {
 });
 
 // POST /:id/follow-ups — last 20 messages are most relevant for suggestions
-router.post("/:id/follow-ups", async (c) => {
+router.post("/:id/follow-ups", requireScope("conversations:write"), async (c) => {
   const db = c.get("db");
   const id = c.req.param("id");
   const conversation = await loadConversation(c, id);
@@ -67,7 +68,7 @@ router.post("/:id/follow-ups", async (c) => {
 });
 
 // POST /:id/generate-all — batch generate title and follow-ups in one call
-router.post("/:id/generate-all", async (c) => {
+router.post("/:id/generate-all", requireScope("conversations:write"), async (c) => {
   const db = c.get("db");
   const id = c.req.param("id");
   const conversation = await loadConversation(c, id);

--- a/packages/api/src/routes/conversations/analytics.ts
+++ b/packages/api/src/routes/conversations/analytics.ts
@@ -2,6 +2,7 @@ import { eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { conversationTags, messages } from "../../db/schema";
 import { loadConversation, notFound } from "../../lib/helpers";
+import { requireScope } from "../../middleware/require-scope";
 import type { Bindings, Variables } from "../../types";
 
 const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
@@ -10,7 +11,7 @@ const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 // GET /:id/analytics — Conversation-level analytics
 // ---------------------------------------------------------------------------
 
-app.get("/:id/analytics", async (c) => {
+app.get("/:id/analytics", requireScope("analytics:read"), async (c) => {
   const id = c.req.param("id");
   const db = c.get("db");
 

--- a/packages/api/src/routes/conversations/bulk.ts
+++ b/packages/api/src/routes/conversations/bulk.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { parseAndValidateBody } from "../../lib/helpers";
 import { BulkDeleteSchema, ExportSchema } from "../../lib/validation";
+import { requireScope } from "../../middleware/require-scope";
 import * as bulkService from "../../services/bulk";
 import type { Bindings, Variables } from "../../types";
 
@@ -10,7 +11,7 @@ const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 // POST /bulk-delete — Delete multiple conversations at once
 // ---------------------------------------------------------------------------
 
-router.post("/bulk-delete", async (c) => {
+router.post("/bulk-delete", requireScope("conversations:write"), async (c) => {
   const { data, error } = await parseAndValidateBody(c, BulkDeleteSchema);
   if (error) return error;
 
@@ -25,7 +26,7 @@ router.post("/bulk-delete", async (c) => {
 // POST /export — Bulk export conversations with messages
 // ---------------------------------------------------------------------------
 
-router.post("/export", async (c) => {
+router.post("/export", requireScope("conversations:read"), async (c) => {
   const { data, error } = await parseAndValidateBody(c, ExportSchema);
   if (error) return error;
 

--- a/packages/api/src/routes/conversations/crud.ts
+++ b/packages/api/src/routes/conversations/crud.ts
@@ -11,6 +11,7 @@ import {
 } from "../../lib/helpers";
 import { deserializeConversationFull, deserializeMessage } from "../../lib/serialization";
 import { CreateConversationSchema, UpdateConversationSchema } from "../../lib/validation";
+import { requireScope } from "../../middleware/require-scope";
 import * as ConversationService from "../../services/conversations";
 import type { Bindings, Variables } from "../../types";
 
@@ -20,7 +21,7 @@ const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 // POST / — Create conversation
 // ---------------------------------------------------------------------------
 
-router.post("/", async (c) => {
+router.post("/", requireScope("conversations:write"), async (c) => {
   const { body, error } = await parseJsonBody(c);
   if (error) return error;
 
@@ -72,7 +73,7 @@ router.post("/", async (c) => {
 // GET / — List conversations
 // ---------------------------------------------------------------------------
 
-router.get("/", async (c) => {
+router.get("/", requireScope("conversations:read"), async (c) => {
   const db = c.get("db");
   const projectId = c.get("projectId");
 
@@ -106,7 +107,7 @@ router.get("/", async (c) => {
 // GET /:id — Get conversation with messages
 // ---------------------------------------------------------------------------
 
-router.get("/:id", async (c) => {
+router.get("/:id", requireScope("conversations:read"), async (c) => {
   const id = c.req.param("id");
   const conversation = await loadConversation(c, id);
   if (!conversation) return notFound(c);
@@ -145,7 +146,7 @@ router.get("/:id", async (c) => {
 // PUT /:id — Update conversation
 // ---------------------------------------------------------------------------
 
-router.put("/:id", async (c) => {
+router.put("/:id", requireScope("conversations:write"), async (c) => {
   const { body, error } = await parseJsonBody(c);
   if (error) return error;
 
@@ -181,7 +182,7 @@ router.put("/:id", async (c) => {
 // DELETE /:id — Delete conversation
 // ---------------------------------------------------------------------------
 
-router.delete("/:id", async (c) => {
+router.delete("/:id", requireScope("conversations:write"), async (c) => {
   const id = c.req.param("id");
   const existing = await loadConversation(c, id);
   if (!existing) return notFound(c);

--- a/packages/api/src/routes/conversations/messages.ts
+++ b/packages/api/src/routes/conversations/messages.ts
@@ -10,6 +10,7 @@ import {
 } from "../../lib/helpers";
 import { deserializeMessage } from "../../lib/serialization";
 import { AppendMessagesSchema } from "../../lib/validation";
+import { requireScope } from "../../middleware/require-scope";
 import { appendMessages } from "../../services/messages";
 import type { Bindings, Variables } from "../../types";
 
@@ -19,7 +20,7 @@ const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 // POST /:id/messages — Append messages
 // ---------------------------------------------------------------------------
 
-router.post("/:id/messages", async (c) => {
+router.post("/:id/messages", requireScope("conversations:write"), async (c) => {
   const { body, error } = await parseJsonBody(c);
   if (error) return error;
 
@@ -44,7 +45,7 @@ router.post("/:id/messages", async (c) => {
 // GET /:id/messages — List messages
 // ---------------------------------------------------------------------------
 
-router.get("/:id/messages", async (c) => {
+router.get("/:id/messages", requireScope("conversations:read"), async (c) => {
   const id = c.req.param("id");
   const existing = await loadConversation(c, id);
   if (!existing) return notFound(c);

--- a/packages/api/src/routes/conversations/search.ts
+++ b/packages/api/src/routes/conversations/search.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { conversations, messages } from "../../db/schema";
 import { errorResponse, notFound, parseLimitParam } from "../../lib/helpers";
 import { deserializeConversationFull, deserializeMessage } from "../../lib/serialization";
+import { requireScope } from "../../middleware/require-scope";
 import { searchConversations } from "../../services/conversation-search";
 import type { Bindings, Variables } from "../../types";
 
@@ -12,7 +13,7 @@ const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 // GET /search — Search conversations by message content
 // ---------------------------------------------------------------------------
 
-router.get("/search", async (c) => {
+router.get("/search", requireScope("conversations:read"), async (c) => {
   const db = c.get("db");
   const projectId = c.get("projectId");
 
@@ -67,7 +68,7 @@ router.get("/search", async (c) => {
 // GET /by-external-id/:externalId — Lookup by caller-provided ID
 // ---------------------------------------------------------------------------
 
-router.get("/by-external-id/:externalId", async (c) => {
+router.get("/by-external-id/:externalId", requireScope("conversations:read"), async (c) => {
   const db = c.get("db");
   const projectId = c.get("projectId");
   const externalId = c.req.param("externalId");

--- a/packages/api/src/routes/conversations/traces.ts
+++ b/packages/api/src/routes/conversations/traces.ts
@@ -9,6 +9,7 @@ import {
 } from "../../lib/helpers";
 import { deserializeConversationFull, deserializeMessage } from "../../lib/serialization";
 import { IngestTraceSchema } from "../../lib/validation";
+import { requireScope } from "../../middleware/require-scope";
 import * as tracesService from "../../services/traces";
 import type { Bindings, Variables } from "../../types";
 
@@ -18,7 +19,7 @@ const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 // POST /traces/ingest — Batch create trace + observations
 // ---------------------------------------------------------------------------
 
-router.post("/traces/ingest", async (c) => {
+router.post("/traces/ingest", requireScope("conversations:write"), async (c) => {
   const { body, error } = await parseJsonBody(c);
   if (error) return error;
 
@@ -45,7 +46,7 @@ router.post("/traces/ingest", async (c) => {
 // GET /traces — List traces
 // ---------------------------------------------------------------------------
 
-router.get("/traces", async (c) => {
+router.get("/traces", requireScope("conversations:read"), async (c) => {
   const db = c.get("db");
   const projectId = c.get("projectId");
 
@@ -66,7 +67,7 @@ router.get("/traces", async (c) => {
 // GET /traces/:id — Get trace with observation tree
 // ---------------------------------------------------------------------------
 
-router.get("/traces/:id", async (c) => {
+router.get("/traces/:id", requireScope("conversations:read"), async (c) => {
   const id = c.req.param("id");
   const existing = await loadConversation(c, id);
   if (!existing) return notFound(c, "Trace not found");

--- a/packages/api/src/routes/keys.ts
+++ b/packages/api/src/routes/keys.ts
@@ -1,14 +1,17 @@
 import { Hono } from "hono";
 import {
+  errorResponse,
   invalidateAuthCacheEntries,
   notFound,
   parseJsonBody,
   requireSameProject,
   validationError,
 } from "../lib/helpers";
+import { scopesSatisfyAll } from "../lib/scopes";
 import { CreateApiKeySchema } from "../lib/validation";
 import { apiKeyAuth } from "../middleware/auth";
 import { rateLimitMiddleware } from "../middleware/rate-limit";
+import { requireScope } from "../middleware/require-scope";
 import * as keysService from "../services/keys";
 import type { Bindings, Variables } from "../types";
 
@@ -23,7 +26,7 @@ app.use("*", rateLimitMiddleware);
 // POST /:projectId/keys — Create API key
 // ---------------------------------------------------------------------------
 
-app.post("/:projectId/keys", async (c) => {
+app.post("/:projectId/keys", requireScope("keys:write"), async (c) => {
   const db = c.get("db");
   const projectId = c.req.param("projectId");
 
@@ -38,7 +41,28 @@ app.post("/:projectId/keys", async (c) => {
     return validationError(c, parsed.error);
   }
 
-  const apiKey = await keysService.createApiKey(db, projectId, parsed.data.name);
+  // Delegation rule: a key may only mint a child key whose scopes are a subset
+  // of its own. An explicit request is validated against the caller's scopes.
+  // When `scopes` is OMITTED, a restricted caller's child INHERITS the caller's
+  // scopes — it must never silently escalate to full access. A full-access (`*`)
+  // caller leaves scopes unset, producing a full-access child (historical default).
+  const callerScopes = c.get("capabilityScopes") ?? [];
+  const callerHasFullAccess = callerScopes.includes("*");
+  let childScopes = parsed.data.scopes;
+  if (childScopes) {
+    if (!scopesSatisfyAll(callerScopes, childScopes)) {
+      return errorResponse(
+        c,
+        "FORBIDDEN",
+        "Cannot grant scopes beyond the calling key's own scopes",
+        403,
+      );
+    }
+  } else if (!callerHasFullAccess) {
+    childScopes = callerScopes;
+  }
+
+  const apiKey = await keysService.createApiKey(db, projectId, parsed.data.name, childScopes);
 
   return c.json(
     {
@@ -46,6 +70,7 @@ app.post("/:projectId/keys", async (c) => {
       name: apiKey.name,
       key_prefix: apiKey.key_prefix,
       key: apiKey.key,
+      scopes: apiKey.scopes,
       created_at: apiKey.created_at,
       last_used_at: apiKey.last_used_at,
       revoked_at: apiKey.revoked_at,
@@ -58,7 +83,7 @@ app.post("/:projectId/keys", async (c) => {
 // GET /:projectId/keys — List API keys
 // ---------------------------------------------------------------------------
 
-app.get("/:projectId/keys", async (c) => {
+app.get("/:projectId/keys", requireScope("keys:read"), async (c) => {
   const db = c.get("db");
   const projectId = c.req.param("projectId");
 
@@ -72,6 +97,7 @@ app.get("/:projectId/keys", async (c) => {
       id: k.id,
       name: k.name,
       key_prefix: k.key_prefix,
+      scopes: k.scopes,
       created_at: k.created_at,
       last_used_at: k.last_used_at,
       revoked_at: k.revoked_at,
@@ -83,7 +109,7 @@ app.get("/:projectId/keys", async (c) => {
 // DELETE /:projectId/keys/:keyId — Revoke API key
 // ---------------------------------------------------------------------------
 
-app.delete("/:projectId/keys/:keyId", async (c) => {
+app.delete("/:projectId/keys/:keyId", requireScope("keys:write"), async (c) => {
   const db = c.get("db");
   const projectId = c.req.param("projectId");
   const keyId = c.req.param("keyId");

--- a/packages/api/src/routes/projects.ts
+++ b/packages/api/src/routes/projects.ts
@@ -236,7 +236,9 @@ app.post("/:id/keys", async (c) => {
   }
 
   try {
-    const result = await createApiKeyService(db, projectId, parsed.data.name);
+    // Dashboard key creation is authenticated by a verified Clerk session
+    // (org owner), so any scopes may be granted — no subset restriction here.
+    const result = await createApiKeyService(db, projectId, parsed.data.name, parsed.data.scopes);
     return c.json(result, 201);
   } catch (err) {
     if (err instanceof Error && err.message === "Project not found") {

--- a/packages/api/src/routes/tags.ts
+++ b/packages/api/src/routes/tags.ts
@@ -3,6 +3,7 @@ import { errorResponse, parseJsonBody, validationError } from "../lib/helpers";
 import { AddTagsSchema } from "../lib/validation";
 import { apiKeyAuth } from "../middleware/auth";
 import { rateLimitMiddleware } from "../middleware/rate-limit";
+import { requireScope } from "../middleware/require-scope";
 import {
   addTagsToConversation,
   conversationBelongsToProject,
@@ -25,7 +26,7 @@ router.use("*", rateLimitMiddleware);
 // GET /tags — List all unique tags for the project
 // ---------------------------------------------------------------------------
 
-router.get("/tags", async (c) => {
+router.get("/tags", requireScope("conversations:read"), async (c) => {
   const db = c.get("db");
   const projectId = c.get("projectId");
 
@@ -38,7 +39,7 @@ router.get("/tags", async (c) => {
 // GET /conversations/:id/tags — List tags for a conversation
 // ---------------------------------------------------------------------------
 
-router.get("/conversations/:id/tags", async (c) => {
+router.get("/conversations/:id/tags", requireScope("conversations:read"), async (c) => {
   const db = c.get("db");
   const projectId = c.get("projectId");
   const conversationId = c.req.param("id");
@@ -57,7 +58,7 @@ router.get("/conversations/:id/tags", async (c) => {
 // POST /conversations/:id/tags — Add tag(s) to a conversation
 // ---------------------------------------------------------------------------
 
-router.post("/conversations/:id/tags", async (c) => {
+router.post("/conversations/:id/tags", requireScope("conversations:write"), async (c) => {
   const { body, error } = await parseJsonBody(c);
   if (error) return error;
 
@@ -85,7 +86,7 @@ router.post("/conversations/:id/tags", async (c) => {
 // DELETE /conversations/:id/tags/:tag — Remove a tag from a conversation
 // ---------------------------------------------------------------------------
 
-router.delete("/conversations/:id/tags/:tag", async (c) => {
+router.delete("/conversations/:id/tags/:tag", requireScope("conversations:write"), async (c) => {
   const db = c.get("db");
   const projectId = c.get("projectId");
   const conversationId = c.req.param("id");

--- a/packages/api/src/routes/v2/capability-tokens/index.ts
+++ b/packages/api/src/routes/v2/capability-tokens/index.ts
@@ -1,8 +1,10 @@
 import { Hono } from "hono";
 import { errorResponse, parseAndValidateBody } from "../../../lib/helpers";
+import { scopesSatisfyAll } from "../../../lib/scopes";
 import { CAPABILITY_SCOPES, CreateCapabilityTokenSchema } from "../../../lib/validation";
 import { apiKeyAuth } from "../../../middleware/auth";
 import { rateLimitMiddleware } from "../../../middleware/rate-limit";
+import { requireScope } from "../../../middleware/require-scope";
 import {
   createCapabilityToken,
   listCapabilityTokens,
@@ -23,12 +25,24 @@ const UniqueCapabilityTokenSchema = CreateCapabilityTokenSchema.refine(
 router.use("*", apiKeyAuth);
 router.use("*", rateLimitMiddleware);
 
-router.post("/", async (c) => {
+router.post("/", requireScope("keys:write"), async (c) => {
   const { data, error } = await parseAndValidateBody(c, UniqueCapabilityTokenSchema);
   if (error) return error;
   if (!data) return errorResponse(c, "BAD_REQUEST", "Invalid request body", 400);
   if (!data.name || !data.scopes) {
     return errorResponse(c, "BAD_REQUEST", "Invalid request body", 400);
+  }
+
+  // Delegation: a key may only mint a capability token whose scopes are a
+  // subset of its own. Full-access (`*`) callers may grant any scope.
+  const callerScopes = c.get("capabilityScopes") ?? [];
+  if (!scopesSatisfyAll(callerScopes, data.scopes)) {
+    return errorResponse(
+      c,
+      "FORBIDDEN",
+      "Cannot grant scopes beyond the calling key's own scopes",
+      403,
+    );
   }
 
   const token = await createCapabilityToken(c.get("db"), c.get("projectId"), {
@@ -39,12 +53,12 @@ router.post("/", async (c) => {
   return c.json(token, 201);
 });
 
-router.get("/", async (c) => {
+router.get("/", requireScope("keys:read"), async (c) => {
   const tokens = await listCapabilityTokens(c.get("db"), c.get("projectId"));
   return c.json({ data: tokens });
 });
 
-router.delete("/:id", async (c) => {
+router.delete("/:id", requireScope("keys:write"), async (c) => {
   const revoked = await revokeCapabilityToken(c.get("db"), c.get("projectId"), c.req.param("id"));
   if (!revoked) return errorResponse(c, "NOT_FOUND", "Capability token not found", 404);
   return c.body(null, 204);

--- a/packages/api/src/routes/webhooks/index.ts
+++ b/packages/api/src/routes/webhooks/index.ts
@@ -1,10 +1,20 @@
 import { Hono } from "hono";
 import { notFound, parseJsonBody, validationError } from "../../lib/helpers";
 import { CreateWebhookSchema, UpdateWebhookSchema } from "../../lib/validation";
+import { apiKeyAuth } from "../../middleware/auth";
+import { rateLimitMiddleware } from "../../middleware/rate-limit";
+import { requireScope } from "../../middleware/require-scope";
 import * as webhooksService from "../../services/webhooks";
 import type { Bindings, Variables } from "../../types";
 
 const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+// Webhook management requires a valid API key for the project with the
+// `webhooks:write` scope. (Previously this router had no auth — projectId was
+// undefined — so these endpoints were non-functional; this fixes that.)
+router.use("*", apiKeyAuth);
+router.use("*", rateLimitMiddleware);
+router.use("*", requireScope("webhooks:write"));
 
 // ---------------------------------------------------------------------------
 // POST / — Create webhook

--- a/packages/api/src/services/keys.ts
+++ b/packages/api/src/services/keys.ts
@@ -6,6 +6,7 @@ import { and, eq } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { apiKeys } from "../db/schema";
 import { buildApiKey } from "../lib/api-key";
+import { parseScopesJson } from "../lib/scopes";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -16,6 +17,8 @@ export interface ApiKeyListItem {
   project_id: string;
   name: string;
   key_prefix: string;
+  /** Granted scopes, or null for a full-access (legacy/unscoped) key. */
+  scopes: string[] | null;
   created_at: number;
   last_used_at: number | null;
   revoked_at: number | null;
@@ -37,8 +40,9 @@ export async function createApiKey(
   db: DrizzleD1Database,
   projectId: string,
   name: string,
+  scopes?: string[],
 ): Promise<ApiKeyWithSecret> {
-  const key = await buildApiKey(projectId, name);
+  const key = await buildApiKey(projectId, name, scopes);
   await db.insert(apiKeys).values(key.values);
 
   return {
@@ -47,6 +51,7 @@ export async function createApiKey(
     name,
     key_prefix: key.prefix,
     key: key.rawKey,
+    scopes: scopes && scopes.length > 0 ? scopes : null,
     created_at: key.now,
     last_used_at: null,
     revoked_at: null,
@@ -109,6 +114,7 @@ function toApiKeyListItem(row: typeof apiKeys.$inferSelect): ApiKeyListItem {
     project_id: row.projectId,
     name: row.name,
     key_prefix: row.keyPrefix,
+    scopes: row.scopes ? parseScopesJson(row.scopes) : null,
     created_at: row.createdAt,
     last_used_at: row.lastUsedAt,
     revoked_at: row.revokedAt,

--- a/packages/api/src/services/projects.ts
+++ b/packages/api/src/services/projects.ts
@@ -16,6 +16,7 @@ import {
 import { buildApiKey } from "../lib/api-key";
 import { DEFAULT_CLERK_ORG_ID } from "../lib/constants";
 import { generateId } from "../lib/id";
+import { parseScopesJson } from "../lib/scopes";
 import { deserializeMetadata } from "../lib/serialization";
 
 // ---------------------------------------------------------------------------
@@ -33,6 +34,7 @@ export interface ProjectWithKeys {
     id: string;
     name: string;
     key_prefix: string;
+    scopes: string[] | null;
     created_at: number;
     last_used_at: number | null;
     revoked_at: number | null;
@@ -86,6 +88,7 @@ export interface CreateProjectResult {
     name: string;
     key_prefix: string;
     key: string;
+    scopes: string[] | null;
     created_at: number;
   };
 }
@@ -192,6 +195,7 @@ export async function createProject(
       name: "Default",
       key_prefix: key.prefix,
       key: key.rawKey,
+      scopes: null, // default key is full-access (unscoped)
       created_at: key.now,
     },
   };
@@ -289,6 +293,7 @@ export async function getProjectById(
       id: apiKeys.id,
       name: apiKeys.name,
       key_prefix: apiKeys.keyPrefix,
+      scopes: apiKeys.scopes,
       created_at: apiKeys.createdAt,
       last_used_at: apiKeys.lastUsedAt,
       revoked_at: apiKeys.revokedAt,
@@ -303,7 +308,15 @@ export async function getProjectById(
     slug: project.slug,
     created_at: project.createdAt,
     retention_days: project.retentionDays ?? null,
-    api_keys: keys,
+    api_keys: keys.map((k) => ({
+      id: k.id,
+      name: k.name,
+      key_prefix: k.key_prefix,
+      scopes: k.scopes ? parseScopesJson(k.scopes) : null,
+      created_at: k.created_at,
+      last_used_at: k.last_used_at,
+      revoked_at: k.revoked_at,
+    })),
   };
 }
 
@@ -325,6 +338,7 @@ export async function getProjectBySlug(
       id: apiKeys.id,
       name: apiKeys.name,
       key_prefix: apiKeys.keyPrefix,
+      scopes: apiKeys.scopes,
       created_at: apiKeys.createdAt,
       last_used_at: apiKeys.lastUsedAt,
       revoked_at: apiKeys.revokedAt,
@@ -339,7 +353,15 @@ export async function getProjectBySlug(
     slug: project.slug,
     created_at: project.createdAt,
     retention_days: project.retentionDays ?? null,
-    api_keys: keys,
+    api_keys: keys.map((k) => ({
+      id: k.id,
+      name: k.name,
+      key_prefix: k.key_prefix,
+      scopes: k.scopes ? parseScopesJson(k.scopes) : null,
+      created_at: k.created_at,
+      last_used_at: k.last_used_at,
+      revoked_at: k.revoked_at,
+    })),
   };
 }
 
@@ -393,11 +415,13 @@ export async function createApiKey(
   db: DrizzleD1Database,
   projectId: string,
   name: string,
+  scopes?: string[],
 ): Promise<{
   id: string;
   name: string;
   key_prefix: string;
   key: string;
+  scopes: string[] | null;
   created_at: number;
 }> {
   // Verify the project exists
@@ -407,7 +431,7 @@ export async function createApiKey(
     throw new Error("Project not found");
   }
 
-  const key = await buildApiKey(projectId, name);
+  const key = await buildApiKey(projectId, name, scopes);
   await db.insert(apiKeys).values(key.values);
 
   return {
@@ -415,6 +439,7 @@ export async function createApiKey(
     name,
     key_prefix: key.prefix,
     key: key.rawKey,
+    scopes: scopes && scopes.length > 0 ? scopes : null,
     created_at: key.now,
   };
 }

--- a/packages/api/src/services/v2-projects.ts
+++ b/packages/api/src/services/v2-projects.ts
@@ -72,6 +72,7 @@ export interface V2CreateProjectResult {
     name: string;
     key_prefix: string;
     key: string;
+    scopes: string[] | null;
     created_at: number;
   };
 }
@@ -244,6 +245,7 @@ export async function createProject(
       name: "Default",
       key_prefix: key.prefix,
       key: key.rawKey,
+      scopes: null, // default key is full-access (unscoped)
       created_at: key.now,
     },
   };

--- a/packages/api/test/scopes.test.ts
+++ b/packages/api/test/scopes.test.ts
@@ -1,0 +1,133 @@
+import { SELF } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import { effectiveKeyScopes, scopeSatisfies, scopesSatisfyAll } from "../src/lib/scopes";
+import { applyMigrations, authHeaders, seedProject, TEST_PROJECT_ID } from "./setup";
+
+function bearer(key: string): Record<string, string> {
+  return { Authorization: `Bearer ${key}`, "Content-Type": "application/json" };
+}
+
+async function createKey(scopes?: string[]): Promise<string> {
+  const res = await SELF.fetch(`http://localhost/api/projects/${TEST_PROJECT_ID}/keys`, {
+    method: "POST",
+    headers: authHeaders(), // full-access seeded key
+    body: JSON.stringify({ name: "scoped", ...(scopes ? { scopes } : {}) }),
+  });
+  expect(res.status).toBe(201);
+  const body = (await res.json()) as { key: string; scopes: string[] | null };
+  return body.key;
+}
+
+describe("scope helpers", () => {
+  it("scopeSatisfies honors exact, global, and resource wildcards", () => {
+    expect(scopeSatisfies(["conversations:read"], "conversations:read")).toBe(true);
+    expect(scopeSatisfies(["conversations:read"], "conversations:write")).toBe(false);
+    expect(scopeSatisfies(["*"], "anything:read")).toBe(true);
+    expect(scopeSatisfies(["state:*"], "state:write")).toBe(true);
+    expect(scopeSatisfies(["state:*"], "conversations:write")).toBe(false);
+  });
+
+  it("scopesSatisfyAll enforces subset/delegation", () => {
+    expect(scopesSatisfyAll(["*"], ["conversations:write", "state:read"])).toBe(true);
+    expect(scopesSatisfyAll(["conversations:read"], ["conversations:read"])).toBe(true);
+    expect(scopesSatisfyAll(["conversations:read"], ["conversations:write"])).toBe(false);
+    // Cannot widen a concrete grant into a resource wildcard.
+    expect(scopesSatisfyAll(["state:read"], ["state:*"])).toBe(false);
+  });
+
+  it("effectiveKeyScopes: null/undefined → full access, explicit list honored", () => {
+    expect(effectiveKeyScopes(null)).toEqual(["*"]);
+    expect(effectiveKeyScopes(undefined)).toEqual(["*"]);
+    // An explicit empty list grants nothing — it never silently becomes full access.
+    expect(effectiveKeyScopes("[]")).toEqual([]);
+    expect(effectiveKeyScopes('["conversations:read"]')).toEqual(["conversations:read"]);
+  });
+});
+
+describe("API key scope enforcement", () => {
+  beforeEach(async () => {
+    await applyMigrations();
+    await seedProject();
+  });
+
+  it("legacy/unscoped key has full access", async () => {
+    const res = await SELF.fetch("http://localhost/api/v1/conversations", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ title: "full access" }),
+    });
+    expect(res.status).toBe(201);
+  });
+
+  it("scoped key is allowed in-scope and forbidden out-of-scope", async () => {
+    const readOnly = await createKey(["conversations:read"]);
+
+    const listRes = await SELF.fetch("http://localhost/api/v1/conversations", {
+      headers: bearer(readOnly),
+    });
+    expect(listRes.status).toBe(200);
+
+    const writeRes = await SELF.fetch("http://localhost/api/v1/conversations", {
+      method: "POST",
+      headers: bearer(readOnly),
+      body: JSON.stringify({ title: "should fail" }),
+    });
+    expect(writeRes.status).toBe(403);
+    await expect(writeRes.json()).resolves.toMatchObject({
+      error: { code: "FORBIDDEN" },
+    });
+  });
+
+  it("a key cannot mint a child key beyond its own scopes", async () => {
+    // This key can read conversations and manage keys, but cannot write conversations.
+    const limited = await createKey(["conversations:read", "keys:write"]);
+
+    const overReach = await SELF.fetch(`http://localhost/api/projects/${TEST_PROJECT_ID}/keys`, {
+      method: "POST",
+      headers: bearer(limited),
+      body: JSON.stringify({ name: "child", scopes: ["conversations:write"] }),
+    });
+    expect(overReach.status).toBe(403);
+
+    const inBounds = await SELF.fetch(`http://localhost/api/projects/${TEST_PROJECT_ID}/keys`, {
+      method: "POST",
+      headers: bearer(limited),
+      body: JSON.stringify({ name: "child", scopes: ["conversations:read"] }),
+    });
+    expect(inBounds.status).toBe(201);
+    const created = (await inBounds.json()) as { scopes: string[] | null };
+    expect(created.scopes).toEqual(["conversations:read"]);
+  });
+
+  it("omitting scopes makes a child inherit the caller's scopes (no escalation)", async () => {
+    const limited = await createKey(["conversations:read", "keys:write"]);
+
+    const res = await SELF.fetch(`http://localhost/api/projects/${TEST_PROJECT_ID}/keys`, {
+      method: "POST",
+      headers: bearer(limited),
+      body: JSON.stringify({ name: "inherited" }), // no scopes field
+    });
+    expect(res.status).toBe(201);
+    const created = (await res.json()) as { key: string; scopes: string[] | null };
+    // Inherits the caller's scopes rather than escalating to full access (null).
+    expect(created.scopes).toEqual(["conversations:read", "keys:write"]);
+
+    // The inherited child cannot write conversations (a scope it never had).
+    const writeRes = await SELF.fetch("http://localhost/api/v1/conversations", {
+      method: "POST",
+      headers: bearer(created.key),
+      body: JSON.stringify({ title: "should fail" }),
+    });
+    expect(writeRes.status).toBe(403);
+  });
+
+  it("a key without keys:write cannot create keys", async () => {
+    const noKeyScope = await createKey(["conversations:read"]);
+    const res = await SELF.fetch(`http://localhost/api/projects/${TEST_PROJECT_ID}/keys`, {
+      method: "POST",
+      headers: bearer(noKeyScope),
+      body: JSON.stringify({ name: "nope" }),
+    });
+    expect(res.status).toBe(403);
+  });
+});

--- a/packages/api/test/setup.ts
+++ b/packages/api/test/setup.ts
@@ -9,6 +9,7 @@ const DDL_STATEMENTS: string[] = [
     \`name\` text NOT NULL,
     \`key_prefix\` text NOT NULL,
     \`key_hash\` text NOT NULL,
+    \`scopes\` text,
     \`last_used_at\` integer,
     \`created_at\` integer NOT NULL,
     \`revoked_at\` integer,
@@ -261,6 +262,50 @@ const DDL_STATEMENTS: string[] = [
   `CREATE UNIQUE INDEX IF NOT EXISTS \`custom_domains_domain_unique\` ON \`custom_domains\` (\`domain\`)`,
   `CREATE INDEX IF NOT EXISTS \`custom_domains_project_id_idx\` ON \`custom_domains\` (\`project_id\`)`,
   `CREATE INDEX IF NOT EXISTS \`custom_domains_verification_status_idx\` ON \`custom_domains\` (\`verification_status\`)`,
+  `CREATE TABLE IF NOT EXISTS \`oauth_clients\` (
+    \`id\` text PRIMARY KEY NOT NULL,
+    \`client_secret_hash\` text,
+    \`client_name\` text NOT NULL,
+    \`redirect_uris\` text NOT NULL,
+    \`grant_types\` text DEFAULT '["authorization_code","refresh_token"]' NOT NULL,
+    \`token_endpoint_auth_method\` text DEFAULT 'none' NOT NULL,
+    \`created_at\` integer NOT NULL
+  )`,
+  `CREATE INDEX IF NOT EXISTS \`oauth_clients_created_at_idx\` ON \`oauth_clients\` (\`created_at\`)`,
+  `CREATE TABLE IF NOT EXISTS \`oauth_authorization_codes\` (
+    \`id\` text PRIMARY KEY NOT NULL,
+    \`code_hash\` text NOT NULL,
+    \`client_id\` text NOT NULL,
+    \`project_id\` text NOT NULL,
+    \`org_id\` text,
+    \`user_id\` text,
+    \`scopes\` text NOT NULL,
+    \`redirect_uri\` text NOT NULL,
+    \`code_challenge\` text NOT NULL,
+    \`code_challenge_method\` text DEFAULT 'S256' NOT NULL,
+    \`resource\` text,
+    \`expires_at\` integer NOT NULL,
+    \`consumed_at\` integer,
+    \`created_at\` integer NOT NULL,
+    FOREIGN KEY (\`project_id\`) REFERENCES \`projects\`(\`id\`) ON UPDATE no action ON DELETE CASCADE
+  )`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS \`oauth_authorization_codes_code_hash_idx\` ON \`oauth_authorization_codes\` (\`code_hash\`)`,
+  `CREATE INDEX IF NOT EXISTS \`oauth_authorization_codes_expires_at_idx\` ON \`oauth_authorization_codes\` (\`expires_at\`)`,
+  `CREATE TABLE IF NOT EXISTS \`oauth_refresh_tokens\` (
+    \`id\` text PRIMARY KEY NOT NULL,
+    \`token_hash\` text NOT NULL,
+    \`client_id\` text NOT NULL,
+    \`project_id\` text NOT NULL,
+    \`access_token_id\` text,
+    \`scopes\` text NOT NULL,
+    \`expires_at\` integer,
+    \`rotated_at\` integer,
+    \`revoked_at\` integer,
+    \`created_at\` integer NOT NULL,
+    FOREIGN KEY (\`project_id\`) REFERENCES \`projects\`(\`id\`) ON UPDATE no action ON DELETE CASCADE
+  )`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS \`oauth_refresh_tokens_token_hash_idx\` ON \`oauth_refresh_tokens\` (\`token_hash\`)`,
+  `CREATE INDEX IF NOT EXISTS \`oauth_refresh_tokens_client_id_idx\` ON \`oauth_refresh_tokens\` (\`client_id\`)`,
 ];
 
 // Fixed seed data for deterministic tests
@@ -289,6 +334,9 @@ export async function seedProject(): Promise<void> {
   const keyPrefix = TEST_API_KEY.substring(0, 12);
 
   for (const table of [
+    "oauth_refresh_tokens",
+    "oauth_authorization_codes",
+    "oauth_clients",
     "claim_verification_runs",
     "claim_evidence",
     "claims",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -143,10 +143,33 @@ export interface ProjectResponse {
   created_at: number;
 }
 
+/**
+ * Permission scopes for API keys and OAuth-issued access tokens.
+ * `*` (the wildcard) grants full access and is the default for legacy keys.
+ */
+export type ApiScope =
+  | "conversations:read"
+  | "conversations:write"
+  | "state:read"
+  | "state:write"
+  | "state:watch"
+  | "leases:write"
+  | "claims:write"
+  | "analytics:read"
+  | "webhooks:write"
+  | "domains:write"
+  | "keys:read"
+  | "keys:write";
+
 export interface ApiKeyResponse {
   id: string;
   name: string;
   key_prefix: string;
+  /**
+   * Granted permission scopes, or null for a full-access (legacy/unscoped) key.
+   * May contain concrete scopes, per-resource wildcards (`state:*`), or `*`.
+   */
+  scopes: string[] | null;
   created_at: number;
   last_used_at: number | null;
   revoked_at: number | null;


### PR DESCRIPTION
## Wave 0 — Foundation for remote MCP + OAuth + scoped keys

This is the security-critical foundation the rest of the MCP/OAuth work builds on. It adds a **permission-scope model to API keys** and enforces it across the API. Subsequent PRs (remote MCP endpoint, OAuth 2.1 flow, consent screen, dashboard key-permissions UI, docs, SDKs) build on these contracts.

### What changed
- **`lib/scopes.ts`** — canonical `API_SCOPES` taxonomy (`conversations:*`, `state:*`, `leases:write`, `claims:write`, `analytics:read`, `webhooks:write`, `domains:write`, `keys:*`) + helpers: `scopeSatisfies`, `scopesSatisfyAll`, `effectiveKeyScopes` (honors `*` and `resource:*` wildcards).
- **DB** — nullable `api_keys.scopes` (**NULL = full access**, backward-compatible) + new `oauth_clients` / `oauth_authorization_codes` / `oauth_refresh_tokens` tables (migration `0007_whole_meggan`). Test DDL updated to match.
- **Auth** — `apiKeyAuth` loads + caches scopes (KV value is now JSON `{projectId,scopes}` with a legacy plain-string fallback); `scopedAuth` now enforces scopes for **API keys too** (previously they bypassed scope checks on v2 routes); new **`requireScope()`** middleware.
- **Enforcement** — `requireScope(...)` wired into every API-key data route (conversations CRUD/messages/search/bulk/analytics/traces, ai, tags, webhooks, capability-tokens).
- **Delegation** — key creation enforces a **subset-of-caller** rule; omitting `scopes` makes a restricted child **inherit** the caller's scopes (never escalates to full access). A full-access (`*`) caller still mints full-access keys.
- **Bug fix** — the `webhooks` router previously had **no auth** (so `projectId` was `undefined` and the endpoints were non-functional). Now `apiKeyAuth` + rate limit + `webhooks:write`.
- **shared** — `ApiKeyResponse.scopes` + `ApiScope` type.

### Backward compatibility
Existing/unscoped keys resolve to `*` (full access), so nothing breaks. The default key minted at project creation is unscoped (full access).

### Notes
- `domains.ts` and project `analytics.ts` are mounted under the Clerk-guarded `/api/v1/projects/*` (dashboard session), not API-key auth, so scope enforcement doesn't apply there.
- The unmounted `routes/v2/keys` router was left as-is (dead code, `.skip` test); it should adopt the same subset rule if ever mounted.

### Verification
- `bunx biome check src/` ✅ · `bunx tsc --noEmit` ✅ · `bunx vitest run` ✅ **290 passed** (incl. new `test/scopes.test.ts`: legacy=full, in-scope 200 / out-of-scope 403, subset-mint 403, no-escalation-on-omit).
- A correctness review caught and fixed a privilege-escalation (omit-scopes → full-access child) before commit.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API keys now support granular permission scopes to limit access to specific operations
  * OAuth infrastructure added (clients, authorization codes, refresh tokens) to support future OAuth flows

* **Security**
  * API endpoints now enforce scope-based authorization checks; unscoped keys retain full access for backward compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->