### PR TITLE
docs: remote MCP server, OAuth 2.1, and key permissions

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,7 +19,9 @@
 | [Integration Guide](integration-guide.md) | Chat apps, AI frameworks, LLM tracing, multi-tenant |
 | [V2 Migration Guide](v2-migration.md) | Migrate from V1 to V2 API |
 | [TypeScript SDK](sdk.md) | SDK installation, methods, and examples |
-| [MCP Server](mcp.md) | Use AgentState from Cursor, Claude Desktop, and Windsurf via MCP |
+| [MCP Server](mcp.md) | Use AgentState from Cursor, Claude Desktop, and Windsurf via MCP — hosted remote server or local stdio |
+| [OAuth 2.1](oauth.md) | Browser auth + PKCE + consent screen so MCP clients can connect |
+| [Permissions & Scopes](permissions.md) | Scope taxonomy, scoped API keys, and the delegation rule |
 | [Framework Integration](integration.md) | Vercel AI SDK, Cloudflare Workers AI, LangGraph |
 | [ClickHouse Monitoring](integrations/clickhouse-monitoring.md) | Use AgentState as the conversation-history backend for the clickhouse-monitoring dashboard |
 | [Environment Variables](environment-variables.md) | Env vars and Cloudflare bindings |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -831,13 +831,15 @@ API key management endpoints. All endpoints require API key authentication.
 POST /api/v1/keys
 ```
 
-Creates a new API key for the authenticated project.
+Creates a new API key for the authenticated project. The project is taken from the
+authenticating key.
 
 **Request body:**
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | string | Yes | Key display name (1-255 characters). |
+| `scopes` | string[] | No | Permission scopes for the new key. Omit for full access. Must be a subset of the authenticating key's scopes. See [Permissions & scopes](#permissions--scopes). |
 
 **Response:** `201 Created`
 
@@ -848,6 +850,7 @@ Creates a new API key for the authenticated project.
   "name": "Production",
   "key_prefix": "as_live_xxxx",
   "key": "as_live_full_key_shown_only_once",
+  "scopes": ["conversations:read", "conversations:write"],
   "created_at": 1710000000000,
   "last_used_at": null,
   "revoked_at": null
@@ -856,9 +859,15 @@ Creates a new API key for the authenticated project.
 
 The `key` field contains the full API key and is only returned at creation time. Store it securely.
 
+The `scopes` field is `null` for full-access keys (created without a `scopes` array, and any legacy key).
+
 **V2 Changes:**
 - `key_id` instead of `id`
 - Includes `project_id` in response
+
+**Errors:**
+- `400 BAD_REQUEST` -- Validation failure.
+- `403 FORBIDDEN` -- Requested `scopes` are not a subset of the authenticating key's scopes.
 
 **Errors:**
 - `400 BAD_REQUEST` -- Validation failure.
@@ -869,7 +878,8 @@ The `key` field contains the full API key and is only returned at creation time.
 GET /api/v1/keys
 ```
 
-Lists all API keys for the authenticated project (including revoked ones).
+Lists all API keys for the authenticated project (including revoked ones). The project is
+taken from the authenticating key.
 
 **Response:** `200 OK`
 
@@ -881,6 +891,7 @@ Lists all API keys for the authenticated project (including revoked ones).
       "project_id": "proj_abc123",
       "name": "Default",
       "key_prefix": "as_live_xxxx",
+      "scopes": null,
       "created_at": 1710000000000,
       "last_used_at": 1710000000000,
       "revoked_at": null
@@ -889,11 +900,12 @@ Lists all API keys for the authenticated project (including revoked ones).
 }
 ```
 
-The full key is never returned after creation.
+The full key is never returned after creation. `scopes` is `null` for full-access keys.
 
 **V2 Changes:**
 - `key_id` instead of `id`
 - Includes `project_id` in each key object
+- Includes `scopes` (`string[]` or `null`)
 
 #### Revoke API Key
 
@@ -907,6 +919,23 @@ Soft-deletes an API key by setting `revoked_at`. The key immediately becomes inv
 
 **Errors:**
 - `404 NOT_FOUND` -- API key not found.
+
+### Permissions & scopes
+
+API keys, capability tokens, and OAuth access tokens carry **scopes** that limit which
+endpoints they can call. A key created without a `scopes` array — and any legacy key — has
+full access (`scopes` is `null`).
+
+Available scopes: `conversations:read`, `conversations:write`, `state:read`, `state:write`,
+`state:watch`, `leases:write`, `claims:write`, `analytics:read`, `webhooks:write`,
+`domains:write`, `keys:read`, `keys:write`. The `*` wildcard grants full access and
+per-resource wildcards like `state:*` cover all actions on a resource.
+
+A key can only mint child keys whose scopes are a subset of its own. Out-of-scope requests
+return `403 FORBIDDEN`. Dashboard key creation (Clerk session) may grant any scopes.
+
+See the [Permissions & Scopes guide](permissions.md) for the full taxonomy, the delegation
+rule, and examples.
 
 ---
 
@@ -2031,6 +2060,7 @@ Creates a new API key for the project.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | string | Yes | Key display name (1-255 characters). |
+| `scopes` | string[] | No | Permission scopes for the new key. Omit for full access. See [Permissions & scopes](#permissions--scopes). On the authenticated route the scopes must be a subset of the authenticating key's; the dashboard route (Clerk session) may grant any scopes. |
 
 **Response:** `201 Created`
 
@@ -2040,13 +2070,14 @@ Creates a new API key for the project.
   "name": "Production",
   "key_prefix": "as_live_xxxx",
   "key": "as_live_full_key_shown_only_once",
+  "scopes": ["conversations:read"],
   "created_at": 1710000000000,
   "last_used_at": null,
   "revoked_at": null
 }
 ```
 
-The `key` field contains the full API key and is only returned at creation time. Store it securely.
+The `key` field contains the full API key and is only returned at creation time. Store it securely. `scopes` is `null` for full-access keys.
 
 **Errors:**
 - `403 FORBIDDEN` -- Attempting to create a key for a different project (authenticated route only).
@@ -2069,6 +2100,7 @@ Lists all API keys for the project (including revoked ones).
       "id": "key_abc123",
       "name": "Default",
       "key_prefix": "as_live_xxxx",
+      "scopes": null,
       "created_at": 1710000000000,
       "last_used_at": 1710000000000,
       "revoked_at": null
@@ -2077,7 +2109,7 @@ Lists all API keys for the project (including revoked ones).
 }
 ```
 
-The full key is never returned after creation.
+The full key is never returned after creation. `scopes` is `null` for full-access keys.
 
 **Errors:**
 - `403 FORBIDDEN` -- Attempting to list keys for a different project.
@@ -2110,6 +2142,32 @@ No authentication required.
 
 ```json
 { "name": "agentstate", "version": "0.1.0", "status": "ok" }
+```
+
+## Remote MCP Server
+
+```
+POST /api/mcp
+```
+
+A hosted MCP (Model Context Protocol) server over Streamable HTTP. Authenticate with
+`Authorization: Bearer <token>`, where the token is an API key (`as_live_...`), a capability
+token (`as_cap_...`), or an OAuth access token. Supports the standard MCP methods
+(`initialize`, `tools/list`, `tools/call`, `ping`); each tool requires a scope. A `401`
+returns `WWW-Authenticate: Bearer resource_metadata=".../.well-known/oauth-protected-resource"`.
+
+See the [MCP guide](mcp.md#remote-mcp-server-hosted) and [OAuth 2.1 guide](oauth.md).
+
+### OAuth Discovery
+
+No authentication required:
+
+```
+GET /.well-known/oauth-protected-resource     # RFC 9728 resource metadata
+GET /.well-known/oauth-authorization-server   # RFC 8414 authorization server metadata
+POST /api/oauth/register                       # RFC 7591 Dynamic Client Registration
+GET /api/oauth/authorize                        # Authorization-code + PKCE flow → consent screen
+POST /api/oauth/token                           # Token exchange and refresh-token rotation
 ```
 
 ## Machine-Readable Endpoints

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,6 +1,97 @@
 # MCP Server
 
-Use AgentState from Cursor, Claude Desktop, Windsurf, and any other MCP-compatible client via the `@agentstate/mcp` server.
+Use AgentState from Cursor, Claude Desktop, Windsurf, and any other MCP-compatible client. There are two ways to connect:
+
+- **Remote MCP server (hosted)** — point your client at `https://agentstate.app/api/mcp`. Nothing to install. Covered first below.
+- **Local stdio server (`@agentstate/mcp`)** — run a local subprocess via `npx`. Covered in [Local stdio server](#local-stdio-server).
+
+## Remote MCP server (hosted)
+
+AgentState hosts a remote MCP server over Streamable HTTP. No install — just point your client at the URL and authenticate.
+
+```
+POST https://agentstate.app/api/mcp
+```
+
+It speaks standard MCP JSON-RPC (`initialize`, `tools/list`, `tools/call`, `ping`) and is stateless — each request responds with `application/json`. The tools mirror the local stdio server (conversations, state, leases, claims, capability tokens) plus key management. Each tool requires a [scope](permissions.md); a token may only call tools its scopes allow.
+
+### Authentication
+
+Send an `Authorization: Bearer <token>` header. Three token types work:
+
+| Mode | Token | When to use |
+|------|-------|-------------|
+| API key | `as_live_...` | Paste a project API key into your client config. |
+| Capability token | `as_cap_...` | A scoped, often short-lived delegation token. |
+| OAuth access token | issued by the flow | Client runs the browser consent flow itself. |
+
+**Bearer token mode** — paste a key or capability token directly. Simplest for clients that accept a static header.
+
+**OAuth mode** — the client discovers AgentState's authorization server and runs the OAuth 2.1 + PKCE flow automatically; the user signs in, picks a project, and approves scopes on a consent screen. See [OAuth 2.1](oauth.md) for the full flow.
+
+A request without a valid token returns `401` with a pointer to the OAuth discovery document:
+
+```
+WWW-Authenticate: Bearer resource_metadata="https://agentstate.app/.well-known/oauth-protected-resource"
+```
+
+### Client configuration
+
+For clients that support remote / Streamable-HTTP MCP servers, give the URL and a Bearer header:
+
+```json
+{
+  "mcpServers": {
+    "agentstate": {
+      "type": "http",
+      "url": "https://agentstate.app/api/mcp",
+      "headers": {
+        "Authorization": "Bearer as_live_your_key_here"
+      }
+    }
+  }
+}
+```
+
+Clients that support OAuth-based remote MCP can omit the header and connect by URL — they run the consent flow on first use:
+
+```json
+{
+  "mcpServers": {
+    "agentstate": {
+      "type": "http",
+      "url": "https://agentstate.app/api/mcp"
+    }
+  }
+}
+```
+
+The exact key name (`type`, `transport`, `url`, etc.) varies by client — check your client's remote-MCP docs. The URL and Bearer auth are the same everywhere.
+
+### Scopes
+
+Each tool maps to a scope. A token can only call tools allowed by its scopes; out-of-scope calls fail with `403 FORBIDDEN`.
+
+| Scope | Grants |
+|-------|--------|
+| `conversations:read` | Read, list, search, export conversations |
+| `conversations:write` | Create, append, update, delete, tag |
+| `state:read` | Read state, list events, query |
+| `state:write` | Create, replace, delete state |
+| `state:watch` | Watch state events |
+| `leases:write` | Acquire, renew, release leases |
+| `claims:write` | Create and verify claims |
+| `analytics:read` | Read analytics |
+| `webhooks:write` | Manage webhooks |
+| `domains:write` | Manage custom domains |
+| `keys:read` | List API keys |
+| `keys:write` | Create and revoke API keys |
+
+`*` grants full access; per-resource wildcards like `state:*` cover all actions on a resource. A key created without scopes (or any legacy key) has full access. See [Permissions & Scopes](permissions.md) for the full taxonomy and the delegation rule.
+
+## Local stdio server
+
+Run AgentState locally via the `@agentstate/mcp` server — a subprocess started by `npx`. Use this for token-based local development, or any client that does not support remote MCP.
 
 ## Prerequisites
 
@@ -149,6 +240,8 @@ Sign up at [agentstate.app](https://agentstate.app) — no credit card required.
 
 ## Related docs
 
+- [OAuth 2.1](oauth.md) — browser auth flow for remote MCP clients
+- [Permissions & Scopes](permissions.md) — scope taxonomy and delegation rule
 - [TypeScript SDK](sdk.md) — typed client for use in your own code
 - [API Reference](api-reference.md) — full REST API documentation
 - [Recipe: Conversations](recipes/conversations.md) — create, append, search, and AI-enrich conversations

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -1,0 +1,200 @@
+# OAuth 2.1
+
+AgentState supports **OAuth 2.1 with PKCE** so MCP clients (and other apps) can connect on
+behalf of a user without the user pasting a raw API key. The user signs in, picks a project,
+and approves a set of [scopes](permissions.md) on a consent screen. The client receives a
+short-lived access token it sends as a Bearer token.
+
+AgentState is **both** the authorization server and the resource server — you discover,
+authorize, and call the API against the same origin (`https://agentstate.app`).
+
+If you just want to paste a token, you don't need OAuth — see the
+[remote MCP server](mcp.md#remote-mcp-server-hosted) Bearer-token mode. OAuth is for clients
+that run the browser flow automatically.
+
+## Flow overview
+
+```
+1. Discover     GET  /.well-known/oauth-protected-resource
+                GET  /.well-known/oauth-authorization-server
+2. Register     POST /api/oauth/register            (Dynamic Client Registration)
+3. Authorize    GET  /api/oauth/authorize  → consent screen → redirect with ?code=
+4. Token        POST /api/oauth/token                (exchange code + PKCE verifier)
+5. Refresh      POST /api/oauth/token                (grant_type=refresh_token)
+```
+
+Access tokens are short-lived (about 1 hour). Refresh tokens rotate — each refresh returns a
+new refresh token and invalidates the old one.
+
+## 1. Discovery
+
+### Protected resource metadata (RFC 9728)
+
+```
+GET https://agentstate.app/.well-known/oauth-protected-resource
+```
+
+```json
+{
+  "resource": "https://agentstate.app/api",
+  "authorization_servers": ["https://agentstate.app"],
+  "scopes_supported": [
+    "conversations:read", "conversations:write",
+    "state:read", "state:write", "state:watch",
+    "leases:write", "claims:write",
+    "analytics:read", "webhooks:write", "domains:write",
+    "keys:read", "keys:write"
+  ],
+  "bearer_methods_supported": ["header"]
+}
+```
+
+A `401` from the API points clients here:
+
+```
+WWW-Authenticate: Bearer resource_metadata="https://agentstate.app/.well-known/oauth-protected-resource"
+```
+
+### Authorization server metadata (RFC 8414)
+
+```
+GET https://agentstate.app/.well-known/oauth-authorization-server
+```
+
+```json
+{
+  "issuer": "https://agentstate.app",
+  "authorization_endpoint": "https://agentstate.app/api/oauth/authorize",
+  "token_endpoint": "https://agentstate.app/api/oauth/token",
+  "registration_endpoint": "https://agentstate.app/api/oauth/register",
+  "scopes_supported": [
+    "conversations:read", "conversations:write",
+    "state:read", "state:write", "state:watch",
+    "leases:write", "claims:write",
+    "analytics:read", "webhooks:write", "domains:write",
+    "keys:read", "keys:write"
+  ],
+  "response_types_supported": ["code"],
+  "grant_types_supported": ["authorization_code", "refresh_token"],
+  "code_challenge_methods_supported": ["S256"],
+  "token_endpoint_auth_methods_supported": ["none"]
+}
+```
+
+## 2. Dynamic Client Registration (RFC 7591)
+
+Most MCP clients register themselves automatically.
+
+```bash
+curl -X POST https://agentstate.app/api/oauth/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "client_name": "My MCP Client",
+    "redirect_uris": ["http://127.0.0.1:33418/callback"],
+    "grant_types": ["authorization_code", "refresh_token"],
+    "response_types": ["code"],
+    "token_endpoint_auth_method": "none"
+  }'
+```
+
+```json
+{
+  "client_id": "client_abc123",
+  "client_name": "My MCP Client",
+  "redirect_uris": ["http://127.0.0.1:33418/callback"],
+  "grant_types": ["authorization_code", "refresh_token"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "none"
+}
+```
+
+Public clients use `token_endpoint_auth_method: "none"` and rely on PKCE — there is no
+client secret.
+
+## 3. Authorize → consent → code
+
+Generate a PKCE verifier and its S256 challenge, then send the user's browser to the
+authorize endpoint:
+
+```
+GET https://agentstate.app/api/oauth/authorize
+      ?response_type=code
+      &client_id=client_abc123
+      &redirect_uri=http://127.0.0.1:33418/callback
+      &scope=conversations:read%20conversations:write%20state:read%20state:write
+      &state=<opaque-csrf-value>
+      &code_challenge=<base64url-sha256-of-verifier>
+      &code_challenge_method=S256
+```
+
+The user signs in (Clerk), **chooses which project** to grant access to, and **approves the
+requested scopes** on the consent screen. On approval AgentState redirects back:
+
+```
+http://127.0.0.1:33418/callback?code=<authorization_code>&state=<opaque-csrf-value>
+```
+
+Verify that `state` matches the value you sent.
+
+## 4. Token exchange
+
+Exchange the code for tokens, sending the original PKCE verifier:
+
+```bash
+curl -X POST https://agentstate.app/api/oauth/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d grant_type=authorization_code \
+  -d code=<authorization_code> \
+  -d redirect_uri=http://127.0.0.1:33418/callback \
+  -d client_id=client_abc123 \
+  -d code_verifier=<original-pkce-verifier>
+```
+
+```json
+{
+  "access_token": "<access-token>",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "refresh_token": "<refresh-token>",
+  "scope": "conversations:read conversations:write state:read state:write"
+}
+```
+
+Call the API (and the [remote MCP server](mcp.md#remote-mcp-server-hosted)) with the access
+token:
+
+```
+Authorization: Bearer <access-token>
+```
+
+The granted scopes match what the user approved on the consent screen, limited to the chosen
+project.
+
+## 5. Refresh tokens
+
+Access tokens expire after about an hour. Use the refresh token to get a new one. Refresh
+tokens **rotate** — store the new refresh token from each response and discard the old one.
+
+```bash
+curl -X POST https://agentstate.app/api/oauth/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d grant_type=refresh_token \
+  -d refresh_token=<refresh-token> \
+  -d client_id=client_abc123
+```
+
+```json
+{
+  "access_token": "<new-access-token>",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "refresh_token": "<new-refresh-token>",
+  "scope": "conversations:read conversations:write state:read state:write"
+}
+```
+
+## Related docs
+
+- [Remote MCP server](mcp.md#remote-mcp-server-hosted) — connect MCP clients via OAuth or a token
+- [Permissions & Scopes](permissions.md) — what each scope grants
+- [API Reference](api-reference.md) — REST API surface

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,123 @@
+# Permissions & Scopes
+
+API keys, capability tokens, and OAuth access tokens carry **scopes** that decide which
+endpoints they can call. Scopes give you least-privilege keys: a key for a read-only
+dashboard can be limited to `conversations:read`, a key handed to an untrusted worker can
+be limited to `state:write`, and so on.
+
+## Scope taxonomy
+
+| Scope | What it grants |
+|-------|----------------|
+| `conversations:read` | Read conversations and messages, list, search, export. |
+| `conversations:write` | Create conversations, append messages, update, delete, tag. |
+| `state:read` | Read state records, list events, run state queries. |
+| `state:write` | Create, replace, and delete state records. |
+| `state:watch` | Watch state events over SSE. |
+| `leases:write` | Acquire, renew, and release write leases. |
+| `claims:write` | Create claims and run verification. |
+| `analytics:read` | Read analytics summaries, time-series, and tag stats. |
+| `webhooks:write` | Create, update, and delete webhooks. |
+| `domains:write` | Manage custom domains. |
+| `keys:read` | List API keys for the project. |
+| `keys:write` | Create and revoke API keys. |
+
+### Wildcards
+
+| Scope | What it grants |
+|-------|----------------|
+| `*` | Full access — every scope above. |
+| `state:*` | Every `state:` scope (`state:read`, `state:write`, `state:watch`). |
+| `conversations:*` | Every `conversations:` scope. |
+| `keys:*` | Every `keys:` scope. |
+
+A per-resource wildcard (`state:*`) covers all current and future actions on that resource.
+
+## Legacy and unscoped keys are full access
+
+A key created **without** a `scopes` array — and any key created before scopes existed — has
+**full access** (equivalent to `*`). The `scopes` field on these keys is `null`. You only
+narrow a key by explicitly passing a `scopes` array at creation time.
+
+## Create a scoped key
+
+Use the keyless `POST /api/v1/keys` endpoint with a `scopes` array. The project is taken
+from the API key you authenticate with.
+
+```bash
+curl -X POST https://agentstate.app/api/v1/keys \
+  -H "Authorization: Bearer as_live_your_key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "read-only dashboard",
+    "scopes": ["conversations:read", "analytics:read"]
+  }'
+```
+
+Response (the `key` value is shown only once):
+
+```json
+{
+  "key_id": "key_abc123",
+  "project_id": "proj_abc123",
+  "name": "read-only dashboard",
+  "key_prefix": "as_live_xxxx",
+  "key": "as_live_full_key_shown_only_once",
+  "scopes": ["conversations:read", "analytics:read"],
+  "created_at": 1710000000000,
+  "last_used_at": null,
+  "revoked_at": null
+}
+```
+
+The `scopes` field is also returned when you list keys (`GET /api/v1/keys`). It is `null`
+for full-access keys.
+
+To grant full access, omit `scopes` (or pass `["*"]`).
+
+## Subset rule (delegation)
+
+A key can only mint child keys whose scopes are a **subset of its own**. This keeps
+delegation safe: a worker holding a `state:write` key can hand out a narrower key but never
+a broader one.
+
+- A full-access key (`null` scopes or `*`) can mint a key with any scopes.
+- A key scoped to `["state:read", "state:write"]` can mint `["state:read"]` but **not**
+  `["conversations:write"]`.
+- A per-resource wildcard counts: a `state:*` key can mint `["state:write"]`.
+
+Dashboard key creation (`POST /api/v1/projects/:id/keys`, authenticated with a Clerk
+session) is **not** restricted by the subset rule — a signed-in project member may grant any
+scopes. The subset rule applies to API/MCP key creation, where you authenticate with a key
+or token rather than a session.
+
+## Out-of-scope requests return 403
+
+When a key, token, or OAuth access token calls an endpoint outside its scopes, the request
+is rejected with HTTP **403**:
+
+```json
+{
+  "error": {
+    "code": "FORBIDDEN",
+    "message": "This key does not have the required scope: state:write"
+  }
+}
+```
+
+Branch on `error.code`, not the message text.
+
+## Where scopes apply
+
+- **API keys** (`as_live_...`) — set scopes at creation; see above.
+- **Capability tokens** (`as_cap_...`) — minted with explicit scopes for sub-agent
+  delegation. See [Recipe: Capability Tokens](recipes/capability-tokens.md).
+- **OAuth access tokens** — the user approves a set of scopes on the
+  [consent screen](oauth.md) when an MCP client connects.
+
+## Related docs
+
+- [OAuth 2.1](oauth.md) — browser auth flow where users approve scopes
+- [Remote MCP server](mcp.md#remote-mcp-server-hosted) — connect MCP clients with scoped tokens
+- [API Reference](api-reference.md) — the `/api/v1/keys` endpoints
+- [Recipe: Capability Tokens](recipes/capability-tokens.md) — scoped delegation tokens

--- a/packages/api/src/content/agents.md
+++ b/packages/api/src/content/agents.md
@@ -479,8 +479,44 @@ Conversations and state live under a project. Create and manage projects with:
 | POST | `/api/v1/projects` | Create project (body: `name`, `slug`) |
 | GET | `/api/v1/projects` | List projects |
 | GET | `/api/v1/projects/:id` | Get project with keys |
-| POST | `/api/v1/projects/:id/keys` | Generate API key |
+| POST | `/api/v1/projects/:id/keys` | Generate API key (body: `name`, `scopes?`) |
 | DELETE | `/api/v1/projects/:id/keys/:keyId` | Revoke API key |
+
+You can also manage keys with just an API key (no project ID — it's taken from the calling key):
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/api/v1/keys` | Create API key — body `{name, scopes?}` |
+| GET | `/api/v1/keys` | List API keys (each has a `scopes` field) |
+| DELETE | `/api/v1/keys/:id` | Revoke an API key |
+
+## Permissions / Scopes
+
+Keys, capability tokens, and OAuth access tokens carry scopes that limit which endpoints they
+can call. A key created **without** a `scopes` array — and any legacy key — has full access
+(`scopes` is `null`). Pass `scopes` on key creation to narrow it.
+
+Scopes: `conversations:read`, `conversations:write`, `state:read`, `state:write`,
+`state:watch`, `leases:write`, `claims:write`, `analytics:read`, `webhooks:write`,
+`domains:write`, `keys:read`, `keys:write`. `*` is full access; per-resource wildcards like
+`state:*` cover all actions on a resource.
+
+A key can only mint child keys whose scopes are a **subset** of its own. Out-of-scope
+requests return `403 FORBIDDEN` — branch on `error.code`.
+
+## Remote MCP server + OAuth
+
+A hosted MCP server is available at `POST /api/mcp` (Streamable HTTP JSON-RPC: `initialize`,
+`tools/list`, `tools/call`, `ping`). Authenticate with `Authorization: Bearer <token>`, where
+the token is an API key (`as_live_...`), a capability token (`as_cap_...`), or an OAuth access
+token. Each tool requires a scope.
+
+For browser auth, AgentState is both the authorization and resource server (OAuth 2.1 + PKCE):
+discovery at `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server`,
+Dynamic Client Registration at `POST /api/oauth/register`, the authorize → consent → token
+flow at `GET /api/oauth/authorize` and `POST /api/oauth/token`, with refresh-token rotation.
+A `401` from the API or MCP endpoint returns
+`WWW-Authenticate: Bearer resource_metadata=".../.well-known/oauth-protected-resource"`.
 
 ```typescript
 const response = await fetch("https://agentstate.app/api/v1/projects", {

--- a/packages/api/src/content/llms.txt
+++ b/packages/api/src/content/llms.txt
@@ -60,8 +60,32 @@ Both SDKs cover the full surface below with the same method names (TS camelCase,
 - POST   /api/v1/projects — Create project (body: name, slug)
 - GET    /api/v1/projects — List projects
 - GET    /api/v1/projects/:id — Get project with API keys
-- POST   /api/v1/projects/:id/keys — Generate API key
+- POST   /api/v1/projects/:id/keys — Generate API key (body: name, scopes?)
 - DELETE /api/v1/projects/:id/keys/:keyId — Revoke API key
+
+## API Key Management (keyless — project taken from the authenticating key)
+
+- POST   /api/v1/keys — Create API key (body: {name, scopes?}); scopes must be a subset of the calling key's
+- GET    /api/v1/keys — List API keys (each has a scopes field: string[] | null, null = full access)
+- DELETE /api/v1/keys/:id — Revoke an API key
+
+## Permissions / Scopes
+
+Keys, capability tokens, and OAuth access tokens carry scopes. A key created without scopes
+(or any legacy key) has full access (scopes = null). Scopes: conversations:read,
+conversations:write, state:read, state:write, state:watch, leases:write, claims:write,
+analytics:read, webhooks:write, domains:write, keys:read, keys:write. `*` = full access;
+per-resource wildcards like state:* cover all actions on a resource. A key can only mint
+child keys whose scopes are a subset of its own. Out-of-scope requests return 403 FORBIDDEN.
+
+## Remote MCP server + OAuth
+
+- POST /api/mcp — Hosted MCP server (Streamable HTTP JSON-RPC: initialize, tools/list, tools/call, ping).
+  Auth: Authorization: Bearer <token> where token is an API key (as_live_), capability token
+  (as_cap_), or OAuth access token. Each tool requires a scope.
+- OAuth 2.1 + PKCE discovery: GET /.well-known/oauth-protected-resource (RFC 9728),
+  GET /.well-known/oauth-authorization-server (RFC 8414), POST /api/oauth/register (RFC 7591),
+  GET /api/oauth/authorize (consent screen), POST /api/oauth/token (exchange + refresh rotation).
 
 ## Message Format
 

--- a/packages/api/src/content/openapi.ts
+++ b/packages/api/src/content/openapi.ts
@@ -206,6 +206,13 @@ export const OPENAPI_SPEC = `{
             "type": "string",
             "example": "as_live_abc1"
           },
+          "scopes": {
+            "type": "array",
+            "items": {"type": "string"},
+            "nullable": true,
+            "description": "Permission scopes. null means full access (legacy and unscoped keys).",
+            "example": ["conversations:read", "conversations:write"]
+          },
           "created_at": {
             "type": "integer",
             "description": "Unix timestamp in milliseconds",
@@ -361,6 +368,14 @@ export const OPENAPI_SPEC = `{
     {
       "name": "Tags",
       "description": "Tag conversations with labels for filtering and organization"
+    },
+    {
+      "name": "MCP",
+      "description": "Hosted Model Context Protocol server (Streamable HTTP)"
+    },
+    {
+      "name": "OAuth",
+      "description": "OAuth 2.1 + PKCE discovery and authorization"
     }
   ],
   "paths": {
@@ -1276,6 +1291,12 @@ export const OPENAPI_SPEC = `{
                     "type": "string",
                     "minLength": 1,
                     "example": "Production"
+                  },
+                  "scopes": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Permission scopes for the new key. Omit for full access. The dashboard route (Clerk session) may grant any scopes.",
+                    "example": ["conversations:read"]
                   }
                 }
               }
@@ -1298,6 +1319,13 @@ export const OPENAPI_SPEC = `{
                       "type": "string",
                       "description": "Full API key — shown only once. Store it securely.",
                       "example": "as_live_abc123fullkey"
+                    },
+                    "scopes": {
+                      "type": "array",
+                      "items": {"type": "string"},
+                      "nullable": true,
+                      "description": "null means full access",
+                      "example": ["conversations:read"]
                     },
                     "created_at": {"type": "integer", "example": 1710500000000}
                   }
@@ -1370,6 +1398,12 @@ export const OPENAPI_SPEC = `{
                     "type": "string",
                     "minLength": 1,
                     "example": "Staging"
+                  },
+                  "scopes": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Permission scopes for the new key. Omit for full access. Must be a subset of the authenticating key's scopes.",
+                    "example": ["state:read", "state:write"]
                   }
                 }
               }
@@ -1389,6 +1423,7 @@ export const OPENAPI_SPEC = `{
                     "name": {"type": "string"},
                     "key_prefix": {"type": "string"},
                     "key": {"type": "string", "description": "Full key — shown only once"},
+                    "scopes": {"type": "array", "items": {"type": "string"}, "nullable": true, "description": "null means full access"},
                     "created_at": {"type": "integer"},
                     "last_used_at": {"type": "integer", "nullable": true},
                     "revoked_at": {"type": "integer", "nullable": true}
@@ -1601,6 +1636,268 @@ export const OPENAPI_SPEC = `{
           },
           "401": {"$ref": "#/components/responses/Unauthorized"},
           "404": {"$ref": "#/components/responses/NotFound"}
+        }
+      }
+    },
+    "/api/v1/keys": {
+      "post": {
+        "tags": ["Keys"],
+        "summary": "Create API key",
+        "description": "Create a new API key for the authenticated project (project taken from the calling key). Optional 'scopes' must be a subset of the calling key's scopes.",
+        "operationId": "createKey",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {"type": "string", "minLength": 1, "example": "read-only dashboard"},
+                  "scopes": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Permission scopes. Omit for full access. Must be a subset of the calling key's scopes.",
+                    "example": ["conversations:read", "analytics:read"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "API key created. The full key value is only returned once.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["key_id", "project_id", "name", "key_prefix", "key", "created_at"],
+                  "properties": {
+                    "key_id": {"type": "string", "example": "key_V1StGXR8"},
+                    "project_id": {"type": "string", "example": "pj_V1StGXR8"},
+                    "name": {"type": "string", "example": "read-only dashboard"},
+                    "key_prefix": {"type": "string", "example": "as_live_abc1"},
+                    "key": {"type": "string", "description": "Full API key — shown only once.", "example": "as_live_abc123fullkey"},
+                    "scopes": {"type": "array", "items": {"type": "string"}, "nullable": true, "description": "null means full access", "example": ["conversations:read", "analytics:read"]},
+                    "created_at": {"type": "integer", "example": 1710500000000},
+                    "last_used_at": {"type": "integer", "nullable": true, "example": null},
+                    "revoked_at": {"type": "integer", "nullable": true, "example": null}
+                  }
+                }
+              }
+            }
+          },
+          "400": {"$ref": "#/components/responses/BadRequest"},
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"}
+        }
+      },
+      "get": {
+        "tags": ["Keys"],
+        "summary": "List API keys",
+        "description": "List all API keys for the authenticated project (including revoked ones). Project taken from the calling key.",
+        "operationId": "listKeys",
+        "responses": {
+          "200": {
+            "description": "List of API keys",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["data"],
+                  "properties": {
+                    "data": {"type": "array", "items": {"$ref": "#/components/schemas/ApiKey"}}
+                  }
+                }
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      }
+    },
+    "/api/v1/keys/{id}": {
+      "delete": {
+        "tags": ["Keys"],
+        "summary": "Revoke API key",
+        "description": "Revoke an API key for the authenticated project. The key is soft-deleted and stops authenticating immediately.",
+        "operationId": "revokeKey",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "API key ID",
+            "schema": {"type": "string"},
+            "example": "key_V1StGXR8"
+          }
+        ],
+        "responses": {
+          "204": {"description": "Key revoked"},
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"}
+        }
+      }
+    },
+    "/api/mcp": {
+      "post": {
+        "tags": ["MCP"],
+        "summary": "Remote MCP server",
+        "description": "Hosted Model Context Protocol server over Streamable HTTP (stateless JSON-RPC). Methods: initialize, tools/list, tools/call, ping. Authenticate with 'Authorization: Bearer <token>' where the token is an API key (as_live_), a capability token (as_cap_), or an OAuth access token. Each tool requires a scope. A 401 returns a WWW-Authenticate header pointing to /.well-known/oauth-protected-resource.",
+        "operationId": "mcpJsonRpc",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["jsonrpc", "method"],
+                "properties": {
+                  "jsonrpc": {"type": "string", "example": "2.0"},
+                  "id": {"description": "Request id", "example": 1},
+                  "method": {"type": "string", "example": "tools/list"},
+                  "params": {"type": "object", "additionalProperties": true}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "JSON-RPC response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "jsonrpc": {"type": "string", "example": "2.0"},
+                    "id": {},
+                    "result": {"type": "object", "additionalProperties": true}
+                  }
+                }
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"}
+        }
+      }
+    },
+    "/.well-known/oauth-protected-resource": {
+      "get": {
+        "tags": ["OAuth"],
+        "summary": "Protected resource metadata (RFC 9728)",
+        "description": "OAuth 2.0 protected resource metadata. Points clients at the authorization server. No authentication required.",
+        "operationId": "oauthProtectedResource",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Resource metadata",
+            "content": {"application/json": {"schema": {"type": "object", "additionalProperties": true}}}
+          }
+        }
+      }
+    },
+    "/.well-known/oauth-authorization-server": {
+      "get": {
+        "tags": ["OAuth"],
+        "summary": "Authorization server metadata (RFC 8414)",
+        "description": "OAuth 2.1 authorization server metadata: endpoints, supported scopes, grant types, and PKCE methods. No authentication required.",
+        "operationId": "oauthAuthorizationServer",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Authorization server metadata",
+            "content": {"application/json": {"schema": {"type": "object", "additionalProperties": true}}}
+          }
+        }
+      }
+    },
+    "/api/oauth/register": {
+      "post": {
+        "tags": ["OAuth"],
+        "summary": "Dynamic Client Registration (RFC 7591)",
+        "description": "Register an OAuth client dynamically. Public clients use token_endpoint_auth_method 'none' with PKCE. No authentication required.",
+        "operationId": "oauthRegister",
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {"application/json": {"schema": {"type": "object", "additionalProperties": true}}}
+        },
+        "responses": {
+          "201": {
+            "description": "Client registered",
+            "content": {"application/json": {"schema": {"type": "object", "additionalProperties": true}}}
+          }
+        }
+      }
+    },
+    "/api/oauth/authorize": {
+      "get": {
+        "tags": ["OAuth"],
+        "summary": "Authorization endpoint (authorization code + PKCE)",
+        "description": "Starts the authorization-code + PKCE (S256) flow. The user signs in, picks a project, and approves scopes on a consent screen, then is redirected back with a 'code'. No API authentication required.",
+        "operationId": "oauthAuthorize",
+        "security": [],
+        "parameters": [
+          {"name": "response_type", "in": "query", "required": true, "schema": {"type": "string"}, "example": "code"},
+          {"name": "client_id", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "redirect_uri", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "scope", "in": "query", "required": false, "schema": {"type": "string"}, "example": "conversations:read state:write"},
+          {"name": "state", "in": "query", "required": false, "schema": {"type": "string"}},
+          {"name": "code_challenge", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "code_challenge_method", "in": "query", "required": true, "schema": {"type": "string"}, "example": "S256"}
+        ],
+        "responses": {
+          "302": {"description": "Redirect to redirect_uri with code (after consent) or an error"}
+        }
+      }
+    },
+    "/api/oauth/token": {
+      "post": {
+        "tags": ["OAuth"],
+        "summary": "Token endpoint (exchange + refresh)",
+        "description": "Exchange an authorization code (with PKCE verifier) for tokens, or refresh an access token. Refresh tokens rotate. No client secret for public clients. Content type application/x-www-form-urlencoded.",
+        "operationId": "oauthToken",
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "grant_type": {"type": "string", "example": "authorization_code"},
+                  "code": {"type": "string"},
+                  "redirect_uri": {"type": "string"},
+                  "client_id": {"type": "string"},
+                  "code_verifier": {"type": "string"},
+                  "refresh_token": {"type": "string"}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Token response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "access_token": {"type": "string"},
+                    "token_type": {"type": "string", "example": "Bearer"},
+                    "expires_in": {"type": "integer", "example": 3600},
+                    "refresh_token": {"type": "string"},
+                    "scope": {"type": "string"}
+                  }
+                }
+              }
+            }
+          },
+          "400": {"$ref": "#/components/responses/BadRequest"}
         }
       }
     }

--- a/packages/api/src/content/static.ts
+++ b/packages/api/src/content/static.ts
@@ -63,8 +63,32 @@ Both SDKs cover the full surface below with the same method names (TS camelCase,
 - POST   /api/v1/projects — Create project (body: name, slug)
 - GET    /api/v1/projects — List projects
 - GET    /api/v1/projects/:id — Get project with API keys
-- POST   /api/v1/projects/:id/keys — Generate API key
+- POST   /api/v1/projects/:id/keys — Generate API key (body: name, scopes?)
 - DELETE /api/v1/projects/:id/keys/:keyId — Revoke API key
+
+## API Key Management (keyless — project taken from the authenticating key)
+
+- POST   /api/v1/keys — Create API key (body: {name, scopes?}); scopes must be a subset of the calling key's
+- GET    /api/v1/keys — List API keys (each has a scopes field: string[] | null, null = full access)
+- DELETE /api/v1/keys/:id — Revoke an API key
+
+## Permissions / Scopes
+
+Keys, capability tokens, and OAuth access tokens carry scopes. A key created without scopes
+(or any legacy key) has full access (scopes = null). Scopes: conversations:read,
+conversations:write, state:read, state:write, state:watch, leases:write, claims:write,
+analytics:read, webhooks:write, domains:write, keys:read, keys:write. \`*\` = full access;
+per-resource wildcards like state:* cover all actions on a resource. A key can only mint
+child keys whose scopes are a subset of its own. Out-of-scope requests return 403 FORBIDDEN.
+
+## Remote MCP server + OAuth
+
+- POST /api/mcp — Hosted MCP server (Streamable HTTP JSON-RPC: initialize, tools/list, tools/call, ping).
+  Auth: Authorization: Bearer <token> where token is an API key (as_live_), capability token
+  (as_cap_), or OAuth access token. Each tool requires a scope.
+- OAuth 2.1 + PKCE discovery: GET /.well-known/oauth-protected-resource (RFC 9728),
+  GET /.well-known/oauth-authorization-server (RFC 8414), POST /api/oauth/register (RFC 7591),
+  GET /api/oauth/authorize (consent screen), POST /api/oauth/token (exchange + refresh rotation).
 
 ## Message Format
 
@@ -569,8 +593,44 @@ Conversations and state live under a project. Create and manage projects with:
 | POST | \`/api/v1/projects\` | Create project (body: \`name\`, \`slug\`) |
 | GET | \`/api/v1/projects\` | List projects |
 | GET | \`/api/v1/projects/:id\` | Get project with keys |
-| POST | \`/api/v1/projects/:id/keys\` | Generate API key |
+| POST | \`/api/v1/projects/:id/keys\` | Generate API key (body: \`name\`, \`scopes?\`) |
 | DELETE | \`/api/v1/projects/:id/keys/:keyId\` | Revoke API key |
+
+You can also manage keys with just an API key (no project ID — it's taken from the calling key):
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | \`/api/v1/keys\` | Create API key — body \`{name, scopes?}\` |
+| GET | \`/api/v1/keys\` | List API keys (each has a \`scopes\` field) |
+| DELETE | \`/api/v1/keys/:id\` | Revoke an API key |
+
+## Permissions / Scopes
+
+Keys, capability tokens, and OAuth access tokens carry scopes that limit which endpoints they
+can call. A key created **without** a \`scopes\` array — and any legacy key — has full access
+(\`scopes\` is \`null\`). Pass \`scopes\` on key creation to narrow it.
+
+Scopes: \`conversations:read\`, \`conversations:write\`, \`state:read\`, \`state:write\`,
+\`state:watch\`, \`leases:write\`, \`claims:write\`, \`analytics:read\`, \`webhooks:write\`,
+\`domains:write\`, \`keys:read\`, \`keys:write\`. \`*\` is full access; per-resource wildcards like
+\`state:*\` cover all actions on a resource.
+
+A key can only mint child keys whose scopes are a **subset** of its own. Out-of-scope
+requests return \`403 FORBIDDEN\` — branch on \`error.code\`.
+
+## Remote MCP server + OAuth
+
+A hosted MCP server is available at \`POST /api/mcp\` (Streamable HTTP JSON-RPC: \`initialize\`,
+\`tools/list\`, \`tools/call\`, \`ping\`). Authenticate with \`Authorization: Bearer <token>\`, where
+the token is an API key (\`as_live_...\`), a capability token (\`as_cap_...\`), or an OAuth access
+token. Each tool requires a scope.
+
+For browser auth, AgentState is both the authorization and resource server (OAuth 2.1 + PKCE):
+discovery at \`/.well-known/oauth-protected-resource\` and \`/.well-known/oauth-authorization-server\`,
+Dynamic Client Registration at \`POST /api/oauth/register\`, the authorize → consent → token
+flow at \`GET /api/oauth/authorize\` and \`POST /api/oauth/token\`, with refresh-token rotation.
+A \`401\` from the API or MCP endpoint returns
+\`WWW-Authenticate: Bearer resource_metadata=".../.well-known/oauth-protected-resource"\`.
 
 \`\`\`typescript
 const response = await fetch("https://agentstate.app/api/v1/projects", {

--- a/packages/dashboard/src/components/docs/docs-data.ts
+++ b/packages/dashboard/src/components/docs/docs-data.ts
@@ -21,6 +21,14 @@ export const DOC_NAV: DocNavGroup[] = [
     items: [["ai-sdk", "Vercel AI SDK"]],
   },
   {
+    group: "REMOTE",
+    items: [
+      ["mcp", "Remote MCP"],
+      ["oauth", "OAuth"],
+      ["permissions", "Permissions"],
+    ],
+  },
+  {
     group: "OPS",
     items: [["analytics", "Analytics"]],
   },
@@ -31,6 +39,9 @@ export const ON_THIS_PAGE: [id: string, label: string][] = [
   ["auth", "Authentication"],
   ["conversations", "Conversations"],
   ["ai-sdk", "Adapters"],
+  ["mcp", "Remote MCP"],
+  ["oauth", "OAuth"],
+  ["permissions", "Permissions"],
   ["analytics", "Analytics"],
 ];
 
@@ -68,4 +79,29 @@ export const ANALYTICS_ENDPOINTS: [method: string, path: string][] = [
   ["GET", "/api/v1/analytics/summary"],
   ["GET", "/api/v1/analytics/timeseries"],
   ["GET", "/api/v1/analytics/tags"],
+];
+
+export const MCP_CONFIG = `{
+  "mcpServers": {
+    "agentstate": {
+      "type": "http",
+      "url": "https://agentstate.app/api/mcp",
+      "headers": { "Authorization": "Bearer as_live_your_key" }
+    }
+  }
+}`;
+
+export const PERMISSION_SCOPES: [scope: string, grants: string][] = [
+  ["conversations:read", "Read, list, search, export conversations"],
+  ["conversations:write", "Create, append, update, delete, tag"],
+  ["state:read", "Read state, list events, query"],
+  ["state:write", "Create, replace, delete state"],
+  ["state:watch", "Watch state events"],
+  ["leases:write", "Acquire, renew, release leases"],
+  ["claims:write", "Create and verify claims"],
+  ["analytics:read", "Read analytics"],
+  ["webhooks:write", "Manage webhooks"],
+  ["domains:write", "Manage custom domains"],
+  ["keys:read", "List API keys"],
+  ["keys:write", "Create and revoke API keys"],
 ];

--- a/packages/dashboard/src/pages/docs.astro
+++ b/packages/dashboard/src/pages/docs.astro
@@ -27,6 +27,14 @@ const navGroups: { group: string; items: [id: string, label: string][] }[] = [
     group: "Adapters",
     items: [["ai-sdk", "Vercel AI SDK"]],
   },
+  {
+    group: "Remote",
+    items: [
+      ["mcp", "Remote MCP"],
+      ["oauth", "OAuth"],
+      ["permissions", "Permissions"],
+    ],
+  },
 ];
 
 // Right TOC — same anchors in document order.
@@ -37,6 +45,9 @@ const onThisPage: [id: string, label: string][] = [
   ["auth", "Authentication"],
   ["conversations", "Conversations"],
   ["ai-sdk", "Adapters"],
+  ["mcp", "Remote MCP"],
+  ["oauth", "OAuth"],
+  ["permissions", "Permissions"],
   ["analytics", "Analytics"],
 ];
 
@@ -109,6 +120,45 @@ const store = createAISDKChatStore(
 );
 const chatId = await store.createChat();
 await store.saveChat({ chatId, messages });`;
+
+// biome-ignore lint/correctness/noUnusedVariables: used in the template below
+const mcpConfig = `{
+  "mcpServers": {
+    "agentstate": {
+      "type": "http",
+      "url": "https://agentstate.app/api/mcp",
+      "headers": { "Authorization": "Bearer as_live_your_key" }
+    }
+  }
+}`;
+
+// biome-ignore lint/correctness/noUnusedVariables: used in the template below
+const oauthSteps: [step: string, detail: string][] = [
+  [
+    "1. Discover",
+    "GET /.well-known/oauth-protected-resource and /.well-known/oauth-authorization-server",
+  ],
+  ["2. Register", "POST /api/oauth/register (Dynamic Client Registration)"],
+  ["3. Authorize", "GET /api/oauth/authorize → sign in, pick a project, approve scopes"],
+  ["4. Token", "POST /api/oauth/token — exchange code + PKCE verifier for tokens"],
+  ["5. Refresh", "POST /api/oauth/token with grant_type=refresh_token (tokens rotate)"],
+];
+
+// biome-ignore lint/correctness/noUnusedVariables: used in the template below
+const permissionScopes: [scope: string, grants: string][] = [
+  ["conversations:read", "Read, list, search, export conversations"],
+  ["conversations:write", "Create, append, update, delete, tag"],
+  ["state:read", "Read state, list events, query"],
+  ["state:write", "Create, replace, delete state"],
+  ["state:watch", "Watch state events"],
+  ["leases:write", "Acquire, renew, release leases"],
+  ["claims:write", "Create and verify claims"],
+  ["analytics:read", "Read analytics"],
+  ["webhooks:write", "Manage webhooks"],
+  ["domains:write", "Manage custom domains"],
+  ["keys:read", "List API keys"],
+  ["keys:write", "Create and revoke API keys"],
+];
 ---
 <MarketingLayout
   title="Docs — AgentState"
@@ -289,6 +339,64 @@ await store.saveChat({ chatId, messages });`;
           }
         </div>
 
+        <!-- Remote MCP -->
+        <h2 id="mcp" class="mt-12 mb-1.5 scroll-mt-20 text-[22px] font-semibold tracking-[-0.02em] text-fg">Remote MCP</h2>
+        <p class="mt-2 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
+          Connect Cursor, Claude Desktop, Windsurf, and any MCP client to the hosted server at
+          <code class="font-mono text-fg">https://agentstate.app/api/mcp</code> — no install. Authenticate with a Bearer
+          API key or capability token, or let the client run the OAuth flow.
+        </p>
+        <div class="mt-3.5 overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-[#0c0c0e]">
+          <div class="flex h-9 items-center border-b border-edge-soft px-4 font-mono text-[11px] text-fg-4">mcp.json</div>
+          <pre class="overflow-auto bg-[#0c0c0e] p-4 font-mono text-[12.5px] leading-[1.75] text-zinc-300"><code>{mcpConfig}</code></pre>
+        </div>
+        <div class="mt-3.5 flex gap-2.5 rounded-[var(--radius-lg)] border border-edge bg-panel2 px-3.5 py-3">
+          <span class="mt-px size-1.5 flex-shrink-0 rounded-full bg-accent"></span>
+          <span class="text-[13.5px] leading-[1.5] text-fg-3">
+            Tools mirror the local stdio server plus key management. Each tool needs a <a href="#permissions" class="text-fg underline-offset-2 hover:underline">scope</a>.
+          </span>
+        </div>
+
+        <!-- OAuth -->
+        <h2 id="oauth" class="mt-12 mb-1.5 scroll-mt-20 text-[22px] font-semibold tracking-[-0.02em] text-fg">OAuth</h2>
+        <p class="mt-2 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
+          OAuth 2.1 + PKCE lets MCP clients connect without pasting a key. The user signs in, picks a
+          project, and approves scopes on a consent screen. AgentState is both the authorization and
+          resource server.
+        </p>
+        <Card class="mt-3.5 overflow-hidden p-0">
+          <ul class="divide-y divide-edge-soft">
+            {
+              oauthSteps.map(([step, detail]) => (
+                <li class="flex flex-wrap items-baseline gap-x-3 gap-y-1 px-4 py-3">
+                  <span class="font-mono text-[12px] font-medium text-fg">{step}</span>
+                  <span class="ml-auto text-right text-[12.5px] text-fg-4">{detail}</span>
+                </li>
+              ))
+            }
+          </ul>
+        </Card>
+
+        <!-- Permissions -->
+        <h2 id="permissions" class="mt-12 mb-1.5 scroll-mt-20 text-[22px] font-semibold tracking-[-0.02em] text-fg">Permissions</h2>
+        <p class="mt-2 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
+          Keys and tokens carry scopes. A key created without scopes (or any legacy key) has full
+          access. A key can only mint child keys with a subset of its own scopes; out-of-scope
+          requests return <code class="font-mono text-fg">403 FORBIDDEN</code>.
+        </p>
+        <Card class="mt-3.5 overflow-hidden p-0">
+          <ul class="divide-y divide-edge-soft">
+            {
+              permissionScopes.map(([scope, grants]) => (
+                <li class="flex flex-wrap items-baseline gap-x-3 gap-y-1 px-4 py-3">
+                  <span class="font-mono text-[12.5px] text-fg">{scope}</span>
+                  <span class="ml-auto text-right text-[12.5px] text-fg-4">{grants}</span>
+                </li>
+              ))
+            }
+          </ul>
+        </Card>
+
         <!-- Analytics -->
         <h2 id="analytics" class="mt-12 mb-1.5 scroll-mt-20 text-[22px] font-semibold tracking-[-0.02em] text-fg">Analytics</h2>
         <p class="mt-2 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
@@ -346,7 +454,7 @@ await store.saveChat({ chatId, messages });`;
     // Scrollspy: mark the section nearest the viewport top as current in both nav and TOC.
     const navLinks = document.querySelectorAll<HTMLAnchorElement>("[data-nav]");
     const tocLinks = document.querySelectorAll<HTMLAnchorElement>("[data-toc]");
-    const sections = ["overview", "agent-prompt", "quickstart", "auth", "conversations", "ai-sdk", "analytics"]
+    const sections = ["overview", "agent-prompt", "quickstart", "auth", "conversations", "ai-sdk", "mcp", "oauth", "permissions", "analytics"]
       .map((id) => document.getElementById(id))
       .filter((el): el is HTMLElement => el !== null);
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,6 +4,8 @@ MCP (Model Context Protocol) server for [AgentState](https://agentstate.app).
 
 Expose AgentState's conversation history, state management, distributed leases, verifiable claims, and capability tokens as MCP tools — usable from Claude Desktop, Cursor, Windsurf, and any MCP-compatible client.
 
+> **Prefer a hosted server?** A remote MCP server is also available at `https://agentstate.app/api/mcp` (Streamable HTTP). Point your client at the URL and authenticate with a Bearer API key, a capability token, or OAuth — no local install. See [docs/mcp.md](https://github.com/duyet/agentstate/blob/main/docs/mcp.md#remote-mcp-server-hosted). This package is the local stdio server, for token-based local use.
+
 ## Tools
 
 | Tool | What it does |


### PR DESCRIPTION
Documents the new remote MCP + OAuth + scoped-permissions feature (U6).

## What

- **`docs/mcp.md`** — new "Remote MCP server (hosted)" section: the `POST https://agentstate.app/api/mcp` URL, both auth modes (Bearer token and OAuth), an example Streamable-HTTP client config, and the scopes list. Local stdio content kept below.
- **`docs/oauth.md`** (new) — OAuth 2.1 + PKCE end-to-end: discovery (RFC 9728 / 8414) with example JSON, DCR (RFC 7591), authorize → consent → token with a `curl` exchange, refresh-token rotation, and the note that AgentState is both authorization and resource server.
- **`docs/permissions.md`** (new) — scope taxonomy table, creating a scoped key via `POST /api/v1/keys`, the subset/delegation rule, 403 behavior, and that legacy/unscoped keys are full access.
- **`docs/INDEX.md`** — links to the two new guides + updated MCP description.
- **`docs/api-reference.md`** — `scopes` request + response field on key creation, the keyless `/api/v1/keys` endpoints, a Permissions & scopes subsection, and a Remote MCP + OAuth discovery section.
- **`packages/api/src/content/`** — `llms.txt` + `agents.md` (regenerated `static.ts`) and `openapi.ts` mention `/api/mcp`, OAuth discovery, the `scopes` field, and `/api/v1/keys`. OpenAPI JSON validated.
- **dashboard `/docs`** — `docs-data.ts` nav entries + `docs.astro` Remote MCP / OAuth / Permissions sections (concise, inline CodeBlock pattern).
- **`packages/mcp/README.md`** — note that a hosted remote server is also available.

## Verification

- `bunx tsc --noEmit -p packages/api/tsconfig.json` → clean
- `bunx vitest run` (changed `src/content/*`) → content/openapi tests pass; the only failures are in `oauth.test.ts`, which is the U2 OAuth implementation still being built in this worktree (unrelated to docs)
- OpenAPI `OPENAPI_SPEC` parses as valid JSON; all 8 new paths + the `scopes` schema present
- `astro check` → no diagnostics for `docs.astro` / `docs-data.ts` (2 pre-existing errors in unrelated `brand.astro`)
- Internal doc links and anchors resolve

Docs only — no build run.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>