### PR TITLE
feat(api): OAuth 2.1 authorization server + discovery for remote MCP

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -13,6 +13,8 @@ import analyticsPublicRouter from "./routes/analytics-public";
 import conversationsRouter from "./routes/conversations";
 import domainsRouter from "./routes/domains";
 import keysRouter from "./routes/keys";
+import oauthDiscoveryRouter from "./routes/oauth/discovery";
+import oauthRouter from "./routes/oauth/index";
 import projectTracesRouter from "./routes/project-traces";
 import projectsRouter from "./routes/projects";
 import tagsRouter from "./routes/tags";
@@ -99,6 +101,15 @@ app.get("/api", (c) => {
 app.get("/llms.txt", (c) => c.text(LLMS_TXT));
 app.get("/agents.md", (c) => c.text(AGENTS_MD));
 app.get("/openapi.json", (c) => c.json(JSON.parse(OPENAPI_SPEC)));
+
+// ---------------------------------------------------------------------------
+// OAuth 2.1 authorization server + discovery (remote MCP auth)
+// ---------------------------------------------------------------------------
+// Discovery metadata lives at the root (.well-known/*); the authorization
+// server endpoints live under /api/oauth. Public except /authorize/decision,
+// which is Clerk-authed inside its own handler.
+app.route("/", oauthDiscoveryRouter);
+app.route("/api/oauth", oauthRouter);
 
 // ---------------------------------------------------------------------------
 // Unified API at /api/v1/*

--- a/packages/api/src/lib/id.ts
+++ b/packages/api/src/lib/id.ts
@@ -14,3 +14,11 @@ export function generateApiKey(): string {
 export function generateCapabilityToken(): string {
   return `as_cap_${generateSecret()}`;
 }
+
+/**
+ * Opaque 40-char base62 secret for OAuth authorization codes and refresh
+ * tokens. No prefix — these are stored only as SHA-256 hashes and never parsed.
+ */
+export function generateOAuthSecret(): string {
+  return generateSecret();
+}

--- a/packages/api/src/routes/oauth/discovery.ts
+++ b/packages/api/src/routes/oauth/discovery.ts
@@ -1,0 +1,47 @@
+import { Hono } from "hono";
+import { API_SCOPES } from "../../lib/scopes";
+import type { Bindings, Variables } from "../../types";
+
+// ---------------------------------------------------------------------------
+// OAuth / MCP discovery metadata
+//
+// Mounted at the root so the well-known paths resolve to the Worker origin:
+//   GET /.well-known/oauth-protected-resource   (RFC 9728)
+//   GET /.well-known/oauth-authorization-server (RFC 8414)
+// ---------------------------------------------------------------------------
+
+const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+function origin(reqUrl: string): string {
+  return new URL(reqUrl).origin;
+}
+
+// RFC 9728 — Protected Resource Metadata. Points MCP clients at this server's
+// authorization server and the protected MCP resource.
+app.get("/.well-known/oauth-protected-resource", (c) => {
+  const o = origin(c.req.url);
+  return c.json({
+    resource: `${o}/api/mcp`,
+    authorization_servers: [o],
+    scopes_supported: API_SCOPES,
+    bearer_methods_supported: ["header"],
+  });
+});
+
+// RFC 8414 — Authorization Server Metadata.
+app.get("/.well-known/oauth-authorization-server", (c) => {
+  const o = origin(c.req.url);
+  return c.json({
+    issuer: o,
+    authorization_endpoint: `${o}/api/oauth/authorize`,
+    token_endpoint: `${o}/api/oauth/token`,
+    registration_endpoint: `${o}/api/oauth/register`,
+    scopes_supported: API_SCOPES,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    code_challenge_methods_supported: ["S256"],
+    token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
+  });
+});
+
+export default app;

--- a/packages/api/src/routes/oauth/index.ts
+++ b/packages/api/src/routes/oauth/index.ts
@@ -1,0 +1,320 @@
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { organizations, projects } from "../../db/schema";
+import { type AppContext, errorResponse } from "../../lib/helpers";
+import { isGrantableScope, WILDCARD_SCOPE } from "../../lib/scopes";
+import { clerkDashboardAuth } from "../../middleware/clerk-dashboard-auth";
+import {
+  createAuthorizationCode,
+  exchangeAuthorizationCode,
+  getClient,
+  isAllowedRedirectUri,
+  OAuthError,
+  parseRedirectUris,
+  refreshAccessToken,
+  registerClient,
+} from "../../services/oauth";
+import type { Bindings, Variables } from "../../types";
+
+const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Origin (scheme + host) of the incoming request — the OAuth issuer. */
+function requestOrigin(c: AppContext): string {
+  return new URL(c.req.url).origin;
+}
+
+/** RFC 6749 OAuth error JSON for the token endpoint. */
+function oauthError(c: AppContext, error: string, description: string, status: 400 | 401 = 400) {
+  return c.json({ error, error_description: description }, status);
+}
+
+/**
+ * Parse a token-endpoint body that may be form-encoded or JSON.
+ * Returns a flat record of string values.
+ */
+async function parseTokenBody(c: AppContext): Promise<Record<string, string>> {
+  const contentType = c.req.header("Content-Type") ?? "";
+  if (contentType.includes("application/json")) {
+    const json = await c.req.json().catch(() => ({}));
+    const out: Record<string, string> = {};
+    if (json && typeof json === "object") {
+      for (const [k, v] of Object.entries(json as Record<string, unknown>)) {
+        if (typeof v === "string") out[k] = v;
+      }
+    }
+    return out;
+  }
+  // Default: form-encoded (the OAuth-standard content type).
+  const form = await c.req.parseBody().catch(() => ({}));
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(form)) {
+    if (typeof v === "string") out[k] = v;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/oauth/register — Dynamic Client Registration (RFC 7591, public)
+// ---------------------------------------------------------------------------
+
+app.post("/register", async (c) => {
+  const body = await c.req.json().catch(() => null);
+  if (!body || typeof body !== "object") {
+    return errorResponse(c, "BAD_REQUEST", "Invalid JSON body", 400);
+  }
+
+  const clientName = (body as Record<string, unknown>).client_name;
+  const redirectUris = (body as Record<string, unknown>).redirect_uris;
+  const grantTypes = (body as Record<string, unknown>).grant_types;
+  const authMethod = (body as Record<string, unknown>).token_endpoint_auth_method;
+
+  if (typeof clientName !== "string" || clientName.length === 0) {
+    return errorResponse(c, "BAD_REQUEST", "client_name is required", 400);
+  }
+  if (
+    !Array.isArray(redirectUris) ||
+    redirectUris.length === 0 ||
+    !redirectUris.every((u): u is string => typeof u === "string")
+  ) {
+    return errorResponse(c, "BAD_REQUEST", "redirect_uris must be a non-empty string array", 400);
+  }
+  for (const uri of redirectUris) {
+    if (!isAllowedRedirectUri(uri)) {
+      return errorResponse(
+        c,
+        "BAD_REQUEST",
+        `redirect_uri must be https or localhost: ${uri}`,
+        400,
+      );
+    }
+  }
+  if (grantTypes !== undefined && !Array.isArray(grantTypes)) {
+    return errorResponse(c, "BAD_REQUEST", "grant_types must be an array", 400);
+  }
+  if (authMethod !== undefined && typeof authMethod !== "string") {
+    return errorResponse(c, "BAD_REQUEST", "token_endpoint_auth_method must be a string", 400);
+  }
+
+  const db = c.get("db");
+  const registered = await registerClient(db, {
+    client_name: clientName,
+    redirect_uris: redirectUris,
+    grant_types: grantTypes as string[] | undefined,
+    token_endpoint_auth_method: authMethod as string | undefined,
+  });
+
+  return c.json(registered, 201);
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/oauth/authorize — Authorization endpoint (public)
+//
+// Validates the request, then redirects the browser to the dashboard consent
+// page. Invalid client/redirect → 400 (never redirect, to avoid open redirect).
+// ---------------------------------------------------------------------------
+
+app.get("/authorize", async (c) => {
+  const responseType = c.req.query("response_type");
+  const clientId = c.req.query("client_id");
+  const redirectUri = c.req.query("redirect_uri");
+  const codeChallenge = c.req.query("code_challenge");
+  const codeChallengeMethod = c.req.query("code_challenge_method");
+
+  if (!clientId) {
+    return errorResponse(c, "INVALID_REQUEST", "client_id is required", 400);
+  }
+  if (!redirectUri) {
+    return errorResponse(c, "INVALID_REQUEST", "redirect_uri is required", 400);
+  }
+
+  const db = c.get("db");
+  const client = await getClient(db, clientId);
+  if (!client) {
+    return errorResponse(c, "INVALID_CLIENT", "Unknown client_id", 400);
+  }
+
+  // Exact-match redirect_uri against the client's registered URIs.
+  const registered = parseRedirectUris(client.redirectUris);
+  if (!registered.includes(redirectUri)) {
+    return errorResponse(c, "INVALID_REQUEST", "redirect_uri does not match", 400);
+  }
+
+  // From here, the request is bound to a known client + valid redirect.
+  // Remaining validation errors are still returned as 400 (not redirected to
+  // the client) because the consent flow has not yet been authorized by a user.
+  if (responseType !== "code") {
+    return errorResponse(c, "UNSUPPORTED_RESPONSE_TYPE", "response_type must be 'code'", 400);
+  }
+  if (!codeChallenge) {
+    return errorResponse(c, "INVALID_REQUEST", "code_challenge is required (PKCE)", 400);
+  }
+  if (codeChallengeMethod !== "S256") {
+    return errorResponse(c, "INVALID_REQUEST", "code_challenge_method must be 'S256'", 400);
+  }
+
+  // Forward every original query param to the dashboard consent page, which
+  // handles login and approval, then calls /authorize/decision.
+  const consentUrl = new URL("/oauth/consent", requestOrigin(c));
+  const incoming = new URL(c.req.url);
+  for (const [key, value] of incoming.searchParams) {
+    consentUrl.searchParams.set(key, value);
+  }
+  return c.redirect(consentUrl.toString(), 302);
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/oauth/authorize/decision — Consent decision (Clerk-authed)
+//
+// Called by the dashboard consent page after the user approves or denies.
+// Verifies the chosen project belongs to the user's Clerk org, re-validates the
+// client + redirect + scopes, and issues an authorization code on approval.
+// ---------------------------------------------------------------------------
+
+app.post("/authorize/decision", clerkDashboardAuth, async (c) => {
+  const body = await c.req.json().catch(() => null);
+  if (!body || typeof body !== "object") {
+    return errorResponse(c, "BAD_REQUEST", "Invalid JSON body", 400);
+  }
+  const b = body as Record<string, unknown>;
+
+  const approve = b.approve === true;
+  const clientId = typeof b.client_id === "string" ? b.client_id : "";
+  const redirectUri = typeof b.redirect_uri === "string" ? b.redirect_uri : "";
+  const state = typeof b.state === "string" ? b.state : "";
+  const codeChallenge = typeof b.code_challenge === "string" ? b.code_challenge : "";
+  const codeChallengeMethod =
+    typeof b.code_challenge_method === "string" ? b.code_challenge_method : "S256";
+  const resource = typeof b.resource === "string" ? b.resource : null;
+  const projectId = typeof b.project_id === "string" ? b.project_id : "";
+  const scopes = Array.isArray(b.scopes)
+    ? b.scopes.filter((s): s is string => typeof s === "string")
+    : [];
+
+  if (!clientId || !redirectUri) {
+    return errorResponse(c, "BAD_REQUEST", "client_id and redirect_uri are required", 400);
+  }
+
+  const db = c.get("db");
+  const client = await getClient(db, clientId);
+  if (!client) {
+    return errorResponse(c, "INVALID_CLIENT", "Unknown client_id", 400);
+  }
+  // Re-validate exact redirect_uri match — never trust the body alone.
+  const registered = parseRedirectUris(client.redirectUris);
+  if (!registered.includes(redirectUri)) {
+    return errorResponse(c, "INVALID_REQUEST", "redirect_uri does not match", 400);
+  }
+
+  // Deny: redirect back to the client with an OAuth error.
+  if (!approve) {
+    const url = new URL(redirectUri);
+    url.searchParams.set("error", "access_denied");
+    if (state) url.searchParams.set("state", state);
+    return c.json({ redirect: url.toString() });
+  }
+
+  // Approve requires PKCE and a valid project the user actually owns.
+  if (!codeChallenge || codeChallengeMethod !== "S256") {
+    return errorResponse(c, "INVALID_REQUEST", "code_challenge (S256) is required", 400);
+  }
+  if (!projectId) {
+    return errorResponse(c, "BAD_REQUEST", "project_id is required to approve", 400);
+  }
+  // Reject the global wildcard for OAuth clients — a third-party client must
+  // request concrete scopes or per-resource wildcards (e.g. "state:*"), never
+  // unrestricted full access. Resource wildcards and concrete scopes are OK.
+  if (scopes.length === 0 || scopes.includes(WILDCARD_SCOPE) || !scopes.every(isGrantableScope)) {
+    return errorResponse(c, "INVALID_SCOPE", "One or more requested scopes are not grantable", 400);
+  }
+
+  // Verify the project belongs to the authenticated Clerk org.
+  const clerkOrgId = c.get("orgId");
+  const clerkUserId = c.get("clerkUserId") ?? null;
+  if (!clerkOrgId) {
+    return errorResponse(c, "FORBIDDEN", "No active organization", 403);
+  }
+  const [[org], [project]] = await Promise.all([
+    db
+      .select({ id: organizations.id })
+      .from(organizations)
+      .where(eq(organizations.clerkOrgId, clerkOrgId))
+      .limit(1),
+    db.select({ orgId: projects.orgId }).from(projects).where(eq(projects.id, projectId)).limit(1),
+  ]);
+  if (!org || !project || project.orgId !== org.id) {
+    // 404 (not 403) avoids leaking the existence of other orgs' projects.
+    return errorResponse(c, "NOT_FOUND", "Project not found", 404);
+  }
+
+  const code = await createAuthorizationCode(db, {
+    clientId,
+    projectId,
+    orgId: org.id,
+    userId: clerkUserId,
+    scopes,
+    redirectUri,
+    codeChallenge,
+    codeChallengeMethod,
+    resource,
+  });
+
+  const url = new URL(redirectUri);
+  url.searchParams.set("code", code);
+  if (state) url.searchParams.set("state", state);
+  return c.json({ redirect: url.toString() });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/oauth/token — Token endpoint (public; form-encoded or JSON)
+// ---------------------------------------------------------------------------
+
+app.post("/token", async (c) => {
+  const body = await parseTokenBody(c);
+  const grantType = body.grant_type;
+  const db = c.get("db");
+
+  try {
+    if (grantType === "authorization_code") {
+      const { code, code_verifier, client_id, redirect_uri } = body;
+      if (!code || !code_verifier || !client_id || !redirect_uri) {
+        return oauthError(
+          c,
+          "invalid_request",
+          "code, code_verifier, client_id and redirect_uri are required",
+        );
+      }
+      const tokens = await exchangeAuthorizationCode(db, {
+        code,
+        codeVerifier: code_verifier,
+        clientId: client_id,
+        redirectUri: redirect_uri,
+      });
+      return c.json(tokens);
+    }
+
+    if (grantType === "refresh_token") {
+      const { refresh_token, client_id } = body;
+      if (!refresh_token || !client_id) {
+        return oauthError(c, "invalid_request", "refresh_token and client_id are required");
+      }
+      const tokens = await refreshAccessToken(db, {
+        refreshToken: refresh_token,
+        clientId: client_id,
+      });
+      return c.json(tokens);
+    }
+
+    return oauthError(c, "unsupported_grant_type", "Unsupported grant_type");
+  } catch (err) {
+    if (err instanceof OAuthError) {
+      return oauthError(c, err.code, err.description, err.status);
+    }
+    throw err;
+  }
+});
+
+export default app;

--- a/packages/api/src/services/oauth.ts
+++ b/packages/api/src/services/oauth.ts
@@ -1,0 +1,394 @@
+import { and, eq, gt, isNull, or } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import {
+  capabilityTokens,
+  type OAuthClient,
+  oauthAuthorizationCodes,
+  oauthClients,
+  oauthRefreshTokens,
+} from "../db/schema";
+import { hashApiKey } from "../lib/crypto";
+import { generateId, generateOAuthSecret } from "../lib/id";
+import { parseScopesJson } from "../lib/scopes";
+import { encodeJson } from "../lib/state-json";
+import type { CapabilityScope } from "../lib/validation";
+import { createCapabilityToken } from "./capability-tokens";
+
+// ---------------------------------------------------------------------------
+// Tunables
+// ---------------------------------------------------------------------------
+
+/** Authorization codes are single-use and short-lived (RFC 6749 §4.1.2). */
+export const AUTH_CODE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+/** Access tokens (capability tokens) live one hour. */
+export const ACCESS_TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
+/** Refresh tokens live 30 days; rotated on every use. */
+export const REFRESH_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+// ---------------------------------------------------------------------------
+// Redirect URI validation
+// ---------------------------------------------------------------------------
+
+/**
+ * A redirect URI is acceptable only if it is an https URL or a loopback http
+ * URL (localhost / 127.0.0.1 / [::1]). Anything else (custom schemes, http to a
+ * remote host) is rejected — prevents open-redirect and credential leakage.
+ */
+export function isAllowedRedirectUri(uri: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol === "https:") return true;
+  if (parsed.protocol === "http:") {
+    // URL normalizes IPv6 loopback to "::1" (brackets stripped).
+    const host = parsed.hostname;
+    return host === "localhost" || host === "127.0.0.1" || host === "::1";
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// PKCE (RFC 7636, S256 only)
+// ---------------------------------------------------------------------------
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/** Compute the S256 PKCE challenge: base64url(SHA-256(code_verifier)). */
+export async function computeS256Challenge(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+/**
+ * Verify a PKCE code_verifier against a stored S256 challenge.
+ * Constant-time-ish compare via length + char equality on the derived hash.
+ */
+export async function verifyPkceS256(verifier: string, challenge: string): Promise<boolean> {
+  const computed = await computeS256Challenge(verifier);
+  if (computed.length !== challenge.length) return false;
+  let diff = 0;
+  for (let i = 0; i < computed.length; i++) {
+    diff |= computed.charCodeAt(i) ^ challenge.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+// ---------------------------------------------------------------------------
+// Clients
+// ---------------------------------------------------------------------------
+
+export function parseRedirectUris(value: string): string[] {
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((u): u is string => typeof u === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function getClient(
+  db: DrizzleD1Database,
+  clientId: string,
+): Promise<OAuthClient | null> {
+  const [client] = await db
+    .select()
+    .from(oauthClients)
+    .where(eq(oauthClients.id, clientId))
+    .limit(1);
+  return client ?? null;
+}
+
+export interface RegisterClientInput {
+  client_name: string;
+  redirect_uris: string[];
+  grant_types?: string[];
+  token_endpoint_auth_method?: string;
+}
+
+export interface RegisteredClient {
+  client_id: string;
+  client_name: string;
+  redirect_uris: string[];
+  grant_types: string[];
+  token_endpoint_auth_method: string;
+  client_secret?: string;
+}
+
+/**
+ * Register a new OAuth client (RFC 7591 Dynamic Client Registration).
+ * Confidential clients (auth method other than "none") receive a secret once;
+ * only its SHA-256 hash is stored.
+ */
+export async function registerClient(
+  db: DrizzleD1Database,
+  input: RegisterClientInput,
+): Promise<RegisteredClient> {
+  const grantTypes = input.grant_types?.length
+    ? input.grant_types
+    : ["authorization_code", "refresh_token"];
+  const authMethod = input.token_endpoint_auth_method ?? "none";
+  const isPublic = authMethod === "none";
+
+  const clientId = generateId();
+  const clientSecret = isPublic ? undefined : generateOAuthSecret();
+  const now = Date.now();
+
+  await db.insert(oauthClients).values({
+    id: clientId,
+    clientSecretHash: clientSecret ? await hashApiKey(clientSecret) : null,
+    clientName: input.client_name,
+    redirectUris: encodeJson(input.redirect_uris),
+    grantTypes: encodeJson(grantTypes),
+    tokenEndpointAuthMethod: authMethod,
+    createdAt: now,
+  });
+
+  return {
+    client_id: clientId,
+    client_name: input.client_name,
+    redirect_uris: input.redirect_uris,
+    grant_types: grantTypes,
+    token_endpoint_auth_method: authMethod,
+    ...(clientSecret ? { client_secret: clientSecret } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Authorization codes
+// ---------------------------------------------------------------------------
+
+export interface CreateAuthCodeInput {
+  clientId: string;
+  projectId: string;
+  orgId: string | null;
+  userId: string | null;
+  scopes: string[];
+  redirectUri: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  resource: string | null;
+}
+
+/**
+ * Issue a single-use authorization code. Returns the raw code (only its hash is
+ * stored). Bound to client, redirect URI, PKCE challenge, scopes, project, org,
+ * granting user, and resource.
+ */
+export async function createAuthorizationCode(
+  db: DrizzleD1Database,
+  input: CreateAuthCodeInput,
+): Promise<string> {
+  const code = generateOAuthSecret();
+  const now = Date.now();
+  await db.insert(oauthAuthorizationCodes).values({
+    id: generateId(),
+    codeHash: await hashApiKey(code),
+    clientId: input.clientId,
+    projectId: input.projectId,
+    orgId: input.orgId,
+    userId: input.userId,
+    scopes: encodeJson(input.scopes),
+    redirectUri: input.redirectUri,
+    codeChallenge: input.codeChallenge,
+    codeChallengeMethod: input.codeChallengeMethod,
+    resource: input.resource,
+    expiresAt: now + AUTH_CODE_TTL_MS,
+    createdAt: now,
+  });
+  return code;
+}
+
+// ---------------------------------------------------------------------------
+// Token issuance
+// ---------------------------------------------------------------------------
+
+export interface TokenResponse {
+  access_token: string;
+  token_type: "Bearer";
+  expires_in: number;
+  refresh_token: string;
+  scope: string;
+}
+
+/**
+ * Mint an access token (capability token) + refresh token for a granted scope
+ * set. Shared by the authorization_code and refresh_token grants.
+ */
+async function issueTokens(
+  db: DrizzleD1Database,
+  params: { clientId: string; clientName: string; projectId: string; scopes: string[] },
+): Promise<TokenResponse> {
+  const now = Date.now();
+  const accessToken = await createCapabilityToken(db, params.projectId, {
+    name: `oauth:${params.clientName}`,
+    // OAuth scopes are stored/validated as plain strings (see scoped-auth.ts);
+    // the CapabilityScope[] type is structurally satisfied at runtime.
+    scopes: params.scopes as CapabilityScope[],
+    expires_at: now + ACCESS_TOKEN_TTL_MS,
+  });
+
+  const refreshToken = generateOAuthSecret();
+  await db.insert(oauthRefreshTokens).values({
+    id: generateId(),
+    tokenHash: await hashApiKey(refreshToken),
+    clientId: params.clientId,
+    projectId: params.projectId,
+    accessTokenId: accessToken.id,
+    scopes: encodeJson(params.scopes),
+    expiresAt: now + REFRESH_TOKEN_TTL_MS,
+    createdAt: now,
+  });
+
+  return {
+    access_token: accessToken.token,
+    token_type: "Bearer",
+    expires_in: Math.floor(ACCESS_TOKEN_TTL_MS / 1000),
+    refresh_token: refreshToken,
+    scope: params.scopes.join(" "),
+  };
+}
+
+export class OAuthError extends Error {
+  constructor(
+    readonly code: "invalid_request" | "invalid_grant" | "invalid_client",
+    readonly description: string,
+    readonly status: 400 | 401 = 400,
+  ) {
+    super(description);
+    this.name = "OAuthError";
+  }
+}
+
+export interface AuthCodeGrantInput {
+  code: string;
+  codeVerifier: string;
+  clientId: string;
+  redirectUri: string;
+}
+
+/**
+ * Exchange an authorization code for tokens (grant_type=authorization_code).
+ * Enforces single-use, expiry, client/redirect binding, and PKCE S256.
+ */
+export async function exchangeAuthorizationCode(
+  db: DrizzleD1Database,
+  input: AuthCodeGrantInput,
+): Promise<TokenResponse> {
+  const codeHash = await hashApiKey(input.code);
+  const [row] = await db
+    .select()
+    .from(oauthAuthorizationCodes)
+    .where(eq(oauthAuthorizationCodes.codeHash, codeHash))
+    .limit(1);
+
+  if (!row) throw new OAuthError("invalid_grant", "Authorization code not found");
+  if (row.consumedAt != null) {
+    throw new OAuthError("invalid_grant", "Authorization code already used");
+  }
+  if (row.expiresAt < Date.now()) {
+    throw new OAuthError("invalid_grant", "Authorization code expired");
+  }
+  if (row.clientId !== input.clientId) {
+    throw new OAuthError("invalid_grant", "client_id mismatch");
+  }
+  if (row.redirectUri !== input.redirectUri) {
+    throw new OAuthError("invalid_grant", "redirect_uri mismatch");
+  }
+  if (!(await verifyPkceS256(input.codeVerifier, row.codeChallenge))) {
+    throw new OAuthError("invalid_grant", "PKCE verification failed");
+  }
+
+  // Single-use: mark consumed atomically, guarding against a concurrent replay
+  // that already consumed it (consumedAt IS NULL guard).
+  const consumed = await db
+    .update(oauthAuthorizationCodes)
+    .set({ consumedAt: Date.now() })
+    .where(and(eq(oauthAuthorizationCodes.id, row.id), isNull(oauthAuthorizationCodes.consumedAt)))
+    .returning({ id: oauthAuthorizationCodes.id });
+  if (consumed.length === 0) {
+    throw new OAuthError("invalid_grant", "Authorization code already used");
+  }
+
+  const client = await getClient(db, row.clientId);
+  return issueTokens(db, {
+    clientId: row.clientId,
+    clientName: client?.clientName ?? row.clientId,
+    projectId: row.projectId,
+    scopes: parseScopesJson(row.scopes),
+  });
+}
+
+export interface RefreshGrantInput {
+  refreshToken: string;
+  /**
+   * Public clients MUST identify themselves at the token endpoint (OAuth 2.1
+   * §4.3.2). Always provided by the route; the binding is enforced below.
+   */
+  clientId: string;
+}
+
+/**
+ * Rotate a refresh token (grant_type=refresh_token). The presented token and
+ * its companion access token are revoked, and a fresh access + refresh token
+ * pair with the same scopes is issued (OAuth 2.1 mandates rotation for public
+ * clients; RFC 6819 §5.2.2.3 mandates revoking the old access token).
+ */
+export async function refreshAccessToken(
+  db: DrizzleD1Database,
+  input: RefreshGrantInput,
+): Promise<TokenResponse> {
+  const tokenHash = await hashApiKey(input.refreshToken);
+  const now = Date.now();
+  const [row] = await db
+    .select()
+    .from(oauthRefreshTokens)
+    .where(
+      and(
+        eq(oauthRefreshTokens.tokenHash, tokenHash),
+        isNull(oauthRefreshTokens.revokedAt),
+        or(isNull(oauthRefreshTokens.expiresAt), gt(oauthRefreshTokens.expiresAt, now)),
+      ),
+    )
+    .limit(1);
+
+  if (!row) throw new OAuthError("invalid_grant", "Refresh token invalid or expired");
+  // Client binding is mandatory — a refresh token may only be redeemed by the
+  // client it was issued to.
+  if (row.clientId !== input.clientId) {
+    throw new OAuthError("invalid_grant", "client_id mismatch");
+  }
+
+  // Rotate: revoke the presented token, guarding against concurrent reuse.
+  const rotated = await db
+    .update(oauthRefreshTokens)
+    .set({ rotatedAt: now, revokedAt: now })
+    .where(and(eq(oauthRefreshTokens.id, row.id), isNull(oauthRefreshTokens.revokedAt)))
+    .returning({ id: oauthRefreshTokens.id });
+  if (rotated.length === 0) {
+    throw new OAuthError("invalid_grant", "Refresh token already used");
+  }
+
+  // Revoke the companion access token so a rotated/compromised token family
+  // cannot keep using the previously-issued access token.
+  if (row.accessTokenId) {
+    await db
+      .update(capabilityTokens)
+      .set({ revokedAt: now })
+      .where(eq(capabilityTokens.id, row.accessTokenId));
+  }
+
+  const client = await getClient(db, row.clientId);
+  return issueTokens(db, {
+    clientId: row.clientId,
+    clientName: client?.clientName ?? row.clientId,
+    projectId: row.projectId,
+    scopes: parseScopesJson(row.scopes),
+  });
+}

--- a/packages/api/test/oauth.test.ts
+++ b/packages/api/test/oauth.test.ts
@@ -1,0 +1,704 @@
+import { env, SELF } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { hashApiKey } from "../src/lib/crypto";
+import { sessionCookie, signTestSessionToken } from "./clerk-jwt";
+import { applyMigrations, seedProject, TEST_PROJECT_ID } from "./setup";
+
+// ---------------------------------------------------------------------------
+// PKCE helpers (mirror the server's S256 implementation)
+// ---------------------------------------------------------------------------
+
+function base64Url(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+async function s256(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+  return base64Url(new Uint8Array(digest));
+}
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+async function insertClient(input: {
+  id: string;
+  redirectUris: string[];
+  name?: string;
+}): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO oauth_clients (id, client_secret_hash, client_name, redirect_uris, grant_types, token_endpoint_auth_method, created_at)
+     VALUES (?, NULL, ?, ?, '["authorization_code","refresh_token"]', 'none', ?)`,
+  )
+    .bind(input.id, input.name ?? "Test Client", JSON.stringify(input.redirectUris), Date.now())
+    .run();
+}
+
+async function insertAuthCode(input: {
+  code: string;
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  scopes: string[];
+  expiresAt?: number;
+}): Promise<void> {
+  const now = Date.now();
+  await env.DB.prepare(
+    `INSERT INTO oauth_authorization_codes
+      (id, code_hash, client_id, project_id, org_id, user_id, scopes, redirect_uri, code_challenge, code_challenge_method, resource, expires_at, created_at)
+     VALUES (?, ?, ?, ?, NULL, 'user_test_001', ?, ?, ?, 'S256', NULL, ?, ?)`,
+  )
+    .bind(
+      `code_${Math.random().toString(36).slice(2)}`,
+      await hashApiKey(input.code),
+      input.clientId,
+      TEST_PROJECT_ID,
+      JSON.stringify(input.scopes),
+      input.redirectUri,
+      input.codeChallenge,
+      input.expiresAt ?? now + 600_000,
+      now,
+    )
+    .run();
+}
+
+async function resetOAuthTables(): Promise<void> {
+  await env.DB.prepare("DELETE FROM oauth_refresh_tokens").run();
+  await env.DB.prepare("DELETE FROM oauth_authorization_codes").run();
+  await env.DB.prepare("DELETE FROM oauth_clients").run();
+  await env.DB.prepare("DELETE FROM capability_tokens").run();
+}
+
+interface TokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  refresh_token: string;
+  scope: string;
+}
+
+const REDIRECT = "http://localhost:9999/cb";
+
+describe("OAuth 2.1 server", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await seedProject();
+  });
+
+  beforeEach(async () => {
+    await resetOAuthTables();
+  });
+
+  // -------------------------------------------------------------------------
+  // Discovery
+  // -------------------------------------------------------------------------
+
+  describe("discovery", () => {
+    it("serves protected-resource metadata (RFC 9728)", async () => {
+      const res = await SELF.fetch("http://localhost/.well-known/oauth-protected-resource");
+      expect(res.status).toBe(200);
+      const body = await res.json<{
+        resource: string;
+        authorization_servers: string[];
+        scopes_supported: string[];
+        bearer_methods_supported: string[];
+      }>();
+      expect(body.resource).toBe("http://localhost/api/mcp");
+      expect(body.authorization_servers).toEqual(["http://localhost"]);
+      expect(body.scopes_supported).toContain("conversations:read");
+      expect(body.bearer_methods_supported).toEqual(["header"]);
+    });
+
+    it("serves authorization-server metadata (RFC 8414)", async () => {
+      const res = await SELF.fetch("http://localhost/.well-known/oauth-authorization-server");
+      expect(res.status).toBe(200);
+      const body = await res.json<{
+        issuer: string;
+        authorization_endpoint: string;
+        token_endpoint: string;
+        registration_endpoint: string;
+        code_challenge_methods_supported: string[];
+        grant_types_supported: string[];
+        response_types_supported: string[];
+      }>();
+      expect(body.issuer).toBe("http://localhost");
+      expect(body.authorization_endpoint).toBe("http://localhost/api/oauth/authorize");
+      expect(body.token_endpoint).toBe("http://localhost/api/oauth/token");
+      expect(body.registration_endpoint).toBe("http://localhost/api/oauth/register");
+      expect(body.code_challenge_methods_supported).toEqual(["S256"]);
+      expect(body.grant_types_supported).toContain("refresh_token");
+      expect(body.response_types_supported).toEqual(["code"]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Dynamic Client Registration (RFC 7591)
+  // -------------------------------------------------------------------------
+
+  describe("POST /api/oauth/register", () => {
+    it("registers a public client and returns a client_id (no secret)", async () => {
+      const res = await SELF.fetch("http://localhost/api/oauth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ client_name: "Test", redirect_uris: [REDIRECT] }),
+      });
+      expect(res.status).toBe(201);
+      const body = await res.json<{
+        client_id: string;
+        client_secret?: string;
+        redirect_uris: string[];
+        token_endpoint_auth_method: string;
+      }>();
+      expect(body.client_id).toBeTruthy();
+      expect(body.client_secret).toBeUndefined();
+      expect(body.redirect_uris).toEqual([REDIRECT]);
+      expect(body.token_endpoint_auth_method).toBe("none");
+    });
+
+    it("returns a secret for confidential clients", async () => {
+      const res = await SELF.fetch("http://localhost/api/oauth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_name: "Conf",
+          redirect_uris: ["https://app.example.com/cb"],
+          token_endpoint_auth_method: "client_secret_post",
+        }),
+      });
+      expect(res.status).toBe(201);
+      const body = await res.json<{ client_secret?: string }>();
+      expect(body.client_secret).toBeTruthy();
+    });
+
+    it("rejects non-https/non-localhost redirect URIs", async () => {
+      const res = await SELF.fetch("http://localhost/api/oauth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ client_name: "Bad", redirect_uris: ["http://evil.com/cb"] }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects missing redirect_uris", async () => {
+      const res = await SELF.fetch("http://localhost/api/oauth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ client_name: "Bad" }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Authorization endpoint
+  // -------------------------------------------------------------------------
+
+  describe("GET /api/oauth/authorize", () => {
+    it("redirects valid requests to the dashboard consent page", async () => {
+      await insertClient({ id: "client_a", redirectUris: [REDIRECT] });
+      const challenge = await s256("verifier-123-verifier-123-verifier-123-ok");
+      const url = new URL("http://localhost/api/oauth/authorize");
+      url.searchParams.set("response_type", "code");
+      url.searchParams.set("client_id", "client_a");
+      url.searchParams.set("redirect_uri", REDIRECT);
+      url.searchParams.set("code_challenge", challenge);
+      url.searchParams.set("code_challenge_method", "S256");
+      url.searchParams.set("scope", "conversations:read");
+      url.searchParams.set("state", "xyz");
+
+      const res = await SELF.fetch(url.toString(), { redirect: "manual" });
+      expect(res.status).toBe(302);
+      const location = res.headers.get("Location") ?? "";
+      const loc = new URL(location);
+      expect(loc.pathname).toBe("/oauth/consent");
+      expect(loc.searchParams.get("client_id")).toBe("client_a");
+      expect(loc.searchParams.get("code_challenge")).toBe(challenge);
+      expect(loc.searchParams.get("state")).toBe("xyz");
+    });
+
+    it("returns 400 (no redirect) for an unknown client", async () => {
+      const url = new URL("http://localhost/api/oauth/authorize");
+      url.searchParams.set("response_type", "code");
+      url.searchParams.set("client_id", "nope");
+      url.searchParams.set("redirect_uri", REDIRECT);
+      url.searchParams.set("code_challenge", "abc");
+      url.searchParams.set("code_challenge_method", "S256");
+      const res = await SELF.fetch(url.toString(), { redirect: "manual" });
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for a redirect_uri not registered to the client", async () => {
+      await insertClient({ id: "client_b", redirectUris: [REDIRECT] });
+      const url = new URL("http://localhost/api/oauth/authorize");
+      url.searchParams.set("response_type", "code");
+      url.searchParams.set("client_id", "client_b");
+      url.searchParams.set("redirect_uri", "http://localhost:9999/evil");
+      url.searchParams.set("code_challenge", "abc");
+      url.searchParams.set("code_challenge_method", "S256");
+      const res = await SELF.fetch(url.toString(), { redirect: "manual" });
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when PKCE is missing", async () => {
+      await insertClient({ id: "client_c", redirectUris: [REDIRECT] });
+      const url = new URL("http://localhost/api/oauth/authorize");
+      url.searchParams.set("response_type", "code");
+      url.searchParams.set("client_id", "client_c");
+      url.searchParams.set("redirect_uri", REDIRECT);
+      const res = await SELF.fetch(url.toString(), { redirect: "manual" });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Consent decision endpoint (Clerk-authed)
+  // -------------------------------------------------------------------------
+
+  describe("POST /api/oauth/authorize/decision", () => {
+    const challengeP = s256("decision-verifier-decision-verifier-decision");
+
+    it("requires a Clerk session", async () => {
+      await insertClient({ id: "client_d", redirectUris: [REDIRECT] });
+      const res = await SELF.fetch("http://localhost/api/oauth/authorize/decision", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ approve: true, client_id: "client_d", redirect_uri: REDIRECT }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("issues a code on approval and returns a redirect with code+state", async () => {
+      await insertClient({ id: "client_e", redirectUris: [REDIRECT] });
+      const token = await signTestSessionToken();
+      const res = await SELF.fetch("http://localhost/api/oauth/authorize/decision", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Cookie: sessionCookie(token) },
+        body: JSON.stringify({
+          approve: true,
+          client_id: "client_e",
+          redirect_uri: REDIRECT,
+          scopes: ["conversations:read"],
+          code_challenge: await challengeP,
+          code_challenge_method: "S256",
+          state: "st8",
+          project_id: TEST_PROJECT_ID,
+        }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json<{ redirect: string }>();
+      const loc = new URL(body.redirect);
+      expect(loc.origin + loc.pathname).toBe(REDIRECT);
+      expect(loc.searchParams.get("code")).toBeTruthy();
+      expect(loc.searchParams.get("state")).toBe("st8");
+
+      // The code is persisted (single row).
+      const count = await env.DB.prepare(
+        "SELECT COUNT(*) as n FROM oauth_authorization_codes",
+      ).first<{ n: number }>();
+      expect(count?.n).toBe(1);
+    });
+
+    it("returns access_denied redirect on deny", async () => {
+      await insertClient({ id: "client_f", redirectUris: [REDIRECT] });
+      const token = await signTestSessionToken();
+      const res = await SELF.fetch("http://localhost/api/oauth/authorize/decision", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Cookie: sessionCookie(token) },
+        body: JSON.stringify({
+          approve: false,
+          client_id: "client_f",
+          redirect_uri: REDIRECT,
+          state: "st9",
+        }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json<{ redirect: string }>();
+      const loc = new URL(body.redirect);
+      expect(loc.searchParams.get("error")).toBe("access_denied");
+      expect(loc.searchParams.get("state")).toBe("st9");
+    });
+
+    it("rejects approving a project from another org (404)", async () => {
+      await insertClient({ id: "client_g", redirectUris: [REDIRECT] });
+      const token = await signTestSessionToken({ orgId: "clerk_other_org_999" });
+      const res = await SELF.fetch("http://localhost/api/oauth/authorize/decision", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Cookie: sessionCookie(token) },
+        body: JSON.stringify({
+          approve: true,
+          client_id: "client_g",
+          redirect_uri: REDIRECT,
+          scopes: ["conversations:read"],
+          code_challenge: await challengeP,
+          code_challenge_method: "S256",
+          project_id: TEST_PROJECT_ID,
+        }),
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("rejects ungrantable scopes", async () => {
+      await insertClient({ id: "client_h", redirectUris: [REDIRECT] });
+      const token = await signTestSessionToken();
+      const res = await SELF.fetch("http://localhost/api/oauth/authorize/decision", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Cookie: sessionCookie(token) },
+        body: JSON.stringify({
+          approve: true,
+          client_id: "client_h",
+          redirect_uri: REDIRECT,
+          scopes: ["not:a:scope"],
+          code_challenge: await challengeP,
+          code_challenge_method: "S256",
+          project_id: TEST_PROJECT_ID,
+        }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Token endpoint — authorization_code grant
+  // -------------------------------------------------------------------------
+
+  describe("POST /api/oauth/token (authorization_code)", () => {
+    it("exchanges a code+verifier for an as_cap_ access token + refresh token", async () => {
+      const verifier = "tok-verifier-tok-verifier-tok-verifier-okok";
+      const challenge = await s256(verifier);
+      await insertClient({ id: "client_t1", redirectUris: [REDIRECT] });
+      await insertAuthCode({
+        code: "rawcode1",
+        clientId: "client_t1",
+        redirectUri: REDIRECT,
+        codeChallenge: challenge,
+        scopes: ["conversations:read", "state:write"],
+      });
+
+      const res = await SELF.fetch("http://localhost/api/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code: "rawcode1",
+          code_verifier: verifier,
+          client_id: "client_t1",
+          redirect_uri: REDIRECT,
+        }).toString(),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json<TokenResponse>();
+      expect(body.access_token.startsWith("as_cap_")).toBe(true);
+      expect(body.token_type).toBe("Bearer");
+      expect(body.expires_in).toBe(3600);
+      expect(body.refresh_token).toBeTruthy();
+      expect(body.scope).toBe("conversations:read state:write");
+
+      // The access token exists in capability_tokens (by hash).
+      const hash = await hashApiKey(body.access_token);
+      const row = await env.DB.prepare(
+        "SELECT project_id, scopes FROM capability_tokens WHERE key_hash = ?",
+      )
+        .bind(hash)
+        .first<{ project_id: string; scopes: string }>();
+      expect(row?.project_id).toBe(TEST_PROJECT_ID);
+
+      // A refresh token row exists.
+      const rt = await env.DB.prepare("SELECT COUNT(*) as n FROM oauth_refresh_tokens").first<{
+        n: number;
+      }>();
+      expect(rt?.n).toBe(1);
+    });
+
+    it("accepts a JSON token body too", async () => {
+      const verifier = "json-verifier-json-verifier-json-verifier-ok";
+      const challenge = await s256(verifier);
+      await insertClient({ id: "client_t2", redirectUris: [REDIRECT] });
+      await insertAuthCode({
+        code: "rawcode2",
+        clientId: "client_t2",
+        redirectUri: REDIRECT,
+        codeChallenge: challenge,
+        scopes: ["conversations:read"],
+      });
+
+      const res = await SELF.fetch("http://localhost/api/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          grant_type: "authorization_code",
+          code: "rawcode2",
+          code_verifier: verifier,
+          client_id: "client_t2",
+          redirect_uri: REDIRECT,
+        }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json<TokenResponse>();
+      expect(body.access_token.startsWith("as_cap_")).toBe(true);
+    });
+
+    it("rejects a PKCE mismatch with invalid_grant", async () => {
+      const challenge = await s256("the-real-verifier-the-real-verifier-okok");
+      await insertClient({ id: "client_t3", redirectUris: [REDIRECT] });
+      await insertAuthCode({
+        code: "rawcode3",
+        clientId: "client_t3",
+        redirectUri: REDIRECT,
+        codeChallenge: challenge,
+        scopes: ["conversations:read"],
+      });
+
+      const res = await SELF.fetch("http://localhost/api/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code: "rawcode3",
+          code_verifier: "WRONG-verifier-WRONG-verifier-WRONG-verifier",
+          client_id: "client_t3",
+          redirect_uri: REDIRECT,
+        }).toString(),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json<{ error: string }>();
+      expect(body.error).toBe("invalid_grant");
+    });
+
+    it("rejects reusing a consumed code", async () => {
+      const verifier = "reuse-verifier-reuse-verifier-reuse-verifier";
+      const challenge = await s256(verifier);
+      await insertClient({ id: "client_t4", redirectUris: [REDIRECT] });
+      await insertAuthCode({
+        code: "rawcode4",
+        clientId: "client_t4",
+        redirectUri: REDIRECT,
+        codeChallenge: challenge,
+        scopes: ["conversations:read"],
+      });
+
+      const exchange = () =>
+        SELF.fetch("http://localhost/api/oauth/token", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams({
+            grant_type: "authorization_code",
+            code: "rawcode4",
+            code_verifier: verifier,
+            client_id: "client_t4",
+            redirect_uri: REDIRECT,
+          }).toString(),
+        });
+
+      const first = await exchange();
+      expect(first.status).toBe(200);
+      const second = await exchange();
+      expect(second.status).toBe(400);
+      const body = await second.json<{ error: string }>();
+      expect(body.error).toBe("invalid_grant");
+    });
+
+    it("rejects a redirect_uri mismatch with invalid_grant", async () => {
+      const verifier = "mm-verifier-mm-verifier-mm-verifier-mm-okok";
+      const challenge = await s256(verifier);
+      await insertClient({ id: "client_t5", redirectUris: [REDIRECT] });
+      await insertAuthCode({
+        code: "rawcode5",
+        clientId: "client_t5",
+        redirectUri: REDIRECT,
+        codeChallenge: challenge,
+        scopes: ["conversations:read"],
+      });
+
+      const res = await SELF.fetch("http://localhost/api/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code: "rawcode5",
+          code_verifier: verifier,
+          client_id: "client_t5",
+          redirect_uri: "http://localhost:9999/other",
+        }).toString(),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json<{ error: string }>();
+      expect(body.error).toBe("invalid_grant");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Token endpoint — refresh_token grant (rotation)
+  // -------------------------------------------------------------------------
+
+  describe("POST /api/oauth/token (refresh_token)", () => {
+    async function mintInitialTokens(): Promise<TokenResponse> {
+      const verifier = "rt-verifier-rt-verifier-rt-verifier-rt-okok";
+      const challenge = await s256(verifier);
+      await insertClient({ id: "client_rt", redirectUris: [REDIRECT] });
+      await insertAuthCode({
+        code: "rawcode_rt",
+        clientId: "client_rt",
+        redirectUri: REDIRECT,
+        codeChallenge: challenge,
+        scopes: ["conversations:read"],
+      });
+      const res = await SELF.fetch("http://localhost/api/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code: "rawcode_rt",
+          code_verifier: verifier,
+          client_id: "client_rt",
+          redirect_uri: REDIRECT,
+        }).toString(),
+      });
+      return res.json<TokenResponse>();
+    }
+
+    it("rotates the refresh token and issues a new access token", async () => {
+      const initial = await mintInitialTokens();
+
+      const res = await SELF.fetch("http://localhost/api/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          refresh_token: initial.refresh_token,
+          client_id: "client_rt",
+        }).toString(),
+      });
+      expect(res.status).toBe(200);
+      const rotated = await res.json<TokenResponse>();
+      expect(rotated.access_token.startsWith("as_cap_")).toBe(true);
+      expect(rotated.refresh_token).not.toBe(initial.refresh_token);
+      expect(rotated.scope).toBe("conversations:read");
+    });
+
+    it("rejects reusing a rotated (revoked) refresh token", async () => {
+      const initial = await mintInitialTokens();
+      const refresh = () =>
+        SELF.fetch("http://localhost/api/oauth/token", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams({
+            grant_type: "refresh_token",
+            refresh_token: initial.refresh_token,
+            client_id: "client_rt",
+          }).toString(),
+        });
+
+      const first = await refresh();
+      expect(first.status).toBe(200);
+      const second = await refresh();
+      expect(second.status).toBe(400);
+      const body = await second.json<{ error: string }>();
+      expect(body.error).toBe("invalid_grant");
+    });
+
+    it("rejects an unknown refresh token", async () => {
+      const res = await SELF.fetch("http://localhost/api/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          refresh_token: "does-not-exist",
+          client_id: "client_rt",
+        }).toString(),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json<{ error: string }>();
+      expect(body.error).toBe("invalid_grant");
+    });
+
+    it("requires client_id on the refresh grant (OAuth 2.1 §4.3.2)", async () => {
+      const initial = await mintInitialTokens();
+      const res = await SELF.fetch("http://localhost/api/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          refresh_token: initial.refresh_token,
+        }).toString(),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json<{ error: string }>();
+      expect(body.error).toBe("invalid_request");
+    });
+
+    it("rejects a refresh token redeemed with the wrong client_id", async () => {
+      const initial = await mintInitialTokens();
+      const res = await SELF.fetch("http://localhost/api/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          refresh_token: initial.refresh_token,
+          client_id: "some_other_client",
+        }).toString(),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json<{ error: string }>();
+      expect(body.error).toBe("invalid_grant");
+    });
+
+    it("revokes the prior access token when rotating (RFC 6819)", async () => {
+      const initial = await mintInitialTokens();
+      // The initial access token works (exists, not revoked).
+      const oldHash = await hashApiKey(initial.access_token);
+      const before = await env.DB.prepare(
+        "SELECT revoked_at FROM capability_tokens WHERE key_hash = ?",
+      )
+        .bind(oldHash)
+        .first<{ revoked_at: number | null }>();
+      expect(before?.revoked_at).toBeNull();
+
+      const res = await SELF.fetch("http://localhost/api/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          refresh_token: initial.refresh_token,
+          client_id: "client_rt",
+        }).toString(),
+      });
+      expect(res.status).toBe(200);
+
+      // After rotation, the old access token is revoked.
+      const after = await env.DB.prepare(
+        "SELECT revoked_at FROM capability_tokens WHERE key_hash = ?",
+      )
+        .bind(oldHash)
+        .first<{ revoked_at: number | null }>();
+      expect(after?.revoked_at).not.toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Wildcard scope is not OAuth-grantable
+  // -------------------------------------------------------------------------
+
+  describe("global wildcard scope", () => {
+    it("rejects approving the '*' scope at /authorize/decision", async () => {
+      await insertClient({ id: "client_wc", redirectUris: [REDIRECT] });
+      const token = await signTestSessionToken();
+      const challenge = await s256("wc-verifier-wc-verifier-wc-verifier-wc-ok");
+      const res = await SELF.fetch("http://localhost/api/oauth/authorize/decision", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Cookie: sessionCookie(token) },
+        body: JSON.stringify({
+          approve: true,
+          client_id: "client_wc",
+          redirect_uri: REDIRECT,
+          scopes: ["*"],
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          project_id: TEST_PROJECT_ID,
+        }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+});


### PR DESCRIPTION
## What

OAuth 2.1 (authorization-code + PKCE S256) server co-hosted in the Worker so remote MCP clients (Claude, Cursor, …) can obtain **scoped** access tokens. Access tokens reuse the existing capability-token mechanism (`as_cap_` tokens), so they validate through the existing `scopedAuth` path with no changes to enforcement.

This is unit **U2** of the remote-MCP + OAuth + scoped-keys feature. It builds on the already-merged foundation (#221: scoped keys + OAuth DB tables). The consent **screen** is a separate dashboard unit; this PR's `/authorize` validates and 302-redirects the browser to `/oauth/consent`, and exposes `/authorize/decision` for that page to call.

## Endpoints

| Method | Path | Auth | Spec |
|---|---|---|---|
| GET | `/.well-known/oauth-protected-resource` | public | RFC 9728 |
| GET | `/.well-known/oauth-authorization-server` | public | RFC 8414 |
| POST | `/api/oauth/register` | public | RFC 7591 (DCR) |
| GET | `/api/oauth/authorize` | public | redirects to consent |
| POST | `/api/oauth/authorize/decision` | Clerk session | org-scoped; issues code |
| POST | `/api/oauth/token` | public | `authorization_code` + `refresh_token` |

## Security

- **PKCE S256** verified with Web Crypto (`crypto.subtle.digest`), constant-time compare.
- **Single-use authorization codes** — atomic `UPDATE … WHERE consumed_at IS NULL` consume guard; replay → `invalid_grant`.
- **Exact `redirect_uri` matching** at authorize / decision / token; redirect URIs restricted to https or loopback (`localhost` / `127.0.0.1` / `::1`) — no open redirect.
- **Refresh-token rotation** — on use, the old refresh token **and its companion access (capability) token** are revoked (RFC 6819 §5.2.2.3); reuse of a rotated token → `invalid_grant`.
- **`client_id` binding required** on the refresh grant (OAuth 2.1 §4.3.2); wrong/absent client_id rejected.
- **Global `*` wildcard is not OAuth-grantable** — clients may request concrete scopes or per-resource wildcards (e.g. `state:*`), never unrestricted full access.
- Decision endpoint verifies the chosen project belongs to the granting user's Clerk org (404 to avoid leaking other orgs' projects).

## Tests

`packages/api/test/oauth.test.ts` — 27 cases: discovery metadata, DCR (public + confidential + bad redirect), authorize redirect + 400s, consent decision (approve / deny / cross-org 404 / ungrantable scope / wildcard reject / unauthenticated 401), full code↔token exchange (form + JSON), PKCE mismatch, code replay, redirect mismatch, refresh rotation + reuse rejection + client_id binding + old-access-token revocation.

- Full API suite: **317 passing**.
- Typecheck: clean. Biome: clean.
- E2E against `wrangler dev`: both `.well-known` endpoints return valid JSON; `POST /register` returns a `client_id`; `http://evil.com` redirect → 400.

## Notes

- The protected-resource metadata advertises `<origin>/api/mcp` as the resource — that route is mounted by the companion MCP unit (U1); this PR only adds the OAuth + discovery routes and their `index.ts` mounts.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>