### PR TITLE
feat(api): remote MCP server at /api/mcp + keyless key-management routes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "hono": "^4.12.21",
         "nanoid": "^5.1.0",
         "zod": "^3.24.0",
+        "zod-to-json-schema": "^3.25.2",
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.16.7",
@@ -1858,7 +1859,7 @@
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "zrender": ["zrender@6.1.0", "", { "dependencies": { "tslib": "2.3.0" } }, "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ=="],
 
@@ -1895,6 +1896,8 @@
     "@langchain/core/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@modelcontextprotocol/sdk/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "@modelcontextprotocol/sdk/zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
@@ -1983,6 +1986,8 @@
     "rollup/@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg=="],
 
     "shadcn/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
+
+    "shadcn/zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,7 +15,8 @@
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.21",
     "nanoid": "^5.1.0",
-    "zod": "^3.24.0"
+    "zod": "^3.24.0",
+    "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.16.7",

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -13,9 +13,11 @@ import analyticsPublicRouter from "./routes/analytics-public";
 import conversationsRouter from "./routes/conversations";
 import domainsRouter from "./routes/domains";
 import keysRouter from "./routes/keys";
+import mcpRouter from "./routes/mcp";
 import projectTracesRouter from "./routes/project-traces";
 import projectsRouter from "./routes/projects";
 import tagsRouter from "./routes/tags";
+import v1KeysRouter from "./routes/v1-keys";
 // V2-only features — new capabilities with no v1 equivalent
 import capabilityTokensV2Router from "./routes/v2/capability-tokens";
 import claimsV2Router from "./routes/v2/claims";
@@ -101,6 +103,12 @@ app.get("/agents.md", (c) => c.text(AGENTS_MD));
 app.get("/openapi.json", (c) => c.json(JSON.parse(OPENAPI_SPEC)));
 
 // ---------------------------------------------------------------------------
+// Remote MCP server (Streamable HTTP) at /api/mcp
+// ---------------------------------------------------------------------------
+// Accepts API keys and OAuth/capability tokens via its own mcpAuth middleware.
+app.route("/api/mcp", mcpRouter);
+
+// ---------------------------------------------------------------------------
 // Unified API at /api/v1/*
 // One API version — v1 is the latest and only version.
 //
@@ -138,6 +146,11 @@ app.route("/api/v1/projects", projectsRouter);
 
 // API keys (at /api/projects for backward compat)
 app.route("/api/projects", keysRouter);
+
+// Keyless API-key management (project from auth context) for non-dashboard
+// clients (SDK / stdio MCP). Mounted before the tags router so its apiKeyAuth
+// catch-all does not intercept these paths.
+app.route("/api/v1/keys", v1KeysRouter);
 
 // Analytics: /api/v1/projects/:id/analytics
 app.route("/api/v1/projects", analyticsRouter);

--- a/packages/api/src/middleware/mcp-auth.ts
+++ b/packages/api/src/middleware/mcp-auth.ts
@@ -1,0 +1,122 @@
+import { and, eq, gt, isNull, or } from "drizzle-orm";
+import { createMiddleware } from "hono/factory";
+import { apiKeys, capabilityTokens } from "../db/schema";
+import { hashApiKey } from "../lib/crypto";
+import { effectiveKeyScopes, parseScopesJson } from "../lib/scopes";
+import type { Bindings, Variables } from "../types";
+
+// ---------------------------------------------------------------------------
+// MCP auth — accepts either an `as_live_` API key or an `as_cap_` capability
+// token (the OAuth-issued access tokens reuse the capability-token table). Sets
+// the same context vars as the other auth middlewares so the MCP tool handlers
+// can call services directly with `c.get("projectId")` and enforce per-tool
+// scopes via `c.get("capabilityScopes")`.
+//
+// On any auth failure the MCP spec requires a 401 carrying a WWW-Authenticate
+// header that points clients at the protected-resource metadata document, so
+// they can discover the authorization server and start the OAuth flow.
+// ---------------------------------------------------------------------------
+
+/** Constant-time failure delay, matching auth.ts / scoped-auth.ts. */
+const AUTH_FAILURE_MIN_MS = 300;
+
+/** Build the resource-metadata URL for the WWW-Authenticate challenge. */
+function resourceMetadataUrl(reqUrl: string): string {
+  const origin = new URL(reqUrl).origin;
+  return `${origin}/.well-known/oauth-protected-resource`;
+}
+
+/**
+ * Normalize legacy capability-token scopes to their canonical API-scope form so
+ * scope enforcement is uniform across the MCP server. Capability tokens carry
+ * `lease:write` / `claim:write` (singular), while API_SCOPES — and the MCP
+ * tools' `requiredScope` — use `leases:write` / `claims:write` (plural). Without
+ * this mapping a capability token could never satisfy the lease/claim tools,
+ * breaking the delegation path those tokens exist for. (state:* scopes are
+ * identical in both forms and pass through unchanged.)
+ */
+function normalizeToApiScopes(scopes: string[]): string[] {
+  return scopes.map((scope) => {
+    if (scope === "lease:write") return "leases:write";
+    if (scope === "claim:write") return "claims:write";
+    return scope;
+  });
+}
+
+async function authFailure(c: any, startedAt: number): Promise<Response> {
+  const remainingMs = Math.max(0, AUTH_FAILURE_MIN_MS - (performance.now() - startedAt));
+  await new Promise((resolve) => setTimeout(resolve, remainingMs));
+  c.header("WWW-Authenticate", `Bearer resource_metadata="${resourceMetadataUrl(c.req.url)}"`);
+  return c.json({ error: { code: "UNAUTHORIZED", message: "Unauthorized" } }, 401);
+}
+
+export const mcpAuth = createMiddleware<{ Bindings: Bindings; Variables: Variables }>(
+  async (c, next) => {
+    const startedAt = performance.now();
+    const authHeader = c.req.header("Authorization");
+    const key = authHeader?.startsWith("Bearer ") ? authHeader.slice(7).trim() : "";
+
+    if (!key) return authFailure(c, startedAt);
+
+    const hash = await hashApiKey(key);
+    const db = c.get("db");
+
+    // Capability / OAuth access token.
+    if (key.startsWith("as_cap_")) {
+      const now = Date.now();
+      const [token] = await db
+        .select({
+          id: capabilityTokens.id,
+          projectId: capabilityTokens.projectId,
+          scopes: capabilityTokens.scopes,
+        })
+        .from(capabilityTokens)
+        .where(
+          and(
+            eq(capabilityTokens.keyHash, hash),
+            isNull(capabilityTokens.revokedAt),
+            or(isNull(capabilityTokens.expiresAt), gt(capabilityTokens.expiresAt, now)),
+          ),
+        )
+        .limit(1);
+
+      if (!token) return authFailure(c, startedAt);
+
+      c.set("projectId", token.projectId);
+      c.set("apiKeyHash", hash);
+      c.set("authType", "capability_token");
+      c.set("capabilityScopes", normalizeToApiScopes(parseScopesJson(token.scopes)));
+      c.executionCtx.waitUntil(
+        db
+          .update(capabilityTokens)
+          .set({ lastUsedAt: now })
+          .where(eq(capabilityTokens.id, token.id)),
+      );
+      await next();
+      return;
+    }
+
+    // Regular API key.
+    if (key.startsWith("as_live_")) {
+      const [apiKey] = await db
+        .select({ id: apiKeys.id, projectId: apiKeys.projectId, scopes: apiKeys.scopes })
+        .from(apiKeys)
+        .where(and(eq(apiKeys.keyHash, hash), isNull(apiKeys.revokedAt)))
+        .limit(1);
+
+      if (!apiKey) return authFailure(c, startedAt);
+
+      c.set("projectId", apiKey.projectId);
+      c.set("apiKeyHash", hash);
+      c.set("authType", "api_key");
+      c.set("capabilityScopes", effectiveKeyScopes(apiKey.scopes));
+      c.executionCtx.waitUntil(
+        db.update(apiKeys).set({ lastUsedAt: Date.now() }).where(eq(apiKeys.id, apiKey.id)),
+      );
+      await next();
+      return;
+    }
+
+    return authFailure(c, startedAt);
+  },
+);

--- a/packages/api/src/routes/mcp/index.ts
+++ b/packages/api/src/routes/mcp/index.ts
@@ -1,0 +1,194 @@
+import { Hono } from "hono";
+import { scopeSatisfies } from "../../lib/scopes";
+import { mcpAuth } from "../../middleware/mcp-auth";
+import type { Bindings, Variables } from "../../types";
+import { TOOLS, TOOLS_BY_NAME, type ToolContext, ToolError } from "./tools";
+
+// ---------------------------------------------------------------------------
+// Remote MCP server — stateless Streamable HTTP transport (MCP 2025-06-18).
+//
+// A single JSON-RPC message is POSTed per request; we dispatch by method and
+// return the JSON-RPC response object. We do NOT maintain sessions
+// (Mcp-Session-Id) or server-initiated SSE — every request carries its own
+// auth and is fully self-contained.
+// ---------------------------------------------------------------------------
+
+const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+const PROTOCOL_VERSION = "2025-06-18";
+// Protocol versions this server can speak. On initialize we echo the client's
+// requested version only if it is one of these; otherwise we answer with our
+// latest supported version, per the MCP spec.
+const SUPPORTED_PROTOCOL_VERSIONS = new Set(["2025-06-18", "2025-03-26"]);
+const SERVER_INFO = { name: "agentstate", version: "0.1.0" };
+
+// Origins allowed to call the MCP endpoint cross-site. Mirrors the global CORS
+// allowlist in index.ts; same-origin requests (no Origin header) always pass.
+const ALLOWED_ORIGINS = new Set([
+  "https://agentstate.app",
+  "http://localhost:3000",
+  "http://localhost:8787",
+  "http://127.0.0.1:3000",
+  "http://127.0.0.1:8787",
+]);
+
+// JSON-RPC error codes (subset of the spec we emit). Tool-level failures use a
+// successful result with `isError: true`, so only these protocol-level codes
+// are needed here.
+const PARSE_ERROR = -32700;
+const INVALID_REQUEST = -32600;
+const METHOD_NOT_FOUND = -32601;
+
+interface JsonRpcRequest {
+  jsonrpc?: string;
+  id?: string | number | null;
+  method?: string;
+  params?: Record<string, unknown>;
+}
+
+function rpcResult(id: string | number | null, result: unknown) {
+  return { jsonrpc: "2.0", id, result };
+}
+
+function rpcError(id: string | number | null, code: number, message: string) {
+  return { jsonrpc: "2.0", id, error: { code, message } };
+}
+
+router.use("*", mcpAuth);
+
+// Server-initiated SSE is not supported in stateless mode.
+router.get("/", (c) =>
+  c.json({ error: { code: "METHOD_NOT_ALLOWED", message: "GET not supported" } }, 405),
+);
+
+router.post("/", async (c) => {
+  // Origin check (DNS-rebinding protection). Browsers always send Origin on
+  // cross-site requests; non-browser MCP clients omit it. Reject a present
+  // Origin that is not same-origin and not allowlisted.
+  const origin = c.req.header("Origin");
+  if (origin) {
+    const sameOrigin = origin === new URL(c.req.url).origin;
+    if (!sameOrigin && !ALLOWED_ORIGINS.has(origin)) {
+      return c.json({ error: { code: "FORBIDDEN", message: "Origin not allowed" } }, 403);
+    }
+  }
+
+  let message: JsonRpcRequest;
+  try {
+    message = (await c.req.json()) as JsonRpcRequest;
+  } catch {
+    return c.json(rpcError(null, PARSE_ERROR, "Parse error"), 200);
+  }
+
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return c.json(rpcError(null, INVALID_REQUEST, "Invalid Request"), 200);
+  }
+
+  // Notifications (and responses) carry no `id` — acknowledge with 202, no body.
+  if (message.id === undefined || message.id === null) {
+    return c.body(null, 202);
+  }
+
+  const id = message.id;
+  const method = message.method;
+
+  switch (method) {
+    case "initialize": {
+      const requested = message.params?.protocolVersion;
+      const negotiated =
+        typeof requested === "string" && SUPPORTED_PROTOCOL_VERSIONS.has(requested)
+          ? requested
+          : PROTOCOL_VERSION;
+      return c.json(
+        rpcResult(id, {
+          protocolVersion: negotiated,
+          capabilities: { tools: {} },
+          serverInfo: SERVER_INFO,
+        }),
+      );
+    }
+
+    case "ping":
+      return c.json(rpcResult(id, {}));
+
+    case "tools/list":
+      return c.json(
+        rpcResult(id, {
+          tools: TOOLS.map((tool) => ({
+            name: tool.name,
+            description: tool.description,
+            inputSchema: tool.inputSchema,
+          })),
+        }),
+      );
+
+    case "tools/call":
+      return c.json(rpcResult(id, await callTool(c, message.params)));
+
+    default:
+      return c.json(rpcError(id, METHOD_NOT_FOUND, `Method not found: ${method ?? "(none)"}`));
+  }
+});
+
+/**
+ * Run a tool call. Tool-level failures (unknown tool, missing scope, invalid
+ * args, handler error) are returned as a successful JSON-RPC result with
+ * `isError: true`, per the MCP spec — only protocol-level problems use
+ * JSON-RPC errors.
+ */
+async function callTool(
+  c: ToolContext,
+  params: Record<string, unknown> | undefined,
+): Promise<{ content: { type: "text"; text: string }[]; isError?: boolean }> {
+  const name = typeof params?.name === "string" ? params.name : "";
+  const tool = TOOLS_BY_NAME.get(name);
+  if (!tool) {
+    return errorContent(`Unknown tool: ${name || "(none)"}`);
+  }
+
+  const granted = c.get("capabilityScopes") ?? [];
+  if (!scopeSatisfies(granted, tool.requiredScope)) {
+    return errorContent(`FORBIDDEN: missing required scope ${tool.requiredScope}`);
+  }
+
+  const parsed = tool.zodSchema.safeParse(params?.arguments ?? {});
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const path = issue?.path.join(".");
+    return errorContent(
+      `INVALID_PARAMS: ${path ? `${path}: ` : ""}${issue?.message ?? "invalid arguments"}`,
+    );
+  }
+
+  try {
+    const result = await tool.handler(c, parsed.data);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    if (err instanceof ToolError) {
+      return errorContent(`Error: ${err.code}: ${err.message}`);
+    }
+    // Unexpected internal error: log it server-side (the global onError handler
+    // is bypassed because we return a successful JSON-RPC result), and return a
+    // generic message so internal details are not leaked to the client.
+    console.error(
+      JSON.stringify({
+        level: "error",
+        request_id: c.res.headers.get("X-Request-Id"),
+        path: c.req.path,
+        tool: name,
+        error: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+      }),
+    );
+    return errorContent("Error: INTERNAL_ERROR: internal server error");
+  }
+}
+
+function errorContent(text: string): {
+  content: { type: "text"; text: string }[];
+  isError: true;
+} {
+  return { content: [{ type: "text", text }], isError: true };
+}
+
+export default router;

--- a/packages/api/src/routes/mcp/tools.ts
+++ b/packages/api/src/routes/mcp/tools.ts
@@ -1,0 +1,617 @@
+import { and, eq } from "drizzle-orm";
+import type { Context } from "hono";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { conversations as conversationsTable, messages as messagesTable } from "../../db/schema";
+import { GrantableScopeSchema, scopesSatisfyAll } from "../../lib/scopes";
+import { deserializeConversationFull, deserializeMessage } from "../../lib/serialization";
+import { CapabilityScopeSchema } from "../../lib/validation";
+import * as capabilityTokensService from "../../services/capability-tokens";
+import * as claimsService from "../../services/claims";
+import * as keysService from "../../services/keys";
+import * as leasesService from "../../services/leases";
+import * as statesService from "../../services/states";
+import * as conversationsService from "../../services/v2-conversations";
+import type { Bindings, Variables } from "../../types";
+
+export type ToolContext = Context<{ Bindings: Bindings; Variables: Variables }>;
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  /** JSON Schema object advertised to MCP clients via tools/list. */
+  inputSchema: Record<string, unknown>;
+  /** Scope the caller must hold (checked before the handler runs). */
+  requiredScope: string;
+  /** Zod schema used to validate `params.arguments` before dispatch. */
+  zodSchema: z.ZodTypeAny;
+  handler: (c: ToolContext, args: any) => Promise<unknown>;
+}
+
+/**
+ * Error thrown by a tool handler that maps to a domain error code. Surfaced to
+ * the client as an `isError` result with `CODE: message` text.
+ */
+export class ToolError extends Error {
+  code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared zod shapes — reused from the stdio MCP (packages/mcp) so the remote
+// and local servers advertise identical tool input shapes.
+// ---------------------------------------------------------------------------
+
+const messageSchema = z.object({
+  role: z.enum(["user", "assistant", "system", "tool"]),
+  content: z.string(),
+  metadata: z.record(z.unknown()).optional(),
+  token_count: z.number().int().optional(),
+});
+
+const claimEvidenceSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("text_hash"),
+    source: z.string(),
+    data: z.string(),
+    hash: z.string(),
+  }),
+  z.object({
+    kind: z.literal("json_value"),
+    source: z.string(),
+    data: z.unknown(),
+    json_path: z.string(),
+    expected_value: z.unknown(),
+  }),
+  z.object({
+    kind: z.literal("state_event"),
+    source: z.string(),
+    hash: z.string().optional(),
+    json_path: z.string().optional(),
+    expected_value: z.unknown().optional(),
+  }),
+]);
+
+// ---------------------------------------------------------------------------
+// Per-tool argument schemas
+// ---------------------------------------------------------------------------
+
+const storeConversationSchema = z.object({
+  external_id: z.string().optional().describe("Optional external identifier for deduplication"),
+  title: z.string().optional().describe("Human-readable title for the conversation"),
+  metadata: z.record(z.unknown()).optional().describe("Arbitrary JSON metadata"),
+  messages: z.array(messageSchema).optional().describe("Initial messages to include"),
+});
+
+const recallConversationSchema = z.object({
+  id: z.string().describe("Conversation ID"),
+});
+
+const listConversationsSchema = z.object({
+  limit: z.number().int().min(1).max(100).optional().describe("Max results (1–100)"),
+  cursor: z.string().optional().describe("Pagination cursor from previous response"),
+  order: z.enum(["asc", "desc"]).optional().describe("Sort order by creation time"),
+  tag: z.string().optional().describe("Filter: only return conversations with this exact tag"),
+});
+
+const upsertStateSchema = z.object({
+  state_key: z.string().describe("Dot-separated key path, e.g. agent:worker-1:progress"),
+  agent_id: z.string().describe("Identifier of the agent that owns this state"),
+  data: z.record(z.unknown()).describe("JSON object to store"),
+  metadata: z.record(z.unknown()).optional().describe("Optional metadata JSON object"),
+  tags: z.array(z.string()).optional().describe("Tags for filtering and querying"),
+  lease_id: z.string().optional().describe("Lease ID for fenced write — prevents stale writes"),
+  idempotency_key: z
+    .string()
+    .optional()
+    .describe("Optional idempotency key for exactly-once semantics"),
+});
+
+const getStateSchema = z.object({
+  state_key: z.string().describe("State key to read"),
+  at_sequence: z.number().int().optional().describe("Read state as of this sequence number"),
+  at_time: z.number().int().optional().describe("Read state as of this Unix-ms timestamp"),
+});
+
+const queryStatesSchema = z.object({
+  agent_id: z.string().optional().describe("Filter by agent ID"),
+  tags: z.array(z.string()).optional().describe("Filter: all records that have these tags"),
+  updated_after: z
+    .number()
+    .int()
+    .optional()
+    .describe("Unix-ms — only records updated after this time"),
+  updated_before: z
+    .number()
+    .int()
+    .optional()
+    .describe("Unix-ms — only records updated before this time"),
+  json_path: z.string().optional().describe("JSON path expression, e.g. $.status"),
+  json_equals: z.unknown().optional().describe("Value that json_path must equal"),
+  at_sequence: z.number().int().optional().describe("Read state as of this sequence"),
+  at_time: z.number().int().optional().describe("Read state as of this Unix-ms timestamp"),
+  limit: z.number().int().min(1).max(100).optional().describe("Max results"),
+  cursor: z.string().optional().describe("Pagination cursor"),
+});
+
+const acquireLeaseSchema = z.object({
+  state_key: z.string().describe("State key to lock, e.g. task:order-42"),
+  holder: z.string().describe("Identifier of the agent trying to acquire the lease"),
+  ttl_ms: z
+    .number()
+    .int()
+    .min(1000)
+    .optional()
+    .describe("Lease TTL in milliseconds (server default: 60000)."),
+});
+
+const renewLeaseSchema = z.object({
+  lease_id: z.string().describe("Lease ID returned by acquire_lease"),
+  ttl_ms: z.number().int().min(1000).optional().describe("New TTL in milliseconds from now"),
+});
+
+const releaseLeaseSchema = z.object({
+  lease_id: z.string().describe("Lease ID to release"),
+});
+
+const createClaimSchema = z.object({
+  subject_type: z.string().describe("Type of subject, e.g. 'conversation' or 'api-call'"),
+  subject_id: z.string().describe("ID of the subject being claimed about"),
+  statement: z.string().describe("Human-readable assertion, e.g. 'The summary is accurate'"),
+  evidence: z
+    .array(claimEvidenceSchema)
+    .min(1)
+    .describe("Evidence list. Each item is one of: text_hash, json_value, or state_event."),
+});
+
+const verifyClaimSchema = z.object({
+  claim_id: z.string().describe("Claim ID to verify"),
+});
+
+const mintCapabilityTokenSchema = z.object({
+  name: z.string().describe("Human-readable name for the token, e.g. 'summarizer-subagent'"),
+  scopes: z
+    .array(CapabilityScopeSchema)
+    .min(1)
+    .describe("Scopes: state:read, state:write, state:watch, lease:write, claim:write"),
+  expires_at: z.number().int().optional().describe("Unix-ms expiry timestamp for the token"),
+});
+
+const createApiKeySchema = z.object({
+  name: z.string().describe("Human-readable name for the new API key"),
+  scopes: z
+    .array(GrantableScopeSchema)
+    .min(1)
+    .optional()
+    .describe(
+      "Scopes to grant. Must be a subset of the caller's scopes. Omit to inherit the caller's scopes.",
+    ),
+});
+
+const listApiKeysSchema = z.object({});
+
+const revokeApiKeySchema = z.object({
+  id: z.string().describe("API key ID to revoke"),
+});
+
+// ---------------------------------------------------------------------------
+// Tool handlers
+// ---------------------------------------------------------------------------
+
+async function recallConversation(c: ToolContext, id: string) {
+  const db = c.get("db");
+  const projectId = c.get("projectId");
+  const [conversation] = await db
+    .select()
+    .from(conversationsTable)
+    .where(and(eq(conversationsTable.id, id), eq(conversationsTable.projectId, projectId)))
+    .limit(1);
+
+  if (!conversation) throw new ToolError("NOT_FOUND", "Conversation not found");
+
+  const msgs = await db
+    .select()
+    .from(messagesTable)
+    .where(eq(messagesTable.conversationId, conversation.id))
+    .orderBy(messagesTable.createdAt);
+
+  return {
+    ...deserializeConversationFull(conversation),
+    messages: msgs.map(deserializeMessage),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// JSON Schema generation
+// ---------------------------------------------------------------------------
+
+function jsonSchema(schema: z.ZodTypeAny): Record<string, unknown> {
+  const generated = zodToJsonSchema(schema, {
+    target: "openApi3",
+    $refStrategy: "none",
+  }) as Record<string, unknown>;
+  // MCP clients expect a bare JSON Schema object; drop the $schema key.
+  const { $schema, ...rest } = generated;
+  return rest;
+}
+
+// ---------------------------------------------------------------------------
+// Tool registry
+// ---------------------------------------------------------------------------
+
+export const TOOLS: ToolDefinition[] = [
+  // --- Conversations ---
+  {
+    name: "store_conversation",
+    description:
+      "Create a new conversation with an optional list of messages. Returns the conversation record including generated ID.",
+    requiredScope: "conversations:write",
+    zodSchema: storeConversationSchema,
+    inputSchema: jsonSchema(storeConversationSchema),
+    handler: async (c, args: z.infer<typeof storeConversationSchema>) => {
+      const result = await conversationsService.createConversation(c.get("db"), {
+        projectId: c.get("projectId"),
+        externalId: args.external_id ?? null,
+        title: args.title ?? null,
+        metadata: args.metadata ?? null,
+        inputMessages: args.messages,
+      });
+      if (result.error) throw new ToolError(result.error.code, result.error.message);
+      return {
+        id: result.conversationId,
+        project_id: result.projectId,
+        external_id: result.externalId,
+        title: result.title,
+        metadata: result.metadata,
+        message_count: result.messageCount,
+        token_count: result.tokenCount,
+        total_cost_microdollars: result.totalCostMicrodollars,
+        total_tokens: result.totalTokens,
+        created_at: result.createdAt,
+        updated_at: result.updatedAt,
+      };
+    },
+  },
+  {
+    name: "recall_conversation",
+    description: "Retrieve a conversation by its ID, including all stored messages.",
+    requiredScope: "conversations:read",
+    zodSchema: recallConversationSchema,
+    inputSchema: jsonSchema(recallConversationSchema),
+    handler: (c, args: z.infer<typeof recallConversationSchema>) => recallConversation(c, args.id),
+  },
+  {
+    name: "list_conversations",
+    description:
+      "List conversations for the current project with optional pagination and filtering.",
+    requiredScope: "conversations:read",
+    zodSchema: listConversationsSchema,
+    inputSchema: jsonSchema(listConversationsSchema),
+    handler: async (c, args: z.infer<typeof listConversationsSchema>) => {
+      const result = await conversationsService.listConversations(
+        c.get("db"),
+        c.env.AUTH_CACHE,
+        c.get("projectId"),
+        {
+          limit: args.limit ?? 50,
+          cursor: args.cursor,
+          order: args.order ?? "desc",
+          tag: args.tag,
+        },
+      );
+      if (result.error) throw new ToolError(result.error.code, result.error.message);
+      return {
+        data: result.rows.map(deserializeConversationFull),
+        pagination: {
+          limit: result.rows.length,
+          next_cursor: result.nextCursor,
+          total: result.totalCount,
+        },
+      };
+    },
+  },
+
+  // --- State ---
+  {
+    name: "upsert_state",
+    description:
+      "Write (create or overwrite) a state record at the given state_key. Optionally pass a lease_id for fenced writes.",
+    requiredScope: "state:write",
+    zodSchema: upsertStateSchema,
+    inputSchema: jsonSchema(upsertStateSchema),
+    handler: async (c, args: z.infer<typeof upsertStateSchema>) => {
+      const { state_key, idempotency_key, ...input } = args;
+      const result = await statesService.upsertState(
+        c.get("d1Db"),
+        c.get("projectId"),
+        state_key,
+        input,
+        idempotency_key,
+      );
+      if (result.error) throw new ToolError(result.error.code, result.error.message);
+      return result.result?.body;
+    },
+  },
+  {
+    name: "get_state",
+    description:
+      "Read the current state record at state_key. Optionally read at a historical sequence or timestamp.",
+    requiredScope: "state:read",
+    zodSchema: getStateSchema,
+    inputSchema: jsonSchema(getStateSchema),
+    handler: async (c, args: z.infer<typeof getStateSchema>) => {
+      const state =
+        args.at_sequence !== undefined || args.at_time !== undefined
+          ? await statesService.getHistoricalState(
+              c.get("d1Db"),
+              c.get("projectId"),
+              args.state_key,
+              args.at_sequence,
+              args.at_time,
+            )
+          : await statesService.getLatestState(c.get("d1Db"), c.get("projectId"), args.state_key);
+      if (!state) throw new ToolError("NOT_FOUND", "State not found");
+      return state;
+    },
+  },
+  {
+    name: "query_states",
+    description:
+      "Query state records across the project with flexible filters (agent, tags, JSON path, time range).",
+    requiredScope: "state:read",
+    zodSchema: queryStatesSchema,
+    inputSchema: jsonSchema(queryStatesSchema),
+    handler: async (c, args: z.infer<typeof queryStatesSchema>) => {
+      const result = await statesService.queryStates(c.get("d1Db"), c.get("projectId"), args);
+      if (result.error) throw new ToolError(result.error.code, result.error.message);
+      return {
+        data: result.rows ?? [],
+        pagination: {
+          limit: result.rows?.length ?? 0,
+          next_cursor: result.nextCursor ?? null,
+        },
+      };
+    },
+  },
+
+  // --- Leases ---
+  {
+    name: "acquire_lease",
+    description:
+      "Acquire a distributed lease on state_key. Returns a conflict if already held. Use the lease_id for fenced state writes.",
+    requiredScope: "leases:write",
+    zodSchema: acquireLeaseSchema,
+    inputSchema: jsonSchema(acquireLeaseSchema),
+    handler: async (c, args: z.infer<typeof acquireLeaseSchema>) => {
+      const result = await leasesService.createLease(
+        c.get("db"),
+        c.get("projectId"),
+        args.state_key,
+        args.holder,
+        args.ttl_ms,
+      );
+      if (result.error) throw new ToolError(result.error.code, result.error.message);
+      return result.lease;
+    },
+  },
+  {
+    name: "renew_lease",
+    description:
+      "Renew an active lease before it expires. Must be called while the lease is still valid.",
+    requiredScope: "leases:write",
+    zodSchema: renewLeaseSchema,
+    inputSchema: jsonSchema(renewLeaseSchema),
+    handler: async (c, args: z.infer<typeof renewLeaseSchema>) => {
+      const result = await leasesService.renewLease(
+        c.get("db"),
+        c.get("projectId"),
+        args.lease_id,
+        args.ttl_ms,
+      );
+      if (result.error) throw new ToolError(result.error.code, result.error.message);
+      return result.lease;
+    },
+  },
+  {
+    name: "release_lease",
+    description:
+      "Release a held lease immediately, making the state key available to the next acquirer.",
+    requiredScope: "leases:write",
+    zodSchema: releaseLeaseSchema,
+    inputSchema: jsonSchema(releaseLeaseSchema),
+    handler: async (c, args: z.infer<typeof releaseLeaseSchema>) => {
+      const error = await leasesService.releaseLease(
+        c.get("db"),
+        c.get("projectId"),
+        args.lease_id,
+      );
+      if (error) throw new ToolError(error.code, error.message);
+      return { released: true };
+    },
+  },
+
+  // --- Claims ---
+  {
+    name: "create_claim",
+    description:
+      "Create a verifiable claim about a subject with attached evidence. Status starts as 'pending'; call verify_claim to evaluate it.",
+    requiredScope: "claims:write",
+    zodSchema: createClaimSchema,
+    inputSchema: jsonSchema(createClaimSchema),
+    handler: async (c, args: z.infer<typeof createClaimSchema>) => {
+      return claimsService.createClaim(c.get("db"), {
+        projectId: c.get("projectId"),
+        subjectType: args.subject_type,
+        subjectId: args.subject_id,
+        statement: args.statement,
+        evidence: args.evidence.map(mapClaimEvidence),
+      });
+    },
+  },
+  {
+    name: "verify_claim",
+    description:
+      "Trigger a verification run for an existing claim. Re-evaluates all evidence items and returns 'verified' or 'failed' with per-item details.",
+    requiredScope: "claims:write",
+    zodSchema: verifyClaimSchema,
+    inputSchema: jsonSchema(verifyClaimSchema),
+    handler: async (c, args: z.infer<typeof verifyClaimSchema>) => {
+      const run = await claimsService.verifyClaim(c.get("db"), c.get("projectId"), args.claim_id);
+      if (!run) throw new ToolError("NOT_FOUND", "Claim not found");
+      return run;
+    },
+  },
+
+  // --- Capability tokens ---
+  {
+    name: "mint_capability_token",
+    description:
+      "Mint a scoped capability token for delegation to sub-agents. The raw token is shown once — store it before discarding the response.",
+    requiredScope: "keys:write",
+    zodSchema: mintCapabilityTokenSchema,
+    inputSchema: jsonSchema(mintCapabilityTokenSchema),
+    handler: async (c, args: z.infer<typeof mintCapabilityTokenSchema>) => {
+      // Delegation: the caller may only mint a token whose scopes are a subset
+      // of its own. The caller's scopes are in API form (mcpAuth normalizes
+      // capability tokens to it), while the REQUESTED scopes are capability-token
+      // form (lease:write/claim:write, singular), so map the request up to API
+      // form before the subset check.
+      const callerScopes = c.get("capabilityScopes") ?? [];
+      const required = args.scopes.map(capabilityToApiScope);
+      if (!scopesSatisfyAll(callerScopes, required)) {
+        throw new ToolError("FORBIDDEN", "Cannot grant scopes beyond the calling key's own scopes");
+      }
+      return capabilityTokensService.createCapabilityToken(c.get("db"), c.get("projectId"), {
+        name: args.name,
+        scopes: args.scopes,
+        expires_at: args.expires_at,
+      });
+    },
+  },
+
+  // --- API key management ---
+  {
+    name: "create_api_key",
+    description:
+      "Create a new API key for the current project. Requested scopes must be a subset of the caller's scopes; omit to inherit them. The raw key is shown once.",
+    requiredScope: "keys:write",
+    zodSchema: createApiKeySchema,
+    inputSchema: jsonSchema(createApiKeySchema),
+    handler: async (c, args: z.infer<typeof createApiKeySchema>) => {
+      // Same delegation rule as routes/keys.ts: a key may only mint a child key
+      // whose scopes are a subset of its own. Omitted scopes inherit the
+      // caller's scopes (no escalation), except a full-access (`*`) caller
+      // leaves scopes unset to produce a full-access child.
+      const callerScopes = c.get("capabilityScopes") ?? [];
+      const callerHasFullAccess = callerScopes.includes("*");
+      let childScopes = args.scopes;
+      if (childScopes) {
+        if (!scopesSatisfyAll(callerScopes, childScopes)) {
+          throw new ToolError(
+            "FORBIDDEN",
+            "Cannot grant scopes beyond the calling key's own scopes",
+          );
+        }
+      } else if (!callerHasFullAccess) {
+        childScopes = callerScopes;
+      }
+      const apiKey = await keysService.createApiKey(
+        c.get("db"),
+        c.get("projectId"),
+        args.name,
+        childScopes,
+      );
+      return {
+        id: apiKey.id,
+        name: apiKey.name,
+        key_prefix: apiKey.key_prefix,
+        key: apiKey.key,
+        scopes: apiKey.scopes,
+        created_at: apiKey.created_at,
+        last_used_at: apiKey.last_used_at,
+        revoked_at: apiKey.revoked_at,
+      };
+    },
+  },
+  {
+    name: "list_api_keys",
+    description: "List API keys for the current project. Raw secrets are never returned.",
+    requiredScope: "keys:read",
+    zodSchema: listApiKeysSchema,
+    inputSchema: jsonSchema(listApiKeysSchema),
+    handler: async (c) => {
+      const keys = await keysService.listApiKeys(c.get("db"), c.get("projectId"));
+      return {
+        data: keys.map((k) => ({
+          id: k.id,
+          name: k.name,
+          key_prefix: k.key_prefix,
+          scopes: k.scopes,
+          created_at: k.created_at,
+          last_used_at: k.last_used_at,
+          revoked_at: k.revoked_at,
+        })),
+      };
+    },
+  },
+  {
+    name: "revoke_api_key",
+    description: "Revoke an API key by ID, immediately invalidating it.",
+    requiredScope: "keys:write",
+    zodSchema: revokeApiKeySchema,
+    inputSchema: jsonSchema(revokeApiKeySchema),
+    handler: async (c, args: z.infer<typeof revokeApiKeySchema>) => {
+      const revokedHash = await keysService.revokeApiKey(c.get("db"), c.get("projectId"), args.id);
+      if (!revokedHash) throw new ToolError("NOT_FOUND", "API key not found");
+      // Drop the auth-cache entry so the revoked key stops working immediately.
+      const cache = c.env.AUTH_CACHE;
+      if (cache) {
+        c.executionCtx.waitUntil(cache.delete(`auth:hash:${revokedHash}`));
+      }
+      return { revoked: true, id: args.id };
+    },
+  },
+];
+
+export const TOOLS_BY_NAME = new Map(TOOLS.map((tool) => [tool.name, tool]));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a capability-token scope (e.g. "lease:write") to the API scope it
+ * corresponds to (e.g. "leases:write") for the delegation subset check.
+ */
+function capabilityToApiScope(scope: string): string {
+  if (scope === "lease:write") return "leases:write";
+  if (scope === "claim:write") return "claims:write";
+  return scope;
+}
+
+type ClaimEvidence = z.infer<typeof claimEvidenceSchema>;
+
+function mapClaimEvidence(input: ClaimEvidence): claimsService.CreateEvidenceInput {
+  if (input.kind === "text_hash") {
+    return { kind: "text_hash", source: input.source, data: input.data, hash: input.hash };
+  }
+  if (input.kind === "json_value") {
+    return {
+      kind: "json_value",
+      source: input.source,
+      data: input.data,
+      jsonPath: input.json_path,
+      expectedValue: input.expected_value,
+    };
+  }
+  return {
+    kind: "state_event",
+    source: input.source,
+    hash: input.hash,
+    jsonPath: input.json_path,
+    expectedValue: input.expected_value,
+  };
+}

--- a/packages/api/src/routes/v1-keys.ts
+++ b/packages/api/src/routes/v1-keys.ts
@@ -1,0 +1,109 @@
+import { Hono } from "hono";
+import {
+  errorResponse,
+  invalidateAuthCacheEntries,
+  notFound,
+  parseJsonBody,
+  validationError,
+} from "../lib/helpers";
+import { scopesSatisfyAll } from "../lib/scopes";
+import { CreateApiKeySchema } from "../lib/validation";
+import { apiKeyAuth } from "../middleware/auth";
+import { rateLimitMiddleware } from "../middleware/rate-limit";
+import { requireScope } from "../middleware/require-scope";
+import * as keysService from "../services/keys";
+import type { Bindings, Variables } from "../types";
+
+// ---------------------------------------------------------------------------
+// Keyless API-key management — manage keys for the authenticated project using
+// only an API key (no projectId in the path, no Clerk session). Used by
+// non-dashboard clients (SDK, stdio MCP). The dashboard keeps using the
+// projectId-scoped routes in routes/keys.ts. Project is always derived from the
+// auth context, so a caller can never manage another project's keys.
+// ---------------------------------------------------------------------------
+
+const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+app.use("*", apiKeyAuth);
+app.use("*", rateLimitMiddleware);
+
+// POST / — Create API key
+app.post("/", requireScope("keys:write"), async (c) => {
+  const db = c.get("db");
+  const projectId = c.get("projectId");
+
+  const { body, error } = await parseJsonBody(c);
+  if (error) return error;
+
+  const parsed = CreateApiKeySchema.safeParse(body);
+  if (!parsed.success) return validationError(c, parsed.error);
+
+  // Delegation rule (identical to routes/keys.ts): a key may only mint a child
+  // whose scopes are a subset of its own. Omitted scopes inherit the caller's
+  // scopes; a full-access (`*`) caller leaves scopes unset for a full child.
+  const callerScopes = c.get("capabilityScopes") ?? [];
+  const callerHasFullAccess = callerScopes.includes("*");
+  let childScopes = parsed.data.scopes;
+  if (childScopes) {
+    if (!scopesSatisfyAll(callerScopes, childScopes)) {
+      return errorResponse(
+        c,
+        "FORBIDDEN",
+        "Cannot grant scopes beyond the calling key's own scopes",
+        403,
+      );
+    }
+  } else if (!callerHasFullAccess) {
+    childScopes = callerScopes;
+  }
+
+  const apiKey = await keysService.createApiKey(db, projectId, parsed.data.name, childScopes);
+
+  return c.json(
+    {
+      id: apiKey.id,
+      name: apiKey.name,
+      key_prefix: apiKey.key_prefix,
+      key: apiKey.key,
+      scopes: apiKey.scopes,
+      created_at: apiKey.created_at,
+      last_used_at: apiKey.last_used_at,
+      revoked_at: apiKey.revoked_at,
+    },
+    201,
+  );
+});
+
+// GET / — List API keys
+app.get("/", requireScope("keys:read"), async (c) => {
+  const db = c.get("db");
+  const keys = await keysService.listApiKeys(db, c.get("projectId"));
+
+  return c.json({
+    data: keys.map((k) => ({
+      id: k.id,
+      name: k.name,
+      key_prefix: k.key_prefix,
+      scopes: k.scopes,
+      created_at: k.created_at,
+      last_used_at: k.last_used_at,
+      revoked_at: k.revoked_at,
+    })),
+  });
+});
+
+// DELETE /:id — Revoke API key
+app.delete("/:id", requireScope("keys:write"), async (c) => {
+  const db = c.get("db");
+  const keyId = c.req.param("id");
+
+  const revokedHash = await keysService.revokeApiKey(db, c.get("projectId"), keyId);
+  if (!revokedHash) return notFound(c, "API key not found");
+
+  // Invalidate the auth-cache entry so the revoked key stops working immediately.
+  invalidateAuthCacheEntries(c, [revokedHash]);
+
+  return c.body(null, 204);
+});
+
+export default app;

--- a/packages/api/test/mcp.test.ts
+++ b/packages/api/test/mcp.test.ts
@@ -1,0 +1,245 @@
+import { SELF } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import { applyMigrations, authHeaders, seedProject, TEST_API_KEY } from "./setup";
+
+// ---------------------------------------------------------------------------
+// Remote MCP server (POST /api/mcp) — stateless Streamable HTTP
+// ---------------------------------------------------------------------------
+
+const MCP_URL = "http://localhost/api/mcp";
+const TEST_KEY = TEST_API_KEY;
+
+function bearer(key: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${key}`,
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+  };
+}
+
+async function rpc(
+  headers: Record<string, string>,
+  body: Record<string, unknown>,
+): Promise<{ status: number; json: any }> {
+  const res = await SELF.fetch(MCP_URL, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  return { status: res.status, json: text ? JSON.parse(text) : null };
+}
+
+/** Create a scoped key via the keyless /api/v1/keys route. */
+async function createScopedKey(scopes: string[]): Promise<string> {
+  const res = await SELF.fetch("http://localhost/api/v1/keys", {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify({ name: "scoped-mcp", scopes }),
+  });
+  expect(res.status).toBe(201);
+  const body = (await res.json()) as { key: string };
+  return body.key;
+}
+
+describe("remote MCP server", () => {
+  beforeEach(async () => {
+    await applyMigrations();
+    await seedProject();
+  });
+
+  it("initialize returns serverInfo and protocol version", async () => {
+    const { status, json } = await rpc(bearer(TEST_KEY), {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2025-06-18" },
+    });
+    expect(status).toBe(200);
+    expect(json.result.serverInfo).toEqual({ name: "agentstate", version: "0.1.0" });
+    expect(json.result.protocolVersion).toBe("2025-06-18");
+    expect(json.result.capabilities).toHaveProperty("tools");
+  });
+
+  it("notifications/initialized returns 202 with no body", async () => {
+    const res = await SELF.fetch(MCP_URL, {
+      method: "POST",
+      headers: bearer(TEST_KEY),
+      body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+    });
+    expect(res.status).toBe(202);
+    expect(await res.text()).toBe("");
+  });
+
+  it("tools/list lists all tools with input schemas", async () => {
+    const { status, json } = await rpc(bearer(TEST_KEY), {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+    });
+    expect(status).toBe(200);
+    const names = json.result.tools.map((t: { name: string }) => t.name);
+    expect(names).toContain("store_conversation");
+    expect(names).toContain("list_conversations");
+    expect(names).toContain("upsert_state");
+    expect(names).toContain("acquire_lease");
+    expect(names).toContain("create_claim");
+    expect(names).toContain("mint_capability_token");
+    expect(names).toContain("create_api_key");
+    expect(names).toContain("list_api_keys");
+    expect(names).toContain("revoke_api_key");
+    // Every tool advertises a JSON Schema object.
+    for (const tool of json.result.tools) {
+      expect(tool.inputSchema).toBeTypeOf("object");
+      expect(tool.inputSchema.type).toBe("object");
+    }
+  });
+
+  it("tools/call list_conversations returns data", async () => {
+    const { status, json } = await rpc(bearer(TEST_KEY), {
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: { name: "list_conversations", arguments: {} },
+    });
+    expect(status).toBe(200);
+    expect(json.result.isError).toBeUndefined();
+    const payload = JSON.parse(json.result.content[0].text);
+    expect(payload).toHaveProperty("data");
+    expect(Array.isArray(payload.data)).toBe(true);
+  });
+
+  it("tools/call store_conversation then recall round-trips", async () => {
+    const store = await rpc(bearer(TEST_KEY), {
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: {
+        name: "store_conversation",
+        arguments: { title: "hi", messages: [{ role: "user", content: "hello" }] },
+      },
+    });
+    expect(store.json.result.isError).toBeUndefined();
+    const created = JSON.parse(store.json.result.content[0].text);
+    expect(created.id).toBeTruthy();
+    expect(created.message_count).toBe(1);
+
+    const recall = await rpc(bearer(TEST_KEY), {
+      jsonrpc: "2.0",
+      id: 5,
+      method: "tools/call",
+      params: { name: "recall_conversation", arguments: { id: created.id } },
+    });
+    const fetched = JSON.parse(recall.json.result.content[0].text);
+    expect(fetched.id).toBe(created.id);
+    expect(fetched.messages).toHaveLength(1);
+    expect(fetched.messages[0].content).toBe("hello");
+  });
+
+  it("a scoped key calling an out-of-scope tool returns isError", async () => {
+    const readOnly = await createScopedKey(["conversations:read"]);
+    const { status, json } = await rpc(bearer(readOnly), {
+      jsonrpc: "2.0",
+      id: 6,
+      method: "tools/call",
+      params: {
+        name: "upsert_state",
+        arguments: { state_key: "k", agent_id: "a", data: { x: 1 } },
+      },
+    });
+    // Tool-level authorization failures are a successful JSON-RPC result.
+    expect(status).toBe(200);
+    expect(json.result.isError).toBe(true);
+    expect(json.result.content[0].text).toContain("FORBIDDEN");
+  });
+
+  it("a scoped key can call an in-scope tool", async () => {
+    const readOnly = await createScopedKey(["conversations:read"]);
+    const { json } = await rpc(bearer(readOnly), {
+      jsonrpc: "2.0",
+      id: 7,
+      method: "tools/call",
+      params: { name: "list_conversations", arguments: {} },
+    });
+    expect(json.result.isError).toBeUndefined();
+  });
+
+  it("a capability token with lease:write can call acquire_lease (scope-form normalization)", async () => {
+    // Mint a capability token scoped to the singular capability form.
+    const mint = await rpc(bearer(TEST_KEY), {
+      jsonrpc: "2.0",
+      id: 20,
+      method: "tools/call",
+      params: {
+        name: "mint_capability_token",
+        arguments: { name: "sub", scopes: ["lease:write"] },
+      },
+    });
+    expect(mint.json.result.isError).toBeUndefined();
+    const token = JSON.parse(mint.json.result.content[0].text).token as string;
+    expect(token.startsWith("as_cap_")).toBe(true);
+
+    // The token's singular lease:write must satisfy the lease tool's plural
+    // leases:write requiredScope, or capability-token delegation is broken.
+    const acquire = await rpc(bearer(token), {
+      jsonrpc: "2.0",
+      id: 21,
+      method: "tools/call",
+      params: {
+        name: "acquire_lease",
+        arguments: { state_key: "task:1", holder: "sub" },
+      },
+    });
+    expect(acquire.json.result.isError).toBeUndefined();
+    const lease = JSON.parse(acquire.json.result.content[0].text);
+    expect(lease.id).toBeTruthy();
+    expect(lease.state_key).toBe("task:1");
+
+    // But it must NOT be able to write conversations (scope it never had).
+    const store = await rpc(bearer(token), {
+      jsonrpc: "2.0",
+      id: 22,
+      method: "tools/call",
+      params: { name: "store_conversation", arguments: { title: "nope" } },
+    });
+    expect(store.json.result.isError).toBe(true);
+    expect(store.json.result.content[0].text).toContain("FORBIDDEN");
+  });
+
+  it("initialize answers with a supported version for an unsupported request", async () => {
+    const { json } = await rpc(bearer(TEST_KEY), {
+      jsonrpc: "2.0",
+      id: 23,
+      method: "initialize",
+      params: { protocolVersion: "1999-01-01" },
+    });
+    expect(json.result.protocolVersion).toBe("2025-06-18");
+  });
+
+  it("unknown method returns JSON-RPC -32601", async () => {
+    const { json } = await rpc(bearer(TEST_KEY), {
+      jsonrpc: "2.0",
+      id: 8,
+      method: "does/not/exist",
+    });
+    expect(json.error.code).toBe(-32601);
+  });
+
+  it("no Authorization returns 401 with WWW-Authenticate header", async () => {
+    const res = await SELF.fetch(MCP_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 9, method: "initialize", params: {} }),
+    });
+    expect(res.status).toBe(401);
+    const challenge = res.headers.get("WWW-Authenticate");
+    expect(challenge).toContain("Bearer");
+    expect(challenge).toContain("resource_metadata=");
+    expect(challenge).toContain("/.well-known/oauth-protected-resource");
+  });
+
+  it("GET /api/mcp returns 405", async () => {
+    const res = await SELF.fetch(MCP_URL, { method: "GET", headers: bearer(TEST_KEY) });
+    expect(res.status).toBe(405);
+  });
+});


### PR DESCRIPTION
## What

Adds a **remote MCP server** at `POST /api/mcp` (MCP spec 2025-06-18, stateless Streamable HTTP) so agents can connect over the network with an AgentState API key or an OAuth/capability access token — no local stdio bridge required. Also adds **keyless API-key management** REST routes so non-dashboard clients (SDK / stdio MCP) can manage keys with just their API key.

This is unit **U1** of the larger remote-MCP + OAuth + scoped-keys feature. It composes with U2 (OAuth): the `401` challenge points at `/.well-known/oauth-protected-resource`, which U2's discovery router serves.

## Changes

- **`middleware/mcp-auth.ts`** — accepts `as_live_` API keys and `as_cap_` capability tokens (honoring expiry/revocation). Sets `projectId` + `capabilityScopes`. On missing/invalid token returns `401` with `WWW-Authenticate: Bearer resource_metadata="<origin>/.well-known/oauth-protected-resource"`. Keeps the 300ms constant-time failure delay. Normalizes legacy capability scopes (`lease:write`/`claim:write`) to API form (`leases:write`/`claims:write`) so capability tokens can satisfy the lease/claim tools they were minted for.
- **`routes/mcp/index.ts`** — JSON-RPC dispatcher: `initialize` (with protocol-version negotiation), `tools/list`, `tools/call`, `ping`, notifications→`202`, unknown method→`-32601`, `GET`→`405`. Origin check for DNS-rebinding protection. Tool failures returned as `isError` results; unexpected errors logged server-side + generic message returned (no internal leak).
- **`routes/mcp/tools.ts`** — 15-tool registry calling the conversation / state / lease / claim / key services **directly** (project from auth context). Reuses the stdio MCP's tool names, descriptions, and zod input shapes; `zod-to-json-schema` generates the JSON Schemas for `tools/list`. New tools: `create_api_key` / `list_api_keys` / `revoke_api_key` with the same subset-delegation rule as the dashboard key routes.
- **`routes/v1-keys.ts`** — keyless `POST` / `GET` / `DELETE` `/api/v1/keys` (project from auth context, never another project's keys).
- **`index.ts`** — mounts both routers.
- Adds `zod-to-json-schema` dependency.

## Tests

`test/mcp.test.ts` (12 tests) covers: `initialize` serverInfo + version negotiation, `tools/list`, `tools/call` (list + store→recall round-trip), scope enforcement (scoped key out-of-scope → `isError`), **capability-token lease delegation** (singular→plural scope normalization), `401` + `WWW-Authenticate`, `GET`→`405`. Full API suite: **302 passing**. Typecheck + biome clean. Verified end-to-end against `wrangler dev`.

## Review

Ran `/code-review` (xhigh). Fixed the one high-severity finding it surfaced: capability tokens carry singular scope forms but lease/claim tools required the plural API forms, so capability-token delegation for leases/claims would always 403 — fixed by normalizing at the auth boundary (now covered by a test). Also addressed protocol-version negotiation and internal-error logging/leak.

**Follow-up (not in this PR):** the child-scope delegation block is now duplicated across `routes/keys.ts`, `routes/v1-keys.ts`, and `routes/mcp/tools.ts`. Consider extracting a shared `resolveChildScopes()` helper — kept consistent-with-existing rather than refactoring the foundation here.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>