### PR TITLE
feat(dashboard): scoped-key permissions UI, OAuth consent screen, MCP connect

### DIFF
--- a/packages/dashboard/src/components/dashboard/integrate/integrate-content.tsx
+++ b/packages/dashboard/src/components/dashboard/integrate/integrate-content.tsx
@@ -96,6 +96,29 @@ curl https://agentstate.app/api/v1/conversations/:id \\
   -H "Authorization: Bearer as_live_..."`,
 };
 
+const MCP_REMOTE_URL = "https://agentstate.app/api/mcp";
+
+// Token mode — paste an API key (or capability token); no browser sign-in needed.
+const MCP_TOKEN_CONFIG = `{
+  "mcpServers": {
+    "agentstate": {
+      "type": "http",
+      "url": "https://agentstate.app/api/mcp",
+      "headers": { "Authorization": "Bearer as_live_..." }
+    }
+  }
+}`;
+
+// OAuth mode — the client runs the consent flow; no key in config.
+const MCP_OAUTH_CONFIG = `{
+  "mcpServers": {
+    "agentstate": {
+      "type": "http",
+      "url": "https://agentstate.app/api/mcp"
+    }
+  }
+}`;
+
 const INTEGRATION_PROMPT = `Integrate AgentState into this project for persistent conversation storage.
 
 Read the full integration guide and implement it:
@@ -180,6 +203,42 @@ export default function IntegrateContent() {
           </div>
         </div>
       </div>
+
+      <hr className="my-1 border-edge" />
+
+      {/* Connect via MCP (remote server) */}
+      <section className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1.5">
+          <span className="as-label text-[10.5px]">Model Context Protocol</span>
+          <h2 className="text-[17px] font-semibold text-fg">Connect via MCP</h2>
+          <p className="text-[13px] text-fg-3">
+            Use AgentState from Claude, Cursor, and other MCP clients. Point the client at the
+            hosted server and authenticate with a token, or let it run the OAuth consent flow.
+          </p>
+        </div>
+
+        <div className="flex items-center justify-between gap-3 rounded-[var(--radius)] border border-edge bg-panel2 px-4 py-3">
+          <code className="num truncate font-mono text-[12.5px] text-fg-2">{MCP_REMOTE_URL}</code>
+          <CopyButton text={MCP_REMOTE_URL} />
+        </div>
+
+        <div className="grid grid-cols-1 gap-3.5 lg:grid-cols-2">
+          <div className="flex flex-col gap-2">
+            <span className="font-mono text-[11px] text-fg-3">Token auth (paste an API key)</span>
+            <CodeBlock code={MCP_TOKEN_CONFIG} title="mcp.json" />
+          </div>
+          <div className="flex flex-col gap-2">
+            <span className="font-mono text-[11px] text-fg-3">OAuth (browser consent)</span>
+            <CodeBlock code={MCP_OAUTH_CONFIG} title="mcp.json" />
+          </div>
+        </div>
+
+        <div className="flex items-center gap-5 font-mono text-xs text-fg-3">
+          <Link href="/docs" className="transition-colors hover:text-fg">
+            MCP &amp; permissions docs
+          </Link>
+        </div>
+      </section>
 
       <hr className="my-1 border-edge" />
 

--- a/packages/dashboard/src/components/dashboard/project/_api-keys-table.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_api-keys-table.tsx
@@ -3,7 +3,31 @@
 import type { ApiKeyResponse } from "@agentstate/shared";
 import { Key, Trash } from "@phosphor-icons/react";
 import { Card } from "@/components/ui/card";
+import { scopeLabel } from "@/lib/scopes";
 import { formatDate } from "./_utils";
+
+/** Render a key's scopes as compact badges, or a "Full access" pill when unscoped. */
+function ScopeBadges({ scopes }: { scopes: string[] | null }) {
+  if (!scopes || scopes.length === 0 || scopes.includes("*")) {
+    return (
+      <span className="inline-flex items-center rounded-full border border-edge bg-panel2 px-2 py-0.5 text-[11px] text-fg-3">
+        Full access
+      </span>
+    );
+  }
+  return (
+    <div className="flex flex-wrap gap-1">
+      {scopes.map((s) => (
+        <span
+          key={s}
+          className="inline-flex items-center rounded-full border border-edge bg-panel2 px-2 py-0.5 font-mono text-[10.5px] text-fg-3"
+        >
+          {scopeLabel(s)}
+        </span>
+      ))}
+    </div>
+  );
+}
 
 interface ApiKeysTableProps {
   keys: ApiKeyResponse[];
@@ -43,6 +67,9 @@ export function ApiKeysTable({ keys, onRevoke }: ApiKeysTableProps) {
               <th className="px-4 py-2.5 font-mono text-[10.5px] font-normal uppercase tracking-[0.12em] text-fg-4">
                 Key
               </th>
+              <th className="hidden px-4 py-2.5 font-mono text-[10.5px] font-normal uppercase tracking-[0.12em] text-fg-4 md:table-cell">
+                Permissions
+              </th>
               <th className="hidden px-4 py-2.5 font-mono text-[10.5px] font-normal uppercase tracking-[0.12em] text-fg-4 sm:table-cell">
                 Last used
               </th>
@@ -62,6 +89,9 @@ export function ApiKeysTable({ keys, onRevoke }: ApiKeysTableProps) {
                 </td>
                 <td className="py-3.5 pr-4">
                   <code className="num font-mono text-xs text-fg-3">{key.key_prefix}...</code>
+                </td>
+                <td className="hidden py-3.5 pr-4 md:table-cell">
+                  <ScopeBadges scopes={key.scopes} />
                 </td>
                 <td className="hidden py-3.5 pr-4 text-xs text-fg-3 sm:table-cell">
                   {key.last_used_at ? formatDate(key.last_used_at) : "Never"}

--- a/packages/dashboard/src/components/dashboard/project/_keys-tab.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_keys-tab.tsx
@@ -5,13 +5,14 @@ import { Plus, X } from "@phosphor-icons/react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { SCOPE_GROUPS } from "@/lib/scopes";
 import { ApiKeysTable } from "./_api-keys-table";
 
 interface KeysTabProps {
   showCreateKey: boolean;
   newKeyName: string;
   apiKeys: ApiKeyResponse[];
-  onCreateKey: () => void;
+  onCreateKey: (scopes?: string[]) => void;
   onChangeKeyName: (value: string) => void;
   onShowCreateKey: () => void;
   onCancelCreateKey: () => void;
@@ -19,8 +20,75 @@ interface KeysTabProps {
 }
 
 /**
- * Local inline key-name form — plain Tailwind on the design-system tokens.
- * Self-contained so this tab has no shared-form dependency.
+ * Permission selector: "Full access" (default) or a custom subset of scopes.
+ * Custom mode reveals a grouped checklist mirroring the API scope taxonomy.
+ */
+function ScopeSelector({
+  mode,
+  selected,
+  onModeChange,
+  onToggle,
+}: {
+  mode: "full" | "custom";
+  selected: Set<string>;
+  onModeChange: (m: "full" | "custom") => void;
+  onToggle: (scope: string) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1.5">
+        <span className="as-label text-fg-3">Permissions</span>
+        <div className="flex gap-2">
+          {(["full", "custom"] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => onModeChange(m)}
+              className={`rounded-[var(--radius)] border px-3 py-1.5 text-[12.5px] font-medium transition-[background-color,color,border-color] ${
+                mode === m
+                  ? "border-accent/50 bg-accent/10 text-fg"
+                  : "border-edge bg-panel2 text-fg-3 hover:text-fg"
+              }`}
+            >
+              {m === "full" ? "Full access" : "Custom"}
+            </button>
+          ))}
+        </div>
+      </div>
+      {mode === "custom" && (
+        <div className="flex flex-col gap-3 rounded-[var(--radius)] border border-edge-soft bg-panel2 p-3">
+          {SCOPE_GROUPS.map((group) => (
+            <div key={group.resource} className="flex flex-col gap-1.5">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-fg-4">
+                {group.label}
+              </span>
+              <div className="flex flex-wrap gap-x-4 gap-y-1.5">
+                {group.scopes.map((s) => (
+                  <label
+                    key={s.value}
+                    className="flex cursor-pointer items-center gap-1.5 text-[12.5px] text-fg-2"
+                    title={s.description}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selected.has(s.value)}
+                      onChange={() => onToggle(s.value)}
+                      className="size-3.5 accent-[var(--color-accent)]"
+                    />
+                    {s.label}
+                  </label>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Local inline key-name + permissions form — plain Tailwind on the design tokens.
  */
 function KeyNameForm({
   value,
@@ -30,42 +98,67 @@ function KeyNameForm({
 }: {
   value: string;
   onChange: (v: string) => void;
-  onSubmit: () => void;
+  onSubmit: (scopes?: string[]) => void;
   onCancel: () => void;
 }) {
   const [local, setLocal] = useState(value);
+  const [mode, setMode] = useState<"full" | "custom">("full");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
   const sync = (v: string) => {
     setLocal(v);
     onChange(v);
   };
-  const submit = () => {
-    if (local.trim()) onSubmit();
+  const toggle = (scope: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(scope)) {
+        next.delete(scope);
+      } else {
+        next.add(scope);
+      }
+      return next;
+    });
   };
+  const customEmpty = mode === "custom" && selected.size === 0;
+  const submit = () => {
+    if (!local.trim() || customEmpty) return;
+    onSubmit(mode === "custom" ? Array.from(selected) : undefined);
+  };
+
   return (
-    <div className="flex flex-col gap-2 rounded-[var(--radius-lg)] border border-edge bg-panel p-5 sm:flex-row sm:items-center">
-      <Input
-        id="key-name"
-        value={local}
-        onChange={(e) => sync(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            e.preventDefault();
-            submit();
-          }
-        }}
-        placeholder="e.g. Production"
-        autoFocus
-        mono
-        className="min-w-0 flex-1"
-      />
-      <div className="flex gap-2">
-        <Button variant="primary" onClick={submit} disabled={!local.trim()}>
-          Create
-        </Button>
-        <Button variant="ghost" onClick={onCancel} aria-label="Cancel" className="px-2.5">
-          <X size={16} aria-hidden />
-        </Button>
+    <div className="flex flex-col gap-4 rounded-[var(--radius-lg)] border border-edge bg-panel p-5">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <Input
+          id="key-name"
+          value={local}
+          onChange={(e) => sync(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && mode === "full") {
+              e.preventDefault();
+              submit();
+            }
+          }}
+          placeholder="e.g. Production"
+          autoFocus
+          mono
+          className="min-w-0 flex-1"
+        />
+        <div className="flex gap-2">
+          <Button variant="primary" onClick={submit} disabled={!local.trim() || customEmpty}>
+            Create
+          </Button>
+          <Button variant="ghost" onClick={onCancel} aria-label="Cancel" className="px-2.5">
+            <X size={16} aria-hidden />
+          </Button>
+        </div>
       </div>
+      <ScopeSelector mode={mode} selected={selected} onModeChange={setMode} onToggle={toggle} />
+      {customEmpty && (
+        <p className="text-[12px] text-warn">
+          Select at least one permission, or choose Full access.
+        </p>
+      )}
     </div>
   );
 }
@@ -83,7 +176,9 @@ export function KeysTab({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <p className="text-[13px] text-fg-3">Manage API keys for this project.</p>
+        <p className="text-[13px] text-fg-3">
+          Manage API keys and their permissions for this project.
+        </p>
         <Button variant="secondary" onClick={onShowCreateKey}>
           <Plus size={16} aria-hidden />
           New Key

--- a/packages/dashboard/src/components/dashboard/project/_use-key-actions.ts
+++ b/packages/dashboard/src/components/dashboard/project/_use-key-actions.ts
@@ -12,11 +12,15 @@ interface UseKeyActionsProps {
 
 export function useKeyActions({ project, onKeyCreated, onProjectRefresh }: UseKeyActionsProps) {
   const handleCreateKey = useCallback(
-    async (keyName: string) => {
+    async (keyName: string, scopes?: string[]) => {
       if (!keyName.trim() || !project) return false;
       const res = await api<{ id: string; key: string }>(`/v1/projects/${project.id}/keys`, {
         method: "POST",
-        body: JSON.stringify({ name: keyName.trim() }),
+        body: JSON.stringify({
+          name: keyName.trim(),
+          // Omit scopes for a full-access key; send the array for a restricted key.
+          ...(scopes && scopes.length > 0 ? { scopes } : {}),
+        }),
       });
       onKeyCreated(res.key);
       await onProjectRefresh();

--- a/packages/dashboard/src/components/dashboard/project/project-content.tsx
+++ b/packages/dashboard/src/components/dashboard/project/project-content.tsx
@@ -143,7 +143,9 @@ function ProjectContent() {
             showCreateKey={keysTab.showCreateKey}
             newKeyName={keysTab.newKeyName}
             apiKeys={project.api_keys}
-            onCreateKey={async () => keyActions.handleCreateKey(keysTab.newKeyName)}
+            onCreateKey={(scopes) => {
+              void keyActions.handleCreateKey(keysTab.newKeyName, scopes);
+            }}
             onChangeKeyName={keysTab.setNewKeyName}
             onShowCreateKey={() => keysTab.setShowCreateKey(true)}
             onCancelCreateKey={keysTab.resetKeyForm}

--- a/packages/dashboard/src/components/oauth/consent-screen.tsx
+++ b/packages/dashboard/src/components/oauth/consent-screen.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { SignIn, useAuth } from "@clerk/react";
+import { ShieldCheck } from "@phosphor-icons/react";
+import { useEffect, useState } from "react";
+import { Providers } from "@/components/providers";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { api } from "@/lib/api";
+import { scopeLabel } from "@/lib/scopes";
+
+interface ProjectItem {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+function Centered({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-[70vh] items-center justify-center px-4 py-12">
+      <div className="w-full max-w-md">{children}</div>
+    </div>
+  );
+}
+
+function ConsentInner() {
+  const { isLoaded, isSignedIn } = useAuth();
+  const [params, setParams] = useState<URLSearchParams | null>(null);
+  const [projects, setProjects] = useState<ProjectItem[]>([]);
+  const [projectId, setProjectId] = useState("");
+  const [loadingProjects, setLoadingProjects] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setParams(new URLSearchParams(window.location.search));
+  }, []);
+
+  useEffect(() => {
+    if (!isSignedIn) return;
+    api<{ data: ProjectItem[] }>("/v1/projects")
+      .then((res) => {
+        setProjects(res.data);
+        if (res.data[0]) setProjectId(res.data[0].id);
+      })
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : "Failed to load projects"))
+      .finally(() => setLoadingProjects(false));
+  }, [isSignedIn]);
+
+  if (!isLoaded) return <Centered>Loading…</Centered>;
+  if (!isSignedIn)
+    return (
+      <Centered>
+        <SignIn routing="hash" />
+      </Centered>
+    );
+  if (!params) return null;
+
+  const clientId = params.get("client_id") ?? "";
+  const redirectUri = params.get("redirect_uri") ?? "";
+  const scopes = (params.get("scope") ?? "").split(" ").filter(Boolean);
+  const state = params.get("state") ?? "";
+  const codeChallenge = params.get("code_challenge") ?? "";
+  const codeChallengeMethod = params.get("code_challenge_method") ?? "S256";
+  const resource = params.get("resource") ?? "";
+
+  if (!clientId || !redirectUri || !codeChallenge) {
+    return (
+      <Centered>
+        <Card className="flex flex-col gap-2 p-6">
+          <h1 className="text-[15px] font-semibold text-fg">Invalid authorization request</h1>
+          <p className="text-[13px] text-fg-3">
+            This authorization link is missing required parameters. Return to the application that
+            sent you here and try again.
+          </p>
+        </Card>
+      </Centered>
+    );
+  }
+
+  let appHost = redirectUri;
+  try {
+    appHost = new URL(redirectUri).host;
+  } catch {
+    // keep raw redirectUri as the label if it isn't a valid URL
+  }
+
+  async function decide(approve: boolean) {
+    if (approve && !projectId) {
+      setError("Select a project to grant access to.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await api<{ redirect: string }>("/oauth/authorize/decision", {
+        method: "POST",
+        body: JSON.stringify({
+          approve,
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          scopes,
+          code_challenge: codeChallenge,
+          code_challenge_method: codeChallengeMethod,
+          state,
+          resource,
+          project_id: projectId,
+        }),
+      });
+      window.location.href = res.redirect;
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Authorization failed");
+      setSubmitting(false);
+    }
+  }
+
+  const noProjects = !loadingProjects && projects.length === 0;
+
+  return (
+    <Centered>
+      <Card className="flex flex-col gap-5 p-6">
+        <div className="flex items-center gap-3">
+          <span className="flex size-10 shrink-0 items-center justify-center rounded-[var(--radius)] border border-edge bg-panel2 text-accent">
+            <ShieldCheck size={20} aria-hidden />
+          </span>
+          <div className="flex flex-col">
+            <h1 className="text-[15px] font-semibold tracking-tight text-fg">Authorize access</h1>
+            <p className="text-[12.5px] text-fg-3">
+              <span className="font-mono">{appHost}</span> wants to connect to AgentState
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <span className="as-label text-fg-3">Requested permissions</span>
+          {scopes.length === 0 ? (
+            <p className="text-[13px] text-fg-3">No specific permissions requested.</p>
+          ) : (
+            <div className="flex flex-wrap gap-1.5">
+              {scopes.map((s) => (
+                <span
+                  key={s}
+                  className="inline-flex items-center rounded-full border border-edge bg-panel2 px-2.5 py-1 font-mono text-[11.5px] text-fg-2"
+                >
+                  {scopeLabel(s)}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="consent-project" className="as-label text-fg-3">
+            Grant access to project
+          </label>
+          {noProjects ? (
+            <p className="text-[13px] text-warn">
+              You have no projects yet.{" "}
+              <a href="/dashboard" className="text-accent underline">
+                Create one
+              </a>{" "}
+              first.
+            </p>
+          ) : (
+            <select
+              id="consent-project"
+              value={projectId}
+              onChange={(e) => setProjectId(e.target.value)}
+              disabled={loadingProjects}
+              className="w-full rounded-[var(--radius)] border border-edge bg-panel2 px-3 py-2 text-[13px] text-fg"
+            >
+              {projects.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+
+        {error && <p className="text-[12.5px] text-neg">{error}</p>}
+
+        <div className="flex gap-2">
+          <Button
+            variant="primary"
+            className="flex-1"
+            disabled={submitting || noProjects || !projectId}
+            onClick={() => decide(true)}
+          >
+            Approve
+          </Button>
+          <Button variant="secondary" disabled={submitting} onClick={() => decide(false)}>
+            Deny
+          </Button>
+        </div>
+        <p className="text-[11.5px] leading-5 text-fg-4">
+          Approving issues a scoped token to this application for the selected project. You can
+          revoke it anytime from the project's API keys.
+        </p>
+      </Card>
+    </Centered>
+  );
+}
+
+export function ConsentScreen() {
+  return (
+    <Providers>
+      <ConsentInner />
+    </Providers>
+  );
+}

--- a/packages/dashboard/src/lib/scopes.ts
+++ b/packages/dashboard/src/lib/scopes.ts
@@ -1,0 +1,90 @@
+import type { ApiScope } from "@agentstate/shared";
+
+// Human-readable catalog of API-key permission scopes, mirroring the API's
+// API_SCOPES taxonomy. Used by the key-creation form and the OAuth consent
+// screen so both render the same labels.
+
+export interface ScopeDef {
+  value: ApiScope;
+  label: string;
+  description: string;
+}
+
+export interface ScopeGroup {
+  resource: string;
+  label: string;
+  scopes: ScopeDef[];
+}
+
+export const SCOPE_GROUPS: ScopeGroup[] = [
+  {
+    resource: "conversations",
+    label: "Conversations",
+    scopes: [
+      { value: "conversations:read", label: "Read", description: "List and read conversations" },
+      {
+        value: "conversations:write",
+        label: "Write",
+        description: "Create, update, tag, and delete conversations",
+      },
+    ],
+  },
+  {
+    resource: "state",
+    label: "State",
+    scopes: [
+      { value: "state:read", label: "Read", description: "Read and query state records" },
+      { value: "state:write", label: "Write", description: "Create and overwrite state" },
+      { value: "state:watch", label: "Watch", description: "Subscribe to the state event stream" },
+    ],
+  },
+  {
+    resource: "leases",
+    label: "Leases",
+    scopes: [
+      { value: "leases:write", label: "Write", description: "Acquire, renew, and release leases" },
+    ],
+  },
+  {
+    resource: "claims",
+    label: "Claims",
+    scopes: [{ value: "claims:write", label: "Write", description: "Create and verify claims" }],
+  },
+  {
+    resource: "analytics",
+    label: "Analytics",
+    scopes: [{ value: "analytics:read", label: "Read", description: "Read usage analytics" }],
+  },
+  {
+    resource: "webhooks",
+    label: "Webhooks",
+    scopes: [{ value: "webhooks:write", label: "Manage", description: "Manage webhooks" }],
+  },
+  {
+    resource: "domains",
+    label: "Domains",
+    scopes: [{ value: "domains:write", label: "Manage", description: "Manage custom domains" }],
+  },
+  {
+    resource: "keys",
+    label: "API keys",
+    scopes: [
+      { value: "keys:read", label: "Read", description: "List API keys and capability tokens" },
+      {
+        value: "keys:write",
+        label: "Manage",
+        description: "Create and revoke keys and capability tokens",
+      },
+    ],
+  },
+];
+
+export const ALL_SCOPES: ApiScope[] = SCOPE_GROUPS.flatMap((g) => g.scopes.map((s) => s.value));
+
+/** Human label for a stored scope value, including the `*` and `resource:*` wildcards. */
+export function scopeLabel(scope: string): string {
+  if (scope === "*") return "Full access";
+  const [resource, action] = scope.split(":");
+  if (action === "*") return `${resource} (all)`;
+  return `${resource}:${action}`;
+}

--- a/packages/dashboard/src/pages/oauth/consent.astro
+++ b/packages/dashboard/src/pages/oauth/consent.astro
@@ -1,0 +1,10 @@
+---
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
+import { ConsentScreen } from "@/components/oauth/consent-screen";
+// biome-ignore lint/correctness/noUnusedImports: used in the template below
+import DashboardLayout from "@/layouts/DashboardLayout.astro";
+---
+
+<DashboardLayout>
+  <ConsentScreen client:only="react" />
+</DashboardLayout>


### PR DESCRIPTION
## Wave 1 — Dashboard UI for the MCP/OAuth/scoped-keys feature

Builds on the merged backend (scoped keys #221, OAuth #223, MCP #224, docs #222).

### U4 — Key-permissions UI
- The "New Key" form now has a **Full access** (default, one-click) vs **Custom** permission selector with a grouped scope checklist mirroring the API `API_SCOPES` taxonomy.
- The keys table shows a **Permissions** column — per-key scope badges, or a "Full access" pill for unscoped keys.
- The create action sends `scopes` (omitted for full access).

### U3 — OAuth consent screen (`/oauth/consent`)
- Clerk-gated React island. Reads the OAuth `/authorize` query params, shows the requesting client (redirect host), the requested scopes as badges, and a **project selector** (the token is project-scoped).
- **Approve/Deny** POST to `/api/oauth/authorize/decision` (Clerk cookie) and follow the returned `{ redirect }`.

### U5 — Connect via MCP
- New section on the Integrate page: the hosted MCP URL (`https://agentstate.app/api/mcp`) with copyable `mcp.json` snippets for **token auth** and **OAuth**.

### Shared
- `src/lib/scopes.ts` — dashboard scope catalog + `scopeLabel()` (handles `*` / `resource:*`), reused by the key form and consent screen.

### Verification
- `bun run build` ✅ (all 14 pages incl. new `/oauth/consent`); Biome clean on changed files.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>