### PR TITLE
feat(mcp): API-key management tools for the stdio MCP server

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -22,6 +22,9 @@ Expose AgentState's conversation history, state management, distributed leases, 
 | `create_claim` | Create a verifiable claim about a subject with evidence |
 | `verify_claim` | Trigger a verification run and get pass/fail results per evidence item |
 | `mint_capability_token` | Mint a scoped sub-agent delegation token |
+| `create_api_key` | Create a new project API key with optional permission scopes (subset of the caller's) |
+| `list_api_keys` | List the project's API keys and their scopes |
+| `revoke_api_key` | Revoke an API key by ID |
 
 ## Install
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -382,6 +382,61 @@ server.tool(
   ),
 );
 
+// --- API Keys ---
+
+const apiScopeSchema = z.enum([
+  "conversations:read",
+  "conversations:write",
+  "state:read",
+  "state:write",
+  "state:watch",
+  "leases:write",
+  "claims:write",
+  "analytics:read",
+  "webhooks:write",
+  "domains:write",
+  "keys:read",
+  "keys:write",
+]);
+
+server.tool(
+  "create_api_key",
+  "Create a new API key for the current project. Scopes must be a subset of the calling key's own scopes; omit `scopes` to inherit the caller's scopes. The raw key is shown once — store it before discarding the response.",
+  {
+    name: z.string().describe("Human-readable name for the key, e.g. 'ci-runner'"),
+    scopes: z
+      .array(apiScopeSchema)
+      .optional()
+      .describe(
+        "Permission scopes to grant. Omit for a key that inherits the caller's scopes. Must be a subset of the caller's own scopes.",
+      ),
+  },
+  toolHandler(async (args) =>
+    apiRequest("/v1/keys", {
+      method: "POST",
+      body: JSON.stringify(args),
+    }),
+  ),
+);
+
+server.tool(
+  "list_api_keys",
+  "List the API keys for the current project, including each key's scopes. Secrets are never returned.",
+  {},
+  toolHandler(async () => apiRequest("/v1/keys")),
+);
+
+server.tool(
+  "revoke_api_key",
+  "Revoke an API key by ID. The key stops working immediately.",
+  {
+    id: z.string().describe("API key ID to revoke (e.g. key_abc123)"),
+  },
+  toolHandler(async ({ id }) =>
+    apiRequest(`/v1/keys/${encodeURIComponent(id)}`, { method: "DELETE" }),
+  ),
+);
+
 // ---------------------------------------------------------------------------
 // Start
 // ---------------------------------------------------------------------------

--- a/packages/mcp/tests/tools.test.ts
+++ b/packages/mcp/tests/tools.test.ts
@@ -186,6 +186,49 @@ describe("acquire_lease", () => {
   });
 });
 
+describe("api key tools", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let captured: CapturedRequest[];
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    captured = [];
+    globalThis.fetch = makeFetchMock(
+      captured,
+      { id: "key_abc", name: "ci", scopes: ["conversations:read"], key: "as_live_x" },
+      201,
+    ) as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  it("create_api_key POSTs to /v1/keys with name + scopes", async () => {
+    const payload = { name: "ci", scopes: ["conversations:read"] };
+    await apiRequest("/v1/keys", { method: "POST", body: JSON.stringify(payload) });
+    const req = captured[0]!;
+    expect(req.method).toBe("POST");
+    expect(new URL(req.url).pathname).toBe("/api/v1/keys");
+    expect(req.body).toEqual(payload);
+  });
+
+  it("list_api_keys GETs /v1/keys", async () => {
+    await apiRequest("/v1/keys");
+    const req = captured[0]!;
+    expect(req.method).toBe("GET");
+    expect(new URL(req.url).pathname).toBe("/api/v1/keys");
+  });
+
+  it("revoke_api_key DELETEs /v1/keys/:id", async () => {
+    await apiRequest("/v1/keys/key_abc", { method: "DELETE" });
+    const req = captured[0]!;
+    expect(req.method).toBe("DELETE");
+    expect(new URL(req.url).pathname).toBe("/api/v1/keys/key_abc");
+  });
+});
+
 describe("error handling", () => {
   let originalFetch: typeof globalThis.fetch;
   let captured: CapturedRequest[];


### PR DESCRIPTION
Adds `create_api_key`, `list_api_keys`, and `revoke_api_key` to the local stdio MCP server (`@agentstate/mcp`), matching the hosted remote MCP server's key tools. They call the keyless `/api/v1/keys` endpoints (project from the authenticating key); `create_api_key` accepts optional `scopes` and the server enforces the subset-of-caller delegation rule.

- 3 new tools + `apiScopeSchema` enum mirroring the API scope taxonomy
- Tests cover request URL/method/body for each
- README tool list updated

Verification: `tsc --noEmit` clean (via node), `vitest run` 11 passed.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>