### PR TITLE
docs(sdk): align SDK base-url notation + complete message-field examples

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -21,6 +21,10 @@ const client = new AgentState({
 });
 ```
 
+> **Base URL aliases.** `https://agentstate.app/api` (the TypeScript SDK default) and
+> `https://api.agentstate.app` (the Python SDK default) point at the same API and are fully
+> interchangeable. Use whichever you prefer; you only need to set `baseUrl` to override the default.
+
 ## Runtime Compatibility
 
 The SDK uses the standard `fetch` API with no platform-specific dependencies. It works in:
@@ -289,6 +293,29 @@ await client.updateConversation(conv.id, {
 await client.deleteConversation(conv.id);
 ```
 
+### Message Response Shape
+
+When you send a message you only need `role` and `content` (plus optional `metadata` and
+`token_count`). When you **read** messages back — via `getConversation`, `listMessages`, or
+`exportConversations` — the API returns the full stored record in snake_case:
+
+```jsonc
+{
+  "id": "V1StGXR8_Z5jdHi6B-myT",
+  "role": "assistant",
+  "content": "Go to Settings > Security > Reset Password.",
+  "metadata": { "source": "web" },      // null if none was set
+  "token_count": 12,                      // null if not recorded
+  "model": "gpt-4o",                      // null if not recorded
+  "input_tokens": 40,                     // null if not recorded
+  "output_tokens": 12,                    // null if not recorded
+  "created_at": 1718300000000             // Unix milliseconds
+}
+```
+
+The `model`, `input_tokens`, and `output_tokens` fields let you track per-message model usage
+and cost. Any field that was not recorded on write is returned as `null`.
+
 ### Cursor-Based Pagination
 
 ```typescript
@@ -348,7 +375,10 @@ Install the Python package:
 pip install agentstate
 ```
 
-The Python SDK (`AgentStateClient`) has feature parity with the TypeScript SDK. All method names follow Python's `snake_case` convention:
+The Python SDK (`AgentStateClient`) has feature parity with the TypeScript SDK. Its default
+`base_url` is `https://api.agentstate.app` — an alias for the TypeScript default
+`https://agentstate.app/api`. Both resolve to the same API, so you can point either SDK at either
+host. All method names follow Python's `snake_case` convention:
 
 | Python method | TS equivalent |
 |---------------|---------------|

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -98,7 +98,9 @@ pytest
 Initialize the client. Automatically retries on HTTP 429 and 5xx with exponential backoff.
 
 - `api_key`: Your AgentState API key (format: `as_live_...`)
-- `base_url`: API base URL (default: `https://api.agentstate.app`)
+- `base_url`: API base URL (default: `https://api.agentstate.app`). This is an alias for the
+  TypeScript SDK default `https://agentstate.app/api` — both resolve to the same API, so either
+  value works.
 - `max_retries`: Max retry attempts (default: 3)
 - `retry_delay_ms`: Base delay between retries in ms (default: 1000)
 

--- a/packages/python-sdk/agentstate/client.py
+++ b/packages/python-sdk/agentstate/client.py
@@ -53,7 +53,9 @@ class AgentStateClient:
 
         Args:
             api_key: AgentState API key (format: as_live_...)
-            base_url: API base URL (default: https://api.agentstate.app)
+            base_url: API base URL (default: https://api.agentstate.app, an alias for
+                the TypeScript SDK default https://agentstate.app/api; both resolve to
+                the same API)
             max_retries: Max retry attempts for 429/5xx. Default: 3
             retry_delay_ms: Base delay in ms for exponential backoff. Default: 1000
         """


### PR DESCRIPTION
## Summary

Documentation-consistency fixes for the SDK docs (Doc1 unit).

### 1. Base-URL notation
The Python SDK docs used `https://api.agentstate.app` while the TS SDK docs used `https://agentstate.app/api`. Both are valid aliases for the same API. This PR:
- Leads with `https://agentstate.app/api` (the TS SDK default, per `packages/sdk/src/index.ts`) as canonical in `docs/sdk.md`, and adds an explicit note that `https://api.agentstate.app` (the Python SDK default, per `packages/python-sdk/agentstate/client.py`) is an equivalent alias.
- Adds the same alias clarification to the Python SDK README and the `AgentStateClient.__init__` docstring (docstring/comment only — no runtime change).

### 2. Complete message-field examples
`docs/sdk.md` message examples omitted fields the API actually returns. Added a **Message Response Shape** example showing `model`, `input_tokens`, `output_tokens`, `metadata`, `token_count`, and `created_at`, matching `deserializeMessage` in `packages/api/src/lib/serialization.ts`.

## Verification
- Cross-checked field list against `serialization.ts` and `crud.ts`.
- Confirmed base URL leads with the actual TS SDK default.
- Internal links (`integration.md`, `api-reference.md`) resolve; referenced endpoints exist.
- `bun run test:sdk-examples` passes ("SDK examples validated").

Docs-only; no runtime behavior changed.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Align SDK documentation around base URL aliases and clarify message response fields returned by the API.

Documentation:
- Document base URL aliasing between https://agentstate.app/api and https://api.agentstate.app across TypeScript and Python SDK docs.
- Add a Message Response Shape example showing the full set of fields returned for stored messages, including usage and timestamp metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified SDK configuration defaults and noted that the main API URL can be used interchangeably with its alias.
  * Added guidance on message response shapes, including snake_case fields and `null` values for missing recorded data.
  * Updated Python SDK reference text to match the clarified base URL behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->