### PR TITLE
docs: fix stale route paths and missing response fields (env vars + API reference + docs-data)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -251,6 +251,8 @@ Each message object:
   "metadata": null,
   "message_count": 1,
   "token_count": 0,
+  "total_cost_microdollars": 0,
+  "total_tokens": 0,
   "created_at": 1710000000000,
   "updated_at": 1710000000000
 }
@@ -294,6 +296,8 @@ Returns conversations for the authenticated project, ordered by `updated_at`.
       "metadata": null,
       "message_count": 5,
       "token_count": 120,
+      "total_cost_microdollars": 0,
+      "total_tokens": 120,
       "created_at": 1710000000000,
       "updated_at": 1710000000000
     }
@@ -346,6 +350,8 @@ GET /api/v1/conversations/:id?include=messages
   "metadata": null,
   "message_count": 2,
   "token_count": 50,
+  "total_cost_microdollars": 0,
+  "total_tokens": 50,
   "created_at": 1710000000000,
   "updated_at": 1710000000000,
   "messages": [
@@ -406,6 +412,8 @@ Update a conversation's title and/or metadata.
   "metadata": { "key": "value" },
   "message_count": 2,
   "token_count": 50,
+  "total_cost_microdollars": 0,
+  "total_tokens": 50,
   "created_at": 1710000000000,
   "updated_at": 1710000080000
 }
@@ -1040,6 +1048,8 @@ Each message object:
   "metadata": null,
   "message_count": 1,
   "token_count": 0,
+  "total_cost_microdollars": 0,
+  "total_tokens": 0,
   "created_at": 1710000000000,
   "updated_at": 1710000000000,
   "messages": [
@@ -1089,6 +1099,8 @@ Returns conversations for the authenticated project, ordered by `updated_at`.
       "metadata": null,
       "message_count": 5,
       "token_count": 120,
+      "total_cost_microdollars": 0,
+      "total_tokens": 120,
       "created_at": 1710000000000,
       "updated_at": 1710000000000
     }
@@ -1116,7 +1128,7 @@ Returns a single conversation with all its messages.
 |-----------|------|---------|-------------|
 | `fields` | string | all | Comma-separated field names to include. Special: `!messages` excludes messages array. |
 
-**Valid fields**: `id`, `project_id`, `external_id`, `title`, `metadata`, `message_count`, `token_count`, `created_at`, `updated_at`, `messages`
+**Valid fields**: `id`, `project_id`, `external_id`, `title`, `metadata`, `message_count`, `token_count`, `total_cost_microdollars`, `total_tokens`, `created_at`, `updated_at`, `messages`
 
 **Examples:**
 
@@ -1144,6 +1156,8 @@ GET /v1/conversations/:id
   "metadata": null,
   "message_count": 2,
   "token_count": 50,
+  "total_cost_microdollars": 0,
+  "total_tokens": 50,
   "created_at": 1710000000000,
   "updated_at": 1710000000000,
   "messages": [
@@ -1342,6 +1356,8 @@ Export conversations with their full message history.
       "metadata": null,
       "message_count": 2,
       "token_count": 50,
+      "total_cost_microdollars": 0,
+      "total_tokens": 50,
       "created_at": 1710000000000,
       "updated_at": 1710000000000,
       "messages": [

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -66,8 +66,8 @@ Omitting these degrades features gracefully — the Worker still starts and hand
 |---------|------|-------------|
 | `AUTH_CACHE` | KV Namespace | Caches API key → project ID lookups to reduce D1 reads. 300 s TTL. Declared in `kv_namespaces`. |
 | `RATE_LIMITS` | KV Namespace | Stores per-key request counters for the sliding-window rate limiter. Without this binding, the Worker falls back to a fixed-window counter that resets on UTC minute boundaries. |
-| `VECTORIZE_INDEX` | Vectorize Index | Stores message embeddings for semantic search (`POST /v2/conversations/search`). Without this binding, semantic search routes return 503. |
-| `STATE_STREAM_HUB` | Durable Object | Coordinates SSE connections for live state-change streaming. Without this binding, `GET /v2/states/:key/watch` returns 503. |
+| `VECTORIZE_INDEX` | Vectorize Index | Stores message embeddings for semantic search (`GET /api/v1/conversations/search`). Without this binding, semantic search routes return 503. |
+| `STATE_STREAM_HUB` | Durable Object | Coordinates SSE connections for live state-change streaming. Without this binding, `GET /api/v1/states/watch` returns 503. |
 
 ### Worker secrets
 

--- a/packages/dashboard/src/components/docs/docs-data.ts
+++ b/packages/dashboard/src/components/docs/docs-data.ts
@@ -71,7 +71,7 @@ export const CONVERSATION_ENDPOINTS: [method: string, path: string][] = [
   ["POST", "/api/v1/conversations"],
   ["GET", "/api/v1/conversations/:id"],
   ["POST", "/api/v1/conversations/:id/messages"],
-  ["PATCH", "/api/v1/conversations/:id"],
+  ["PUT", "/api/v1/conversations/:id"],
   ["DELETE", "/api/v1/conversations/:id"],
 ];
 


### PR DESCRIPTION
## Summary

Doc consistency fixes for env-vars, API reference, and dashboard docs-data — all verified against the real routes and serializer.

### Fixes

1. **Stale `/v2/*` paths** (`docs/environment-variables.md`)
   - `VECTORIZE_INDEX` and `STATE_STREAM_HUB` referenced `/v2/conversations/search` and `/v2/states/:key/watch`. The v2 route code is mounted at `/api/v1/*` (`packages/api/src/index.ts`), so corrected to `GET /api/v1/conversations/search` and `GET /api/v1/states/watch` (real handlers: `routes/conversations/search.ts`, `routes/v2/states/index.ts`).

2. **Missing response fields** (`docs/api-reference.md`)
   - Added `total_cost_microdollars` and `total_tokens` to every conversation response example (create, list, get, update, legacy variants, export) and to the `Valid fields` whitelist. These are returned by `deserializeConversationFull()` (`packages/api/src/lib/serialization.ts`) and the create handler (`routes/conversations/crud.ts`), and are accepted by `parseFieldsParam` (`services/conversations.ts`).

3. **docs-data.ts endpoint accuracy** (`packages/dashboard/src/components/docs/docs-data.ts`)
   - Conversation update method `PATCH` -> `PUT` to match the mounted `routes/conversations/crud.ts` router (`router.put("/:id", ...)`). All other `CONVERSATION_ENDPOINTS`, `ANALYTICS_ENDPOINTS`, and `PERMISSION_SCOPES` verified accurate against the real routes and `lib/scopes.ts` (`API_SCOPES`).

### Verification
- Every referenced path/method confirmed to exist in `packages/api/src/routes/` via grep against the route mounts in `src/index.ts`.
- Dashboard build passes: `PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_placeholder bun run build` (14 pages built, exit 0).

### Out of scope (flagged as follow-ups)
- The api-reference "current API" conversations section documents `PATCH` / `?include=messages` / `pagination.total`, but the actually-mounted router (`routes/conversations/`) uses `PUT` / `fields` / no `pagination.total` — the `v2/conversations` router that implements those is unmounted dead code. Docs-vs-routing reconciliation left as a separate task.
- Message JSON examples omit ~10 fields the serializer returns (`model`, `input_tokens`, `output_tokens`, `cost_microdollars`, `parent_message_id`, `observation_type`, `start_time`, `end_time`, `status`, `level`) — flagged as a separate task to avoid bloating this focused PR.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Align documentation and dashboard docs-data with the actual API routes and conversation response schema.

Enhancements:
- Adjust dashboard docs-data conversation endpoint metadata to use PUT for conversation updates instead of PATCH.

Documentation:
- Update API reference examples and field whitelist to include total_cost_microdollars and total_tokens in conversation responses.
- Correct environment variable docs to reference the current /api/v1 conversation search and state watch endpoints.