### PR TITLE
fix(api): enforce scope checks and fix response contracts on v2 conversations

### DIFF
--- a/packages/api/src/routes/v2/conversations/crud.ts
+++ b/packages/api/src/routes/v2/conversations/crud.ts
@@ -13,6 +13,7 @@ import {
 } from "../../../lib/helpers";
 import { deserializeConversationFull, deserializeMessage } from "../../../lib/serialization";
 import { CreateConversationSchema, UpdateConversationSchema } from "../../../lib/validation";
+import { requireScope } from "../../../middleware/require-scope";
 import {
   createConversation,
   deleteConversation,
@@ -28,7 +29,7 @@ const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 // POST / — Create conversation
 // ---------------------------------------------------------------------------
 
-router.post("/", async (c) => {
+router.post("/", requireScope("conversations:write"), async (c) => {
   const { data, error } = await parseAndValidateBody(c, CreateConversationSchema);
   if (error) return error;
   if (!data)
@@ -56,9 +57,11 @@ router.post("/", async (c) => {
 // GET / — List conversations (v2: includes total count)
 // ---------------------------------------------------------------------------
 
-router.get("/", async (c) => {
+router.get("/", requireScope("conversations:read"), async (c) => {
+  const limit = parseLimitParam(c.req.query("limit"));
+
   const result = await listConversationsService(c.get("db"), c.env.AUTH_CACHE, c.get("projectId"), {
-    limit: parseLimitParam(c.req.query("limit")),
+    limit,
     cursor: c.req.query("cursor"),
     order: parseOrderParam(c.req.query("order")),
     tag: c.req.query("tag"),
@@ -77,7 +80,7 @@ router.get("/", async (c) => {
 
   return c.json({
     data: result.rows.map(deserializeConversationFull),
-    pagination: { limit: result.rows.length, next_cursor: result.nextCursor, total: totalCount },
+    pagination: { limit, next_cursor: result.nextCursor, total: totalCount },
   });
 });
 
@@ -85,7 +88,7 @@ router.get("/", async (c) => {
 // GET /:id — Get conversation (v2: messages not included by default)
 // ---------------------------------------------------------------------------
 
-router.get("/:id", async (c) => {
+router.get("/:id", requireScope("conversations:read"), async (c) => {
   const conversation = await loadConversation(c, c.req.param("id"));
   if (!conversation) return notFound(c);
 
@@ -108,7 +111,7 @@ router.get("/:id", async (c) => {
 // PATCH /:id — Update conversation (v2: uses PATCH instead of PUT)
 // ---------------------------------------------------------------------------
 
-router.patch("/:id", async (c) => {
+router.patch("/:id", requireScope("conversations:write"), async (c) => {
   const { data, error } = await parseAndValidateBody(c, UpdateConversationSchema);
   if (error) return error;
   if (!data)
@@ -125,7 +128,7 @@ router.patch("/:id", async (c) => {
 // DELETE /:id — Delete conversation
 // ---------------------------------------------------------------------------
 
-router.delete("/:id", async (c) => {
+router.delete("/:id", requireScope("conversations:write"), async (c) => {
   const id = c.req.param("id");
   if (!(await loadConversation(c, id))) return notFound(c);
 

--- a/packages/api/src/routes/v2/conversations/messages.ts
+++ b/packages/api/src/routes/v2/conversations/messages.ts
@@ -4,6 +4,7 @@ import { conversations, messages } from "../../../db/schema";
 import { notFound, parseJsonBody, parseLimitParam, validationError } from "../../../lib/helpers";
 import { deserializeMessage } from "../../../lib/serialization";
 import { AppendMessagesSchema } from "../../../lib/validation";
+import { requireScope } from "../../../middleware/require-scope";
 import { embedAndUpsert, messageVectorMeta } from "../../../services/embeddings";
 import { appendMessages } from "../../../services/messages";
 import type { Bindings, Variables } from "../../../types";
@@ -14,7 +15,7 @@ const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 // POST /:id/messages — Append messages
 // ---------------------------------------------------------------------------
 
-router.post("/:id/messages", async (c) => {
+router.post("/:id/messages", requireScope("conversations:write"), async (c) => {
   const id = c.req.param("id");
 
   // Verify conversation exists
@@ -65,15 +66,14 @@ router.post("/:id/messages", async (c) => {
     );
   }
 
-  // V2: Return 204 with no body (resource updated)
-  return c.body(null, 204);
+  return c.json({ messages: messageRows.map(deserializeMessage) }, 201);
 });
 
 // ---------------------------------------------------------------------------
 // GET /:id/messages — List messages with pagination
 // ---------------------------------------------------------------------------
 
-router.get("/:id/messages", async (c) => {
+router.get("/:id/messages", requireScope("conversations:read"), async (c) => {
   const id = c.req.param("id");
 
   // Verify conversation exists

--- a/packages/api/test/v2-conversations-scopes.test.ts
+++ b/packages/api/test/v2-conversations-scopes.test.ts
@@ -1,0 +1,227 @@
+import { createExecutionContext, env, SELF, waitOnExecutionContext } from "cloudflare:test";
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it } from "vitest";
+import { apiKeyAuth } from "../src/middleware/auth";
+import { dbMiddleware } from "../src/middleware/db";
+import crudRouter from "../src/routes/v2/conversations/crud";
+import messagesRouter from "../src/routes/v2/conversations/messages";
+import type { Bindings, Variables } from "../src/types";
+import { applyMigrations, authHeaders, seedProject, TEST_PROJECT_ID } from "./setup";
+
+// ---------------------------------------------------------------------------
+// v2/conversations is not currently mounted in src/index.ts (see
+// docs/knowledge/core-memory.md), so it can't be exercised via SELF.fetch.
+// Build a standalone app that wires the same middleware chain production
+// mounts (apiKeyAuth -> requireScope -> handler) so the scope-enforcement
+// and response-contract fixes on crud.ts / messages.ts are covered.
+// ---------------------------------------------------------------------------
+
+type App = Hono<{ Bindings: Bindings; Variables: Variables }>;
+
+function buildApp(): App {
+  const app: App = new Hono();
+  app.use("*", dbMiddleware);
+  app.use("*", apiKeyAuth);
+  app.route("/", messagesRouter);
+  app.route("/", crudRouter);
+  return app;
+}
+
+async function request(app: App, path: string, init?: RequestInit): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await app.fetch(new Request(`http://localhost${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+interface Conversation {
+  id: string;
+  project_id: string;
+  message_count: number;
+}
+
+interface ListResponse<T> {
+  data: T[];
+  pagination: { limit: number; next_cursor: string | null; total?: number };
+}
+
+function bearer(key: string): Record<string, string> {
+  return { Authorization: `Bearer ${key}`, "Content-Type": "application/json" };
+}
+
+async function createScopedKey(scopes?: string[]): Promise<string> {
+  const res = await SELF.fetch(`http://localhost/api/projects/${TEST_PROJECT_ID}/keys`, {
+    method: "POST",
+    headers: authHeaders(), // full-access seeded key
+    body: JSON.stringify({ name: "v2-conv-scope-test", ...(scopes ? { scopes } : {}) }),
+  });
+  expect(res.status).toBe(201);
+  const body = (await res.json()) as { key: string };
+  return body.key;
+}
+
+async function createConversation(app: App): Promise<Conversation> {
+  const fullAccess = await createScopedKey();
+  const res = await request(app, "/", {
+    method: "POST",
+    headers: bearer(fullAccess),
+    body: JSON.stringify({ title: "seed convo" }),
+  });
+  return res.json<Conversation>();
+}
+
+describe("v2 conversations — scope enforcement", () => {
+  const app = buildApp();
+
+  beforeEach(async () => {
+    await applyMigrations();
+    await seedProject();
+  });
+
+  describe("POST / — create conversation", () => {
+    it("rejects a key without conversations:write with 403", async () => {
+      const readOnly = await createScopedKey(["conversations:read"]);
+      const res = await request(app, "/", {
+        method: "POST",
+        headers: bearer(readOnly),
+        body: JSON.stringify({ title: "should fail" }),
+      });
+      expect(res.status).toBe(403);
+      const body = await res.json<{ error: { code: string } }>();
+      expect(body.error.code).toBe("FORBIDDEN");
+    });
+
+    it("allows a key with conversations:write", async () => {
+      const writer = await createScopedKey(["conversations:write"]);
+      const res = await request(app, "/", {
+        method: "POST",
+        headers: bearer(writer),
+        body: JSON.stringify({ title: "ok" }),
+      });
+      expect(res.status).toBe(201);
+    });
+  });
+
+  describe("PATCH /:id — update conversation", () => {
+    it("rejects a key without conversations:write with 403", async () => {
+      const created = await createConversation(app);
+      const readOnly = await createScopedKey(["conversations:read"]);
+
+      const res = await request(app, `/${created.id}`, {
+        method: "PATCH",
+        headers: bearer(readOnly),
+        body: JSON.stringify({ title: "nope" }),
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("DELETE /:id — delete conversation", () => {
+    it("rejects a key without conversations:write with 403", async () => {
+      const created = await createConversation(app);
+      const readOnly = await createScopedKey(["conversations:read"]);
+
+      const res = await request(app, `/${created.id}`, {
+        method: "DELETE",
+        headers: bearer(readOnly),
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("GET / and GET /:id — read scope", () => {
+    it("rejects a key without conversations:read with 403", async () => {
+      const writeOnly = await createScopedKey(["conversations:write"]);
+      const res = await request(app, "/", { headers: bearer(writeOnly) });
+      expect(res.status).toBe(403);
+    });
+
+    it("allows a key with conversations:read", async () => {
+      const reader = await createScopedKey(["conversations:read"]);
+      const res = await request(app, "/", { headers: bearer(reader) });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("POST /:id/messages — append messages", () => {
+    it("rejects a key without conversations:write with 403", async () => {
+      const created = await createConversation(app);
+      const readOnly = await createScopedKey(["conversations:read"]);
+
+      const res = await request(app, `/${created.id}/messages`, {
+        method: "POST",
+        headers: bearer(readOnly),
+        body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 201 with the created messages as JSON body (matches V1 contract)", async () => {
+      const created = await createConversation(app);
+      const writer = await createScopedKey(["conversations:write"]);
+
+      const res = await request(app, `/${created.id}/messages`, {
+        method: "POST",
+        headers: bearer(writer),
+        body: JSON.stringify({
+          messages: [{ role: "user", content: "Appended message", token_count: 8 }],
+        }),
+      });
+      expect(res.status).toBe(201);
+
+      const body = await res.json<{ messages: Array<{ id: string; content: string }> }>();
+      expect(Array.isArray(body.messages)).toBe(true);
+      expect(body.messages.length).toBe(1);
+      expect(body.messages[0].content).toBe("Appended message");
+    });
+
+    it("rejects a key without conversations:read for GET messages with 403", async () => {
+      const created = await createConversation(app);
+      const writeOnly = await createScopedKey(["conversations:write"]);
+
+      const res = await request(app, `/${created.id}/messages`, { headers: bearer(writeOnly) });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("GET / — pagination reflects the requested limit", () => {
+    it("echoes the requested limit, not the row count", async () => {
+      const writer = await createScopedKey(["conversations:write", "conversations:read"]);
+
+      // Seed 3 conversations, request a page of 2.
+      for (let i = 0; i < 3; i++) {
+        await request(app, "/", {
+          method: "POST",
+          headers: bearer(writer),
+          body: JSON.stringify({ title: `convo-${i}` }),
+        });
+      }
+
+      const res = await request(app, "/?limit=2", { headers: bearer(writer) });
+      expect(res.status).toBe(200);
+
+      const body = await res.json<ListResponse<Conversation>>();
+      // Fewer rows than the requested limit can come back depending on seed
+      // state, but pagination.limit must always echo the requested value.
+      expect(body.pagination.limit).toBe(2);
+      expect(body.data.length).toBeLessThanOrEqual(2);
+    });
+
+    it("reflects a different requested limit than the actual row count", async () => {
+      const writer = await createScopedKey(["conversations:write", "conversations:read"]);
+      // Seed exactly 1 conversation but request a page of 10 — the row count
+      // (1) must not leak into pagination.limit (must stay 10).
+      await request(app, "/", {
+        method: "POST",
+        headers: bearer(writer),
+        body: JSON.stringify({}),
+      });
+
+      const res = await request(app, "/?limit=10", { headers: bearer(writer) });
+      const body = await res.json<ListResponse<Conversation>>();
+
+      expect(body.data.length).toBe(1);
+      expect(body.pagination.limit).toBe(10);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Critical (Finding 2):** V2 conversations mutation routes (`POST/PATCH/DELETE` conversation, `POST` messages) ran `apiKeyAuth` with no `requireScope` check — any valid API key could mutate conversations regardless of granted scopes. Added `requireScope("conversations:write")` on every mutation and `requireScope("conversations:read")` on every read, mirroring the existing V1 pattern in `packages/api/src/routes/conversations/` exactly.
- **High (Finding 3):** `POST /:id/messages` returned `204 No Content`. Changed to `201` with `{ messages: [...] }` JSON body, matching V1's contract.
- **High (Finding 5):** `GET /` pagination echoed `result.rows.length` (actual row count) instead of the requested `limit` query param. Fixed to echo the requested limit, matching V1.

Files touched: `packages/api/src/routes/v2/conversations/crud.ts`, `packages/api/src/routes/v2/conversations/messages.ts`, plus a new test file `packages/api/test/v2-conversations-scopes.test.ts`.

**Note:** `packages/api/src/routes/v2/conversations` is not currently mounted anywhere in `packages/api/src/index.ts` (confirmed via grep — only `states`, `leases`, `capability-tokens`, `claims`, `organizations` v2 routers are wired up). This means the routes are unreachable in production today. This is flagged separately for follow-up (mount vs. remove); this PR hardens the code regardless since it may be re-enabled and matches the audit finding scope exactly.

## Test plan
- [x] New test file `v2-conversations-scopes.test.ts` builds a standalone Hono app wiring the same `dbMiddleware -> apiKeyAuth -> requireScope -> handler` chain production uses, and exercises it against the real Workers runtime + D1 (via `cloudflare:test`). Covers: 403 without `conversations:write` on POST/PATCH/DELETE conversation and POST messages; 403 without `conversations:read` on GET conversation(s)/messages; 201 + JSON body contract on message create; pagination `limit` echoing the requested value across different row counts.
- [x] `bunx vitest run` — full suite: 26 files, 341 tests passing
- [x] `bunx biome check packages/api/src/routes/v2/conversations/` and on the new test file — clean
- [x] `bunx tsc --noEmit -p packages/api/tsconfig.json` — clean
- [ ] Runtime `wrangler dev` + curl check skipped: the router isn't mounted in `src/index.ts`, so no HTTP path reaches these handlers outside of tests today (see note above)

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Enforce scope-based authorization and align response contracts for v2 conversations and messages APIs.

Bug Fixes:
- Require conversations:write scope for all v2 conversation and message mutation routes.
- Require conversations:read scope for all v2 conversation and message read routes.
- Return 201 Created with a messages JSON body from POST /:id/messages instead of 204 No Content.
- Ensure list conversations pagination echoes the requested limit parameter rather than the actual row count.

Tests:
- Add integration-style tests validating v2 conversations scope enforcement, message creation response shape, and pagination limit behavior using a standalone Hono app wired like production.