### PR TITLE
feat(dashboard): unified design-system v2 foundation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,8 +36,6 @@
       "dependencies": {
         "@agentstate/shared": "workspace:*",
         "@clerk/react": "^6.6.6",
-        "@fontsource-variable/geist": "^5.2.9",
-        "@fontsource-variable/geist-mono": "^5.2.8",
         "@fontsource-variable/hanken-grotesk": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.6",
         "@fontsource-variable/space-grotesk": "^5.2.8",
@@ -328,10 +326,6 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
-
-    "@fontsource-variable/geist": ["@fontsource-variable/geist@5.2.9", "", {}, "sha512-TP+QSBG3wxKGPE33CbMy/L0Nu3qvJ6Fy81Yc4LnQ95xH+i+cfEp8fyU8/kfV14YwszxIFPhnoMTbjL71waVpyQ=="],
-
-    "@fontsource-variable/geist-mono": ["@fontsource-variable/geist-mono@5.2.8", "", {}, "sha512-KI5bj+hkkRiHttYHmccotUZ80ZuZyai+RwI1d7UId0clkx/jXxlo8qYK8j54WzmpBjtMoEMPyllV7faDcj+6RA=="],
 
     "@fontsource-variable/hanken-grotesk": ["@fontsource-variable/hanken-grotesk@5.2.8", "", {}, "sha512-K7hu09ZKReBc7EifRLeM4K94NZBrxFEg0nGcISmVwlFQOJo4EmYkLXTWEwr5JcNW4z2hr5zy8vLS2sxC8JDmrQ=="],
 

--- a/packages/dashboard/DESIGN.md
+++ b/packages/dashboard/DESIGN.md
@@ -1,0 +1,129 @@
+# AgentState Dashboard — Design System v2
+
+The dashboard and marketing site share **one** design-token system. This doc
+is the canonical reference for downstream page work: token names, type/space
+scale, primitive components, and the rules that keep every page visually
+consistent.
+
+Source of truth:
+- **`src/styles/tokens.css`** — colors, fonts, radius, base styles, scroll-reveal. `@theme` block, single authoritative palette.
+- **`src/styles/global.css`** — imports `tokens.css`, adds shadcn-style aliases (back-compat only — see below), the `@utility` spacing/padding helpers, base `@layer`, and keyframe animations.
+
+Both are imported transitively by every layout (`RootLayout` → `global.css` → `tokens.css`; `MarketingLayout` → `global.css` → `tokens.css`). You never need to import either stylesheet yourself in a page or component.
+
+## Art direction
+
+Dark-first "state console": restrained neutral surfaces, one vermilion brand accent, mono for data/labels, generous but tight spacing. No gradients-as-decoration, no drop shadows beyond `Dialog`'s modal elevation, no more than one accent color on screen at a time.
+
+## Theme mechanism
+
+`.dark` on `<html>` is the **only** mechanism that drives color. Both Tailwind's `dark:` variant (`@custom-variant dark (&:is(.dark *))`) and every token in `tokens.css` key off it.
+
+- `theme-script.astro` (inline, pre-hydration, loaded by every layout) toggles `.dark` before paint and persists to `localStorage.theme`.
+- `Providers` (`next-themes`) uses `attribute="class"` so the client island stays in sync with the same class and the same `localStorage` key post-hydration.
+- `data-theme` / `data-mode` attributes are also set for convenience but are **cosmetic only** (they drive the sun/moon icon swap on `[data-theme-toggle]`). Never gate a color or component style on `data-theme` — use `dark:` or the tokens, which already flip with `.dark`.
+
+If you add a new theme-aware style, use the `dark:` variant or reference a token — do not write your own `[data-theme="..."]` selector.
+
+## Color tokens
+
+Canonical names (defined in `tokens.css`, use these in new code):
+
+| Token | Dark | Light | Use |
+|---|---|---|---|
+| `--color-base` / `bg-base` | `#09090b` | `#fafafa` | App canvas |
+| `--color-panel` / `bg-panel` | `#111113` | `#ffffff` | Cards, table head |
+| `--color-panel2` / `bg-panel2` | `#161618` | `#f4f4f5` | Hover / elevated surface |
+| `--color-edge` / `border-edge` | `#262629` | `#e4e4e7` | Primary borders |
+| `--color-edge-soft` / `border-edge-soft` | `#1f1f22` | `#ededee` | Subtle borders (dividers) |
+| `--color-fg` / `text-fg` | `#fafafa` | `#18181b` | Headings, strong text |
+| `--color-fg-2` / `text-fg-2` | `#d4d4d8` | `#3f3f46` | Body text |
+| `--color-fg-3` / `text-fg-3` | `#a1a1aa` | `#71717a` | Muted text |
+| `--color-fg-4` / `text-fg-4` | `#71717a` | `#a1a1aa` | Faint text, placeholders |
+| `--color-accent` / `*-accent` | `#e2664d` | `#d9543a` | **The one brand accent** — vermilion. Primary buttons, links, active nav, focus rings |
+| `--color-accent-fg` | `#ffffff` | `#ffffff` | Text/icon on a solid accent fill |
+| `--color-pos` / `*-pos` | `#34d399` | `#059669` | Positive / live status |
+| `--color-warn` / `*-warn` | `#f59e0b` | `#d97706` | Warning / rate-limited status |
+| `--color-neg` / `*-neg` | `#f87171` | `#dc2626` | Negative / error / destructive |
+
+**Back-compat aliases** (`global.css`, shadcn-style names): `bg-background`→base, `bg-card`→panel, `text-foreground`→fg, `text-muted-foreground`→fg-3, `bg-secondary`/`bg-muted`→panel2, `border-border`/`border-input`→edge, `ring`/`--color-accent` (shadcn `accent`)→accent, `bg-destructive`→neg, plus `sidebar-*` and `chart-*` aliases. These exist so already-shipped markup (docs/, brand/, some dashboard pages) keeps working without a mass find-replace. **Do not use them in new code** — use the canonical names above instead, so the codebase converges on one vocabulary over time.
+
+Never hardcode a hex color in a component. If you need a color not covered above (e.g. a third chart series), add a new named token to `tokens.css`/`global.css` with both light and dark values — don't inline a literal.
+
+## Type
+
+Three families, loaded via `@fontsource-variable/*` in every layout:
+
+| Token | Family | Use |
+|---|---|---|
+| `font-display` (`--font-display`) | Space Grotesk Variable | `h1`–`h5` (applied automatically by the base layer — don't set it manually) |
+| `font-sans` (`--font-sans`, default body font) | Hanken Grotesk Variable | Body copy, UI labels, buttons |
+| `font-mono` (`--font-mono`) | JetBrains Mono Variable | Data values, IDs, timestamps, table headers, badges, code |
+
+Headings get `font-family: var(--font-display)`, `font-weight: 600`, `letter-spacing: -0.02em`, `line-height: 1.1`, `text-wrap: balance` automatically from the base layer — just use `<h1>`–`<h5>` or the equivalent Tailwind `text-*` size utility, don't reapply font/weight/tracking by hand.
+
+Mono utility shortcuts (defined in `global.css`, prefer these over raw `font-mono text-[11px] uppercase tracking-...`):
+- `as-label` / `as-label-sm` / `as-label-xs` — uppercase mono eyebrow labels (section headers, group labels)
+- `as-mono` / `as-mono-sm` / `as-mono-xs` — tabular-nums mono for data values
+
+Numeric data outside those utilities should still get `.num` (or Tailwind's `tabular-nums`) so columns of numbers align.
+
+## Spacing & layout
+
+Use the semantic scale utilities from `global.css` — never ad-hoc `gap-4`/`p-6`/`mt-6` for these standard rhythms:
+
+| Utility | Value | Use |
+|---|---|---|
+| `space-y-section` | 24px | Vertical rhythm between major page sections |
+| `space-y-component` | 16px | Between components within a section |
+| `space-y-element` | 12px | Between closely related elements |
+| `space-y-tight` | 8px | Tightest grouping (e.g. label + input) |
+| `gap-section` / `gap-component` / `gap-element` / `gap-tight` | 24/16/12/8px | Flex/grid equivalents of the above |
+| `page-padding` / `page-padding-sm` | 16px→24px / 12px→20px responsive | Horizontal page gutters |
+| `card-padding` / `card-padding-sm` | 24px / 16px | Card interior padding |
+| `section-padding` / `section-padding-sm` | 28px / 20px vertical | Section top/bottom padding |
+
+Other helpers: `dot-grid` (dotted background texture), `fade-up` (entrance animation), `[data-reveal]` + `RevealScript` (scroll-triggered fade/slide-up, respects `prefers-reduced-motion`).
+
+## Radius & elevation
+
+| Token | Value | Use |
+|---|---|---|
+| `--radius-sm` | 6px | Small controls (checkboxes, tight chips) |
+| `--radius` | 9px | Default — buttons, inputs, cards, badges' square corners |
+| `--radius-lg` | 12px | `Card` |
+| `--radius-xl` | 14px | `Dialog` content |
+
+Use `rounded-[var(--radius)]` etc. rather than Tailwind's generic `rounded-md`/`rounded-lg` scale, so radius stays token-driven.
+
+Elevation is minimal: no box-shadow anywhere except `Dialog` (`shadow-xl`) and the mobile drawer overlay. Depth comes from the panel/panel2 surface steps and borders, not shadows.
+
+## Primitive components (`src/components/ui/`)
+
+Prop APIs are stable — do not rename variants or props when redesigning a page.
+
+- **`Button`** (`.tsx` + `.astro`) — `variant`: `primary` | `secondary` | `ghost` | `danger`. `size` (`.tsx` only): `sm` | `md` | `lg` | `icon`. `.astro` also accepts `href` to render as `<a>`.
+- **`Card`** (`.tsx` + `.astro`) — no variants, just a bordered `bg-panel` surface. Pair with `card-padding`/`card-padding-sm`.
+- **`Badge`** (`.tsx` + `.astro`) — `tone`: `default` | `live` | `warn` | `idle`. `dot` boolean for a status dot.
+- **`Input` / `Textarea` / `Label` / `Select`** (`.tsx`) — all accept `label`, `description`, `error`, `mono`.
+- **`Dialog`** family (`.tsx`) — `Dialog`, `DialogTrigger`, `DialogContent`, `DialogHeader`, `DialogTitle`, `DialogDescription`, `DialogFooter`, `DialogClose`.
+- **`Table`** family (`.tsx`) — `Table`, `TableHeader`, `TableBody`, `TableRow` (`clickable`), `TableHead` (`align`), `TableCell` (`align`, `mono`), `TableCaption`, `TableSkeleton`.
+- **`Toggle` / `Switch`** (`.tsx`) — `Toggle` variants `default` | `outline` | `ghost`, sizes `sm` | `md` | `lg`. `Switch` is a separate boolean control with `label`/`description`.
+- **`Markdown`** (`.tsx`) — renders GFM markdown styled with these tokens; no typography plugin.
+
+## Shared layout shell
+
+- **`AppShell`** (`app-shell.tsx`) — the dashboard sidebar/header/mobile-drawer chrome, auth gate, and project-scope switcher. Renders as a `client:only` React island from `DashboardLayout`.
+- **`PageHeader`** (`components/dashboard/page-header.tsx`) — standard `title` + `description` + `actions` header. Use on every dashboard page instead of hand-rolling an `<h1>` block.
+- **Layouts**: `MarketingLayout.astro` (marketing/docs/brand — full standalone `<html>`, top nav + footer), `RootLayout.astro` (bare `<html>` + Clerk-ready `<body>`, used by `DashboardLayout`), `DashboardLayout.astro` (thin wrapper around `RootLayout` for dashboard routes — the actual chrome is `AppShell`, rendered by the page).
+
+## Do / Don't
+
+- **Do** use `text-fg` / `text-fg-2` / `text-fg-3` / `text-fg-4` and `bg-panel` / `bg-panel2` / `bg-base`. **Don't** use the shadcn alias classes (`text-foreground`, `bg-card`, …) in new code — they're back-compat only.
+- **Do** use `page-padding`, `gap-component`, `space-y-section`, etc. **Don't** hand-write ad-hoc padding/margin values for standard rhythms.
+- **Do** reference `var(--radius)` / `var(--radius-lg)` / `var(--radius-xl)`. **Don't** use Tailwind's generic `rounded-md`/`rounded-lg`/`rounded-xl` scale.
+- **Do** let `<h1>`–`<h5>` pick up the display font/weight/tracking from the base layer. **Don't** reapply `font-display`/`font-semibold`/`tracking-tight` by hand on headings.
+- **Do** use `as-label`/`as-mono` utilities for mono eyebrows and data values. **Don't** hand-roll `font-mono text-[11px] uppercase tracking-[0.1em]`.
+- **Do** gate theme-aware styles on the `dark:` variant or a token that already flips with `.dark`. **Don't** write new `[data-theme="..."]` CSS — that attribute is cosmetic-only now.
+- **Do** keep primitive component prop APIs (`variant`, `size`, `tone`, …) stable when touching a page that uses them. **Don't** rename or remove a variant without updating every caller.
+- **Never** hardcode a hex color. If a token doesn't exist for what you need, add one to `tokens.css` (with both light and dark values) rather than inlining a literal.

--- a/packages/dashboard/astro.config.mjs
+++ b/packages/dashboard/astro.config.mjs
@@ -4,18 +4,10 @@ import react from "@astrojs/react";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
 
-// Kumo + base-ui call React.createContext at module eval. Under Vite these
-// must be pre-bundled (optimizeDeps.include) and kept internal for SSR so the
-// right React runtime resolves — the equivalent of Next's `transpilePackages`.
-// All four are listed explicitly to match the original next.config.ts.
-const KUMO_DEPS = [
-  "@cloudflare/kumo",
-  "@cloudflare/kumo/components/button",
-  "@cloudflare/kumo/components/surface",
-  "@base-ui/react",
-  "@phosphor-icons/react",
-  "echarts",
-];
+// These call React.createContext at module eval. Under Vite they must be
+// pre-bundled (optimizeDeps.include) and kept internal for SSR so the right
+// React runtime resolves — the equivalent of Next's `transpilePackages`.
+const REACT_CONTEXT_DEPS = ["@phosphor-icons/react", "echarts"];
 
 // Fail loud on production deploys when the Clerk publishable key is missing or
 // a placeholder. The key is inlined at build time (import.meta.env) and Clerk
@@ -61,14 +53,14 @@ export default defineConfig({
       },
     },
     optimizeDeps: {
-      include: KUMO_DEPS,
+      include: REACT_CONTEXT_DEPS,
       // Only scan the Astro entry points for deps. The legacy Next.js tree under
       // src/app/ still imports `next/*` (removed in Phase 3); excluding it here
       // stops Vite's dependency scanner from choking on unresolvable imports.
       entries: ["src/pages/**/*.{astro,tsx,ts}"],
     },
     ssr: {
-      noExternal: KUMO_DEPS,
+      noExternal: REACT_CONTEXT_DEPS,
     },
   },
 });

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -12,8 +12,6 @@
   "dependencies": {
     "@agentstate/shared": "workspace:*",
     "@clerk/react": "^6.6.6",
-    "@fontsource-variable/geist": "^5.2.9",
-    "@fontsource-variable/geist-mono": "^5.2.8",
     "@fontsource-variable/hanken-grotesk": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.6",
     "@fontsource-variable/space-grotesk": "^5.2.8",

--- a/packages/dashboard/src/components/dashboard/page-header.tsx
+++ b/packages/dashboard/src/components/dashboard/page-header.tsx
@@ -51,10 +51,8 @@ export function PageHeader({ title, description, actions }: PageHeaderProps) {
   return (
     <header className="mb-[22px] flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
       <div className="flex max-w-2xl flex-col gap-1.5">
-        <h1 className="text-[26px] tracking-tight text-foreground">{title}</h1>
-        {description && (
-          <p className="text-[14.5px] leading-6 text-muted-foreground">{description}</p>
-        )}
+        <h1 className="text-[26px] tracking-tight text-fg">{title}</h1>
+        {description && <p className="text-[14.5px] leading-6 text-fg-3">{description}</p>}
       </div>
       {actions && <div className="flex flex-wrap items-center gap-2 sm:justify-end">{actions}</div>}
     </header>

--- a/packages/dashboard/src/components/providers.tsx
+++ b/packages/dashboard/src/components/providers.tsx
@@ -17,7 +17,12 @@ const publishableKey = import.meta.env.PUBLIC_CLERK_PUBLISHABLE_KEY;
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <ThemeProvider attribute="data-theme" defaultTheme="dark" enableSystem>
+    // `.dark` is the single theme mechanism (see tokens.css) — must match the
+    // inline theme-script.astro, which toggles the same class before paint.
+    // `attribute="class"` keeps next-themes from fighting the inline script
+    // by writing a separate data-theme attribute that global.css/tokens.css
+    // don't key their color tokens off.
+    <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
       <ClerkProvider publishableKey={publishableKey} appearance={clerkAppearance}>
         {children}
         <Toaster richColors position="bottom-right" />

--- a/packages/dashboard/src/components/theme-script.astro
+++ b/packages/dashboard/src/components/theme-script.astro
@@ -4,6 +4,13 @@
  * 1. Applies the saved/system theme before paint (no FOUC).
  * 2. Delegates clicks on any [data-theme-toggle] to flip + persist the theme.
  * `is:inline` so it runs immediately and is not bundled/delayed.
+ *
+ * `.dark` is the single mechanism tokens.css/global.css key their color
+ * tokens off (via `@custom-variant dark (&:is(.dark *))`); it is the source
+ * of truth here. `data-theme`/`data-mode` are cosmetic-only (drive the sun/
+ * moon icon swap in tokens.css) — do not gate colors on them. Persists to
+ * `localStorage.theme`, the same key next-themes (attribute="class") reads
+ * on hydration, so the client island and this pre-paint script never disagree.
  */
 ---
 {/* biome-ignore lint/security/noDangerouslySetInnerHtml: theme detection must run before hydration */}

--- a/packages/dashboard/src/layouts/DashboardLayout.astro
+++ b/packages/dashboard/src/layouts/DashboardLayout.astro
@@ -1,9 +1,8 @@
 ---
 import RootLayout from "./RootLayout.astro";
-// New design-system tokens (base/panel/fg/edge/accent …). Imported by the
-// dashboard layout so routes rebuilt onto AppShell resolve the token classes.
-// Keeps the marketing-only import in MarketingLayout.astro unchanged.
-import "../styles/tokens.css";
+// tokens.css (base/panel/fg/edge/accent …) is imported transitively via
+// RootLayout → global.css → tokens.css, so every dashboard route already
+// resolves the token classes without a separate import here.
 ---
 
 <!--

--- a/packages/dashboard/src/layouts/MarketingLayout.astro
+++ b/packages/dashboard/src/layouts/MarketingLayout.astro
@@ -1,7 +1,8 @@
 ---
-import "../styles/tokens.css";
-import "@fontsource-variable/geist";
-import "@fontsource-variable/geist-mono";
+import "@fontsource-variable/space-grotesk";
+import "@fontsource-variable/hanken-grotesk";
+import "@fontsource-variable/jetbrains-mono";
+import "../styles/global.css";
 import Logo from "../components/logo.astro";
 import RevealScript from "../components/reveal-script.astro";
 import ThemeScript from "../components/theme-script.astro";

--- a/packages/dashboard/src/layouts/RootLayout.astro
+++ b/packages/dashboard/src/layouts/RootLayout.astro
@@ -17,7 +17,7 @@ const {
 ---
 
 <!doctype html>
-<html lang="en" class="font-sans">
+<html lang="en" class="dark font-sans">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/dashboard/src/styles/global.css
+++ b/packages/dashboard/src/styles/global.css
@@ -1,165 +1,90 @@
-@import "tailwindcss";
+/*
+ * Dashboard stylesheet. Imports tokens.css (the single source of truth for
+ * color/type/shape — see DESIGN.md) and layers shadcn-style semantic aliases
+ * on top so existing `bg-card` / `text-foreground` / `border-border` markup
+ * keeps working. New code should prefer the tokens.css names directly
+ * (bg-panel, text-fg, border-edge — see DESIGN.md "Do / Don't").
+ */
+@import "./tokens.css";
 @import "tw-animate-css";
 
-@custom-variant dark (&:is(.dark *));
-
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-sans);
-  --font-display: var(--font-display);
-  --font-mono: var(--font-mono);
-  --color-sidebar-ring: var(--sidebar-ring);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
-  --color-ring: var(--ring);
-  --color-input: var(--input);
-  --color-border: var(--border);
-  --color-destructive: var(--destructive);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-accent: var(--accent);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-muted: var(--muted);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-secondary: var(--secondary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-primary: var(--primary);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-popover: var(--popover);
-  --color-card-foreground: var(--card-foreground);
-  --color-card: var(--card);
+  /* ---- shadcn-style aliases → tokens.css canonical vars (back-compat) ---- */
+  --color-background: var(--color-base);
+  --color-foreground: var(--color-fg);
+  --color-card: var(--color-panel);
+  --color-card-foreground: var(--color-fg);
+  --color-popover: var(--color-panel);
+  --color-popover-foreground: var(--color-fg);
+  --color-primary: var(--color-fg);
+  --color-primary-foreground: var(--color-base);
+  --color-secondary: var(--color-panel2);
+  --color-secondary-foreground: var(--color-fg);
+  --color-muted: var(--color-panel2);
+  --color-muted-foreground: var(--color-fg-3);
+  --color-destructive: var(--color-neg);
+  --color-border: var(--color-edge);
+  --color-input: var(--color-edge);
+  --color-ring: var(--color-accent);
 
-  /* AgentState extended palette (crisp dev-tool: zinc + vermilion) */
-  --color-brand: var(--brand);
+  /* AgentState extended palette aliases (back-compat for docs/ and brand/ markup) */
+  --color-brand: var(--color-accent);
   --color-brand-ink: var(--brand-ink);
   --color-brand-soft: var(--brand-soft);
   --color-brand-line: var(--brand-line);
-  --color-surface: var(--surface);
-  --color-bg-deep: var(--bg-deep);
-  --color-ink-2: var(--ink-2);
-  --color-faint: var(--faint);
-  --color-line-soft: var(--line-soft);
+  --color-surface: var(--color-panel);
+  --color-bg-deep: var(--color-panel2);
+  --color-ink-2: var(--color-fg-2);
+  --color-faint: var(--color-fg-4);
+  --color-line-soft: var(--color-edge-soft);
 
-  --radius-sm: calc(var(--radius) * 0.66);
-  --radius-md: calc(var(--radius) * 0.85);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) * 1.55);
+  /* charts */
+  --color-chart-1: var(--color-accent);
+  --color-chart-2: var(--color-fg);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--color-fg-3);
+  --color-chart-5: var(--color-fg-4);
+
+  /* sidebar */
+  --color-sidebar: var(--color-panel);
+  --color-sidebar-foreground: var(--color-fg);
+  --color-sidebar-primary: var(--color-fg);
+  --color-sidebar-primary-foreground: var(--color-base);
+  --color-sidebar-accent: var(--color-panel2);
+  --color-sidebar-accent-foreground: var(--color-fg);
+  --color-sidebar-border: var(--color-edge);
+  --color-sidebar-ring: var(--color-accent);
 }
 
 :root {
-  /* Fonts — loaded via @fontsource-variable/* (replaces next/font/google).
-     next/font injected these variables as classes on <html>; here they are
-     fixed on :root since the font families no longer vary per-render. */
+  /* Fonts injected as classes on <html> via @fontsource-variable/* imports
+     in RootLayout/MarketingLayout — mirrored here so `var(--font-*)` reads
+     work from any component regardless of hydration order. Canonical values
+     live in tokens.css; kept in sync manually since Tailwind v4 `@theme`
+     vars aren't re-exposed as plain custom properties automatically. */
   --font-display: "Space Grotesk Variable", ui-sans-serif, system-ui, sans-serif;
   --font-sans: "Hanken Grotesk Variable", ui-sans-serif, system-ui, sans-serif;
   --font-mono: "JetBrains Mono Variable", ui-monospace, SFMono-Regular, monospace;
 
-  --background: #fafafa;
-  --foreground: #18181b;
-  --card: #ffffff;
-  --card-foreground: #18181b;
-  --popover: #ffffff;
-  --popover-foreground: #18181b;
-  --primary: #18181b;
-  --primary-foreground: #ffffff;
-  --secondary: #f4f4f5;
-  --secondary-foreground: #18181b;
-  --muted: #f4f4f5;
-  --muted-foreground: #71717a;
-  --accent: #f4f4f5;
-  --accent-foreground: #18181b;
-  --destructive: #dc2626;
-  --border: #e4e4e7;
-  --input: #e4e4e7;
-  --ring: #d9543a;
-  --radius: 0.5625rem; /* 9px — matches the prototype --r */
+  /* violet accent used only for the third chart series — no equivalent in
+     the restrained brand palette, so it stays a standalone token. */
+  --chart-3: #6b46c1;
 
-  /* brand accent (vermilion) */
-  --brand: #d9543a;
+  /* brand-ink/soft/line: deeper + alpha-blended accent tones (active nav text,
+     tinted fills/borders) — no 1:1 equivalent in the base palette, so they
+     stay standalone tokens derived from the light accent (#d9543a). */
   --brand-ink: #b43d27;
   --brand-soft: rgba(217, 84, 58, 0.08);
   --brand-line: rgba(217, 84, 58, 0.28);
-
-  /* extended neutrals from the prototype */
-  --surface: #ffffff;
-  --bg-deep: #f4f4f5;
-  --ink-2: #3f3f46;
-  --faint: #a1a1aa;
-  --line-soft: #efeff1;
-
-  /* charts */
-  --chart-1: #d9543a; /* brand */
-  --chart-2: #18181b; /* ink */
-  --chart-3: #6b46c1; /* violet — tokens */
-  --chart-4: #71717a;
-  --chart-5: #a1a1aa;
-
-  /* sidebar — shadcn neutral palette */
-  --sidebar: #f8f9fa;
-  --sidebar-foreground: #111111;
-  --sidebar-primary: #1a1a1a;
-  --sidebar-primary-foreground: #f8f9fa;
-  --sidebar-accent: #f0f0f2;
-  --sidebar-accent-foreground: #1a1a1a;
-  --sidebar-border: #e2e2e5;
-  --sidebar-ring: #888888;
 }
 
 .dark {
-  --background: #0a0a0b;
-  --foreground: #fafafa;
-  --card: #161618;
-  --card-foreground: #fafafa;
-  --popover: #161618;
-  --popover-foreground: #fafafa;
-  --primary: #fafafa;
-  --primary-foreground: #18181b;
-  --secondary: #1c1c1f;
-  --secondary-foreground: #fafafa;
-  --muted: #1c1c1f;
-  --muted-foreground: #a1a1aa;
-  --accent: #1f1f23;
-  --accent-foreground: #fafafa;
-  --destructive: #ef4444;
-  --border: #27272a;
-  --input: #27272a;
-  --ring: #e2664d;
+  --chart-3: #a78bfa;
 
-  --brand: #e2664d;
+  /* derived from the dark accent (#e2664d) */
   --brand-ink: #f08a76;
   --brand-soft: rgba(226, 102, 77, 0.14);
   --brand-line: rgba(226, 102, 77, 0.34);
-
-  --surface: #161618;
-  --bg-deep: #161618;
-  --ink-2: #d4d4d8;
-  --faint: #71717a;
-  --line-soft: #1f1f22;
-
-  --chart-1: #e2664d;
-  --chart-2: #fafafa;
-  --chart-3: #a78bfa;
-  --chart-4: #a1a1aa;
-  --chart-5: #71717a;
-
-  --sidebar: #111111;
-  --sidebar-foreground: #f0f0f2;
-  --sidebar-primary: #a0a0d0;
-  --sidebar-primary-foreground: #f0f0f2;
-  --sidebar-accent: #262628;
-  --sidebar-accent-foreground: #f0f0f2;
-  --sidebar-border: rgba(255, 255, 255, 0.1);
-  --sidebar-ring: #666666;
 }
 
 @layer base {
@@ -185,7 +110,7 @@
   }
 
   ::selection {
-    background: var(--brand-soft);
+    background: color-mix(in srgb, var(--color-accent) 30%, transparent);
   }
 }
 
@@ -195,7 +120,7 @@
   font-weight: 500;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--muted-foreground);
+  color: var(--color-fg-3);
 }
 
 @utility as-mono {
@@ -227,7 +152,7 @@
 }
 
 @utility dot-grid {
-  background-image: radial-gradient(var(--border) 1px, transparent 1px);
+  background-image: radial-gradient(var(--color-edge) 1px, transparent 1px);
   background-size: 22px 22px;
 }
 

--- a/packages/dashboard/src/styles/tokens.css
+++ b/packages/dashboard/src/styles/tokens.css
@@ -1,15 +1,21 @@
 /*
- * AgentState design tokens — "state console" (dark-first, Geist, restrained).
- * Centralized so a redesign is a one-file change. Imported by global.css.
+ * AgentState Design System v2 — single source of truth for color, type, and
+ * shape tokens ("state console": dark-first, vermilion-accented, restrained).
+ * Imported by global.css so BOTH the dashboard (RootLayout) and marketing
+ * (MarketingLayout) resolve the exact same palette. See
+ * packages/dashboard/DESIGN.md for the full spec and usage rules.
  */
 @import "tailwindcss";
 
 @custom-variant dark (&:is(.dark *));
 
 @theme {
-  /* type */
-  --font-sans: "Geist", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-  --font-mono: "Geist Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  /* type — Space Grotesk (display) + Hanken Grotesk (body) + JetBrains Mono (code) */
+  --font-sans:
+    "Hanken Grotesk Variable", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    sans-serif;
+  --font-display: "Space Grotesk Variable", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "JetBrains Mono Variable", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 
   /* surfaces (dark-first) */
   --color-base: #09090b; /* app canvas (zinc-950) */
@@ -24,8 +30,8 @@
   --color-fg-3: #a1a1aa; /* muted (zinc-400) */
   --color-fg-4: #71717a; /* faint (zinc-500) */
 
-  /* accents (restrained: one blue + functional) */
-  --color-accent: #3b82f6; /* primary interactive (blue-500) */
+  /* accents (restrained: one vermilion brand + functional) */
+  --color-accent: #e2664d; /* primary interactive — vermilion (dark) */
   --color-accent-fg: #ffffff;
   --color-pos: #34d399; /* positive / live (emerald-400) */
   --color-warn: #f59e0b; /* warn / rate-limited (amber-500) */
@@ -33,18 +39,25 @@
 
   /* shape */
   --radius-sm: 6px;
-  --radius: 8px;
+  --radius: 9px;
   --radius-lg: 12px;
+  --radius-xl: 14px;
 }
 
 /*
- * Light theme — flips the tokens. The `data-theme` attribute is set on <html>
- * by the inline theme scripts in RootLayout / MarketingLayout (load-time,
- * before paint, to avoid FOUC) and toggled by [data-theme-toggle] buttons.
- * `:root[data-theme="light"]` outranks the default `:root` emission, so every
- * bg / text / border utility that references these vars flips automatically.
+ * Light theme — flips the tokens. `.dark` is the ONE mechanism that drives
+ * every layout: theme-script.astro toggles the class on <html> before paint
+ * (no FOUC) and next-themes (attribute="class") keeps it in sync post-hydration.
+ * The default `:root` values above are the dark palette; `html:not(.dark)`
+ * below is the light palette. (Tailwind's `dark:` variant — declared via
+ * @custom-variant above — is also keyed off `.dark`, so utilities and tokens
+ * always agree.)
  */
-:root[data-theme="light"] {
+:root {
+  color-scheme: dark;
+}
+
+html:not(.dark) {
   color-scheme: light;
 
   --color-base: #fafafa; /* app canvas */
@@ -58,7 +71,7 @@
   --color-fg-3: #71717a; /* muted */
   --color-fg-4: #a1a1aa; /* faint */
 
-  --color-accent: #2563eb; /* slightly deeper for light-bg contrast */
+  --color-accent: #d9543a; /* vermilion (light) — deeper for contrast on white */
   --color-pos: #059669;
   --color-warn: #d97706;
   --color-neg: #dc2626;
@@ -75,17 +88,14 @@
 [data-theme-toggle] .icon-moon {
   display: grid;
 }
-:root[data-theme="light"] [data-theme-toggle] .icon-sun {
+html:not(.dark) [data-theme-toggle] .icon-sun {
   display: grid;
 }
-:root[data-theme="light"] [data-theme-toggle] .icon-moon {
+html:not(.dark) [data-theme-toggle] .icon-moon {
   display: none;
 }
 
 /* base */
-html {
-  color-scheme: dark;
-}
 html,
 body {
   background: var(--color-base);
@@ -100,6 +110,7 @@ body {
 h1,
 h2,
 h3 {
+  font-family: var(--font-display);
   text-wrap: balance;
 }
 p {


### PR DESCRIPTION
## Summary

**F1 — Design System v2 foundation.** Merges the two competing token systems (`tokens.css` and `global.css`) into one source of truth, fixes a real theme-mechanism bug, and documents the result for downstream page workers.

- **One canonical `@theme`**: `tokens.css` is now the single authoritative palette/type/shape scale — vermilion (`#e2664d` dark / `#d9543a` light) replaces the old blue `#3b82f6` accent as the one brand accent; unified on Space Grotesk (display) + Hanken Grotesk (body) + JetBrains Mono (code), retiring Geist entirely (fonts, `@fontsource-variable/geist*` deps, `bun.lock`).
- **`global.css` now imports `tokens.css`** and layers shadcn-style aliases (`bg-card`, `text-foreground`, `border-border`, …) plus the legacy marketing aliases (`bg-brand-soft`, `text-ink-2`, `text-faint`, …) on top for back-compat — verified every alias class still compiles to the same visual value.
- **Fixed the theme mechanism**: previously `tokens.css` keyed light/dark off `data-theme="light"` while `global.css` keyed it off `.dark`, and `next-themes` was configured with `attribute="data-theme"` — meaning post-hydration theme toggles would stop touching `.dark` and silently desync from `global.css`'s colors. Everything now keys off a single `.dark` class (`next-themes` → `attribute="class"`), matching the existing `@custom-variant dark (&:is(.dark *))` declaration.
- **`MarketingLayout` now flows through `global.css`** instead of importing `tokens.css` directly. This was a real pre-existing bug fix as a side effect: `docs.astro`/`brand.astro` reference `bg-brand-soft`/`text-ink-2`/`text-faint`/`border-line-soft` classes that only ever lived in `global.css`, which `MarketingLayout` never loaded — those were rendering unstyled on `main`.
- **Cleaned stale `astro.config.mjs` Vite config**: removed `@cloudflare/kumo`/`@base-ui/react` from `optimizeDeps`/`ssr.noExternal` — both packages were already removed from `package.json` in the earlier Kumo migration, so these were dead entries.
- **New `packages/dashboard/DESIGN.md`**: canonical spec for downstream page workers — token names + meaning, type/spacing/radius scale, primitive component variant APIs, and explicit do/don't rules (use `text-fg`/`bg-panel` not the shadcn aliases in new code, use the semantic spacing utilities, gate theme styles on `.dark`/tokens not `data-theme`, never hardcode hex).

Primitive components (`Button`, `Card`, `Badge`, `Input`, `Dialog`, `Table`, `Toggle`) already used the `tokens.css` naming convention (confirmed 84/92 files in `src` already did) — their prop APIs are untouched.

## Test plan
- [x] `bun run build` passes (`PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_placeholder`)
- [x] `astro check` — 0 new errors (2 pre-existing errors in untouched `src/pages/brand.astro`, confirmed present on `main`)
- [x] `biome check` — 0 new errors on changed files (pre-existing warnings elsewhere confirmed present on `main`)
- [x] Dev server: `/`, `/docs`, `/brand`, `/dashboard`, `/dashboard/conversations` all return `200`, no runtime errors in dev log
- [x] Verified compiled production CSS: `--color-accent` resolves to real vermilion values in both light/dark (no circular refs), `.dark`/`html:not(.dark)` correctly scope the palette, zero `Geist` references remain
- [x] Exhaustively diffed old vs. new custom-property names and grepped the full `src` tree for every removed/renamed class to confirm zero regressions (found and fixed one: restored `brand`/`brand-ink`/`brand-soft`/`brand-line`/`surface`/`bg-deep`/`ink-2`/`faint`/`line-soft` aliases that `docs/docs-nav.tsx` and `brand/code-block.tsx` still reference)

## Follow-ups flagged (out of scope for this unit, spawned as separate tasks)
- `brand.astro` type specimen still labeled "Geist" — needs copy update to Space Grotesk/Hanken Grotesk/JetBrains Mono
- Three files still hardcode the old blue `#3b82f6` accent (`analytics/area-chart.tsx`, `dashboard/analytics/_analytics-content.tsx`, `brand.astro` swatch list) — belongs to the analytics/brand page workers

## Summary by Sourcery

Unify the dashboard and marketing site onto a single design-system v2 foundation, consolidating tokens, theming, fonts, and documentation while fixing theme desync and styling gaps.

Enhancements:
- Make tokens.css the canonical source of color, type, and radius tokens and have global.css import it, providing backward-compatible alias variables and utilities.
- Align the theme mechanism across layouts by keying all color and Tailwind dark variants off the .dark class and updating next-themes configuration accordingly.
- Update MarketingLayout to use the shared global stylesheet and new variable fonts, and ensure headings and selection styles use the new token palette.
- Refresh Vite config to drop obsolete Kumo/base-ui dependencies and rename the React context dep list for clarity.

Documentation:
- Add DESIGN.md as the authoritative design-system v2 spec covering tokens, typography, spacing, primitives, and usage rules for new dashboard and marketing work.

Chores:
- Remove Geist font dependencies and lockfile entries associated with the old design system.