### PR TITLE
docs(api): document keys/leases/states/webhooks/oauth scope conventions

### DIFF
--- a/packages/api/src/routes/leases/index.ts
+++ b/packages/api/src/routes/leases/index.ts
@@ -7,6 +7,12 @@ import type { Bindings, Variables } from "../../types";
 
 const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
+// Note: there is intentionally no `POST /` here to create a lease. A lease
+// is always scoped to a state key, so it is created via
+// `POST /v1/states/:state_key/lease` (see routes/states/index.ts) instead
+// of being duplicated here. This router only operates on an existing lease
+// by id (renew/release).
+
 router.post("/:id/renew", scopedAuth({ scope: "lease:write" }), async (c) => {
   const { data, error } = await parseAndValidateBody(c, RenewLeaseSchema);
   if (error) return error;

--- a/packages/api/src/routes/oauth/index.ts
+++ b/packages/api/src/routes/oauth/index.ts
@@ -27,6 +27,15 @@ function requestOrigin(c: AppContext): string {
   return new URL(c.req.url).origin;
 }
 
+// Deviation from the project-wide error format (`{ error: { code, message } }`,
+// see lib/helpers.ts#errorResponse): the /token endpoint below is consumed by
+// generic OAuth 2.1 clients (e.g. MCP clients doing the authorization_code /
+// refresh_token grants), which expect the RFC 6749 §5.2 shape
+// `{ error, error_description }` with `error` as a short machine string
+// ("invalid_request", "invalid_grant", etc.), not the API's nested object.
+// Every other route in this file (register/authorize/authorize-decision) is
+// AgentState-specific tooling, not a generic OAuth client surface, so those
+// keep using the standard `errorResponse` format.
 /** RFC 6749 OAuth error JSON for the token endpoint. */
 function oauthError(c: AppContext, error: string, description: string, status: 400 | 401 = 400) {
   return c.json({ error, error_description: description }, status);

--- a/packages/api/src/routes/states/index.ts
+++ b/packages/api/src/routes/states/index.ts
@@ -89,6 +89,13 @@ router.get("/watch", scopedAuth({ scope: "state:watch", allowQueryToken: true })
 
 // ---------------------------------------------------------------------------
 // POST /query — Rich state query
+//
+// Cursor format: `next_cursor` (and the request's `cursor` field) is the
+// state_event `sequence` value serialized as a string, e.g. "12345". Results
+// are ordered by sequence DESCENDING (newest first), so paginating means
+// passing the last row's sequence back as `cursor` to fetch older rows
+// (`sequence < cursor`). This differs from GET /:state_key/events below,
+// whose `after` cursor is ascending (`sequence > after`).
 // ---------------------------------------------------------------------------
 
 router.post("/query", scopedAuth({ scope: "state:read" }), async (c) => {

--- a/packages/api/src/routes/webhooks/index.ts
+++ b/packages/api/src/routes/webhooks/index.ts
@@ -12,6 +12,13 @@ const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 // Webhook management requires a valid API key for the project with the
 // `webhooks:write` scope. (Previously this router had no auth — projectId was
 // undefined — so these endpoints were non-functional; this fixes that.)
+//
+// There is intentionally no separate `webhooks:read` scope: the canonical
+// scope set (lib/scopes.ts API_SCOPES) only defines `webhooks:write`, so GET
+// routes below require it too. Webhook configs aren't sensitive secrets in
+// the way keys/tokens are, and splitting read/write here would add a scope
+// with no other caller in the codebase — add `webhooks:read` if a real
+// read-only use case shows up.
 router.use("*", apiKeyAuth);
 router.use("*", rateLimitMiddleware);
 router.use("*", requireScope("webhooks:write"));

--- a/packages/api/test/v1-keys-scopes.test.ts
+++ b/packages/api/test/v1-keys-scopes.test.ts
@@ -1,0 +1,118 @@
+import { SELF } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import { applyMigrations, authHeaders, seedProject, TEST_PROJECT_ID } from "./setup";
+
+// ---------------------------------------------------------------------------
+// Scope enforcement for the keyless key-management route (routes/v1-keys.ts,
+// mounted at /api/v1/keys). This is the live route a caller uses to create,
+// list, and revoke API keys without a projectId in the path — the natural
+// target for "can a low-privilege key manage other keys?" (Finding 1: v2
+// keys route missing scope enforcement — that unmounted routes/v2/keys/
+// router was removed entirely in #228; this is its still-mounted successor).
+// ---------------------------------------------------------------------------
+
+function bearer(key: string): Record<string, string> {
+  return { Authorization: `Bearer ${key}`, "Content-Type": "application/json" };
+}
+
+async function createScopedKey(scopes: string[]): Promise<string> {
+  const res = await SELF.fetch(`http://localhost/api/projects/${TEST_PROJECT_ID}/keys`, {
+    method: "POST",
+    headers: authHeaders(), // full-access seeded key
+    body: JSON.stringify({ name: "scoped", scopes }),
+  });
+  expect(res.status).toBe(201);
+  const body = (await res.json()) as { key: string };
+  return body.key;
+}
+
+describe("/api/v1/keys — scope enforcement", () => {
+  beforeEach(async () => {
+    await applyMigrations();
+    await seedProject();
+  });
+
+  it("POST / requires keys:write", async () => {
+    const noScope = await createScopedKey(["conversations:read"]);
+    const res = await SELF.fetch("http://localhost/api/v1/keys", {
+      method: "POST",
+      headers: bearer(noScope),
+      body: JSON.stringify({ name: "child" }),
+    });
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({ error: { code: "FORBIDDEN" } });
+  });
+
+  it("POST / succeeds with keys:write", async () => {
+    const withScope = await createScopedKey(["keys:write"]);
+    const res = await SELF.fetch("http://localhost/api/v1/keys", {
+      method: "POST",
+      headers: bearer(withScope),
+      body: JSON.stringify({ name: "child" }),
+    });
+    expect(res.status).toBe(201);
+  });
+
+  it("GET / requires keys:read", async () => {
+    const noScope = await createScopedKey(["conversations:read"]);
+    const res = await SELF.fetch("http://localhost/api/v1/keys", { headers: bearer(noScope) });
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({ error: { code: "FORBIDDEN" } });
+  });
+
+  it("GET / succeeds with keys:read", async () => {
+    const withScope = await createScopedKey(["keys:read"]);
+    const res = await SELF.fetch("http://localhost/api/v1/keys", { headers: bearer(withScope) });
+    expect(res.status).toBe(200);
+  });
+
+  it("DELETE /:id requires keys:write", async () => {
+    const writer = await createScopedKey(["keys:write"]);
+    const created = await SELF.fetch("http://localhost/api/v1/keys", {
+      method: "POST",
+      headers: bearer(writer),
+      body: JSON.stringify({ name: "to-delete" }),
+    });
+    const { id } = (await created.json()) as { id: string };
+
+    const noScope = await createScopedKey(["conversations:read"]);
+    const res = await SELF.fetch(`http://localhost/api/v1/keys/${id}`, {
+      method: "DELETE",
+      headers: bearer(noScope),
+    });
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({ error: { code: "FORBIDDEN" } });
+  });
+
+  it("DELETE /:id succeeds with keys:write", async () => {
+    const writer = await createScopedKey(["keys:write"]);
+    const created = await SELF.fetch("http://localhost/api/v1/keys", {
+      method: "POST",
+      headers: bearer(writer),
+      body: JSON.stringify({ name: "to-delete" }),
+    });
+    const { id } = (await created.json()) as { id: string };
+
+    const res = await SELF.fetch(`http://localhost/api/v1/keys/${id}`, {
+      method: "DELETE",
+      headers: bearer(writer),
+    });
+    expect(res.status).toBe(204);
+  });
+
+  it("keys:read alone cannot create or delete keys (read/write are separate scopes)", async () => {
+    const reader = await createScopedKey(["keys:read"]);
+    const postRes = await SELF.fetch("http://localhost/api/v1/keys", {
+      method: "POST",
+      headers: bearer(reader),
+      body: JSON.stringify({ name: "x" }),
+    });
+    expect(postRes.status).toBe(403);
+
+    const deleteRes = await SELF.fetch("http://localhost/api/v1/keys/some_key_id", {
+      method: "DELETE",
+      headers: bearer(reader),
+    });
+    expect(deleteRes.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary

Audit unit **A2 — V2 keys security + minor consistency**.

- **Finding 1 (CRITICAL — V2 keys route missing scope enforcement)**: already fixed upstream. The unmounted `routes/v2/keys` router this finding targeted was deleted entirely by #228's v2→v1 collapse (it was never wired into `src/index.ts`, so it was unreachable dead code — confirmed by grepping for any import/mount of it). The live route (`routes/v1-keys.ts`, mounted at `/api/v1/keys`) already enforces `keys:read` / `keys:write` via `requireScope`, matching the V1 pattern. Verified via `bunx wrangler dev` + curl that a key without `keys:read`/`keys:write` gets 403 on GET/POST/DELETE against `/api/v1/keys`.
  - Added `packages/api/test/v1-keys-scopes.test.ts` — no test previously covered scope enforcement on this specific route directly (only the dashboard-facing `/api/projects/:projectId/keys` had coverage in `test/scopes.test.ts`). 7 new tests: POST/GET/DELETE each with and without the correct scope, plus a read-only-cannot-write case.
- **Finding 12**: documented the `/v1/states/query` cursor format (descending `state_events.sequence`, serialized as a string) and contrasted it with the ascending cursor on `GET /:state_key/events`.
- **Finding 15**: documented why `routes/leases/index.ts` has no `POST /` — leases are always created via `POST /v1/states/:state_key/lease` (already scope-enforced with `lease:write`), so no duplicate create endpoint was added.
- **Finding 4**: documented that webhooks intentionally has no separate `webhooks:read` scope — the canonical scope set (`lib/scopes.ts` `API_SCOPES`) only defines `webhooks:write`, so all webhook routes (including GET) correctly require it.
- **Finding 6**: documented why the OAuth `/token` endpoint uses the RFC 6749 `{ error, error_description }` shape instead of the project's standard `{ error: { code, message } }` format, and noted the rest of the oauth router (register/authorize/authorize-decision) uses the standard format.

## Test plan

- [x] `bunx biome check` clean on all touched files
- [x] `bunx tsc --noEmit` clean
- [x] `bunx vitest run` — 334/334 passing (25 test files)
- [x] `bunx wrangler dev --local` + curl: confirmed 403 with `FORBIDDEN`/`Missing required scope` for `/api/v1/keys` (GET & POST) and `/api/v1/webhooks` (GET) when the caller key lacks the required scope; confirmed 200/201/204 with the correct scope
- [x] Confirmed OAuth `/token` returns `{"error":"unsupported_grant_type","error_description":"..."}` (RFC 6749 shape) at runtime

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Document security and behavior conventions for keys, leases, states, webhooks, and OAuth token errors, and add tests to verify scope enforcement on the v1 keys API.

Bug Fixes:
- Add direct test coverage to ensure the /api/v1/keys route correctly enforces keys:read and keys:write scopes for creating, listing, and deleting keys.

Enhancements:
- Clarify the OAuth /token endpoint's intentional deviation from the standard API error format to follow RFC 6749 semantics.
- Document the cursor format and ordering semantics for the /v1/states/query endpoint and how it differs from the state events cursor on GET /:state_key/events.
- Explain why the leases router omits a POST / create endpoint in favor of the state-scoped lease creation route on /v1/states/:state_key/lease.
- Document that webhook management uses a single webhooks:write scope for both read and write operations, and that a separate webhooks:read scope is intentionally not defined.

Tests:
- Introduce v1-keys scope enforcement tests covering POST/GET/DELETE on /api/v1/keys with and without keys:read/keys:write, including a read-only key case.