### PR TITLE
style(dashboard): redesign Integrate page to canonical design tokens (D8)

### DIFF
--- a/packages/dashboard/src/components/dashboard/integrate/code-block.tsx
+++ b/packages/dashboard/src/components/dashboard/integrate/code-block.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { CheckIcon, CopyIcon } from "@phosphor-icons/react";
-import { useState } from "react";
+import { useCopiedText } from "@/lib/hooks/use-copied-text";
 import { cn } from "@/lib/utils";
 
 // Lightweight monochrome highlighter — escapes HTML first, then wraps strings,
@@ -41,7 +41,7 @@ export function CodeBlock({
   copyable?: boolean;
   className?: string;
 }) {
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopiedText();
   const lines = code.replace(/\n$/, "").split("\n");
 
   return (
@@ -57,15 +57,7 @@ export function CodeBlock({
           <button
             type="button"
             className="inline-flex items-center gap-1.5 rounded-[var(--radius-sm)] px-2 py-0.5 text-fg-3 transition-colors hover:bg-panel hover:text-fg"
-            onClick={async () => {
-              try {
-                await navigator.clipboard.writeText(code);
-                setCopied(true);
-                setTimeout(() => setCopied(false), 1200);
-              } catch {
-                setCopied(false);
-              }
-            }}
+            onClick={() => copy(code)}
           >
             {copied ? (
               <CheckIcon size={12} className="text-accent" aria-hidden="true" />

--- a/packages/dashboard/src/components/dashboard/integrate/code-block.tsx
+++ b/packages/dashboard/src/components/dashboard/integrate/code-block.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { CheckIcon, CopyIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+
+// Lightweight monochrome highlighter — escapes HTML first, then wraps strings,
+// HTTP verbs and a few keywords. Output is injected as HTML, so escaping the
+// angle brackets / ampersands up front is what keeps it safe.
+function highlight(line: string): string {
+  const t = line.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const trimmed = t.trimStart();
+  if (trimmed.startsWith("//") || trimmed.startsWith("#")) {
+    return `<span class="text-fg-4">${t}</span>`;
+  }
+  return t
+    .replace(/("[^"]*"|'[^']*'|`[^`]*`)/g, '<span class="text-accent">$1</span>')
+    .replace(
+      /\b(POST|GET|PATCH|PUT|DELETE)\b/g,
+      '<span class="text-accent font-semibold">$1</span>',
+    )
+    .replace(
+      /\b(const|await|async|function|return|import|from|export|new|let)\b/g,
+      '<span class="text-fg-2 font-medium">$1</span>',
+    );
+}
+
+/**
+ * Page-local code block used by the Integrate page — canonical-token version
+ * of the shared brand `CodeBlock`, styled per DESIGN.md (panel surfaces,
+ * `--radius`, single accent color).
+ */
+export function CodeBlock({
+  code,
+  title,
+  copyable = true,
+  className,
+}: {
+  code: string;
+  title?: string;
+  copyable?: boolean;
+  className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  const lines = code.replace(/\n$/, "").split("\n");
+
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-[var(--radius)] border border-edge bg-panel",
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between border-b border-edge-soft bg-panel2 px-3 py-2">
+        <span className="as-label text-[10.5px]">{title || "code"}</span>
+        {copyable && (
+          <button
+            type="button"
+            className="inline-flex items-center gap-1.5 rounded-[var(--radius-sm)] px-2 py-0.5 text-fg-3 transition-colors hover:bg-panel hover:text-fg"
+            onClick={async () => {
+              try {
+                await navigator.clipboard.writeText(code);
+                setCopied(true);
+                setTimeout(() => setCopied(false), 1200);
+              } catch {
+                setCopied(false);
+              }
+            }}
+          >
+            {copied ? (
+              <CheckIcon size={12} className="text-accent" aria-hidden="true" />
+            ) : (
+              <CopyIcon size={12} aria-hidden="true" />
+            )}
+            <span className="font-mono text-[11px]">{copied ? "copied" : "copy"}</span>
+          </button>
+        )}
+      </div>
+      <pre className="overflow-x-auto p-4 font-mono text-[12.5px] leading-[1.7] text-fg-2">
+        {lines.map((line, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: index included with line content for uniqueness; duplicate lines are possible
+          <div key={`${i}-${line}`} className="flex gap-3.5">
+            <span className="w-4 flex-shrink-0 select-none text-right text-fg-4">{i + 1}</span>
+            <code
+              className="whitespace-pre"
+              // biome-ignore lint/security/noDangerouslySetInnerHtml: input is HTML-escaped in highlight() before tokens are wrapped
+              dangerouslySetInnerHTML={{ __html: highlight(line) || "&nbsp;" }}
+            />
+          </div>
+        ))}
+      </pre>
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/integrate/integrate-content.tsx
+++ b/packages/dashboard/src/components/dashboard/integrate/integrate-content.tsx
@@ -1,11 +1,11 @@
 import { ArrowUpRightIcon } from "@phosphor-icons/react";
 import Link from "next/link";
 import { useState } from "react";
-import { Pill } from "@/components/brand/bits";
-import { CodeBlock } from "@/components/brand/code-block";
 import { FRAMEWORKS, type FrameworkId, FwGlyph } from "@/components/brand/frameworks";
 import { CopyButton } from "@/components/copy-button";
+import { CodeBlock } from "@/components/dashboard/integrate/code-block";
 import { PageHeader } from "@/components/dashboard/page-header";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
@@ -175,19 +175,18 @@ export default function IntegrateContent() {
         {/* Active framework detail */}
         <div className="flex flex-col gap-3.5">
           <div className="flex items-center gap-3.5 rounded-[var(--radius)] border border-edge bg-panel p-[18px]">
-            <span className="flex size-11 flex-shrink-0 items-center justify-center rounded-[9px] border border-edge bg-panel2">
+            <span className="flex size-11 flex-shrink-0 items-center justify-center rounded-[var(--radius)] border border-edge bg-panel2">
               <FwGlyph kind={active.glyph} size={22} />
             </span>
             <div className="min-w-0 flex-1">
               <div className="text-[17px] font-semibold text-fg">{active.name}</div>
-              <div className="num mt-0.5 font-mono text-[12px] text-fg-3">
+              <div className="as-mono mt-0.5 text-[12px] text-fg-3">
                 {isCurl ? "no SDK required · raw REST" : "npm i @agentstate/sdk"}
               </div>
             </div>
-            <Pill>
-              <span className="size-1.5 rounded-full bg-accent" />
+            <Badge tone="live" dot>
               ready
-            </Pill>
+            </Badge>
           </div>
 
           <CodeBlock code={ADAPTER_SNIPPETS[fw]} title={isCurl ? "terminal" : `${active.tag}.ts`} />
@@ -218,7 +217,7 @@ export default function IntegrateContent() {
         </div>
 
         <div className="flex items-center justify-between gap-3 rounded-[var(--radius)] border border-edge bg-panel2 px-4 py-3">
-          <code className="num truncate font-mono text-[12.5px] text-fg-2">{MCP_REMOTE_URL}</code>
+          <code className="as-mono truncate text-[12.5px] text-fg-2">{MCP_REMOTE_URL}</code>
           <CopyButton text={MCP_REMOTE_URL} />
         </div>
 


### PR DESCRIPTION
## Summary
- Redesigns `/dashboard/integrate` (framework adapter switcher, MCP setup, coding-agent system prompt) to the bold, consistent design-system v2 look per `packages/dashboard/DESIGN.md`.
- Swaps the shared `brand/bits.tsx` `Pill` and `brand/code-block.tsx` `CodeBlock` (both still on legacy shadcn-alias tokens — `border-border`, `bg-card`, `text-muted-foreground`, `var(--faint)`, `var(--brand-ink)`) for the canonical `Badge` primitive and a new page-local `CodeBlock` (`src/components/dashboard/integrate/code-block.tsx`) built entirely on canonical tokens (`text-fg`/`bg-panel`/`border-edge`, `var(--radius)`, single vermilion accent).
- Fixes a stray hardcoded `rounded-[9px]` to `rounded-[var(--radius)]`, and replaces the ad-hoc `.num font-mono` combo with the documented `as-mono` utility shortcut.
- No content, copy, or copy-to-clipboard behavior changes — framework list, adapter snippets, MCP config blocks, and the coding-agent prompt are unchanged.

Note: original instructions said to base this off `redesign/v2`, but that branch was merged into `main` (#245) and deleted while this unit was in progress, so this PR targets `main` directly. Rebased cleanly — the integrate page was untouched by the redesign/v2 merge.

Out of scope (not touched — shared/foundation-owned): `src/components/brand/bits.tsx`, `src/components/brand/code-block.tsx`, `src/components/brand/frameworks.tsx` remain on legacy tokens; they're also used by `project/_conversations-empty-state.tsx` and `project/_quick-start-code.tsx`, so converting them in place was out of this unit's file ownership. Flagging for a future foundation-scoped cleanup pass.

## Test plan
- [x] `bun install` in `packages/dashboard`
- [x] `PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_placeholder bun run build` — passes, all 14 routes generated including `/dashboard/integrate`
- [x] `bunx biome check packages/dashboard/src/components/dashboard/integrate/` — clean
- [x] `bun run dev` — `/dashboard/integrate` returns 200, no console errors, no 500s (verified via chrome-devtools MCP; Clerk placeholder key renders the expected auth-gate loading state client-side)
- [x] Scanned owned files for non-canonical tokens / hardcoded hex — none found

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Redesign the /dashboard/integrate page to use canonical design-system v2 tokens and a page-local code block component.

Enhancements:
- Replace legacy Pill and shared brand CodeBlock usage with the canonical Badge primitive and a new integrate-specific CodeBlock component.
- Align framework detail and MCP URL styles with design-system utilities, including standardized radius tokens and monospace text helpers.