### PR TITLE
style(dashboard): redesign organizations/settings pages to design-system v2 (D7)

### DIFF
--- a/packages/dashboard/src/components/dashboard/organizations/create/_create-org-form.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/_create-org-form.tsx
@@ -2,13 +2,9 @@ import { useRouter } from "next/navigation";
 import type * as React from "react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import { DomainWarning } from "./_domain-warning";
 import { useCreateOrganization } from "./_use-create-organization";
-
-const inputClass =
-  "h-9 w-full rounded-[var(--radius)] border border-edge bg-panel px-3 text-[13.5px] text-fg placeholder:text-fg-4 outline-none transition-colors focus:border-accent/60 disabled:opacity-50";
-
-const labelClass = "font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4";
 
 interface CreateOrgFormProps {
   organizationName: string;
@@ -51,21 +47,18 @@ export function CreateOrgForm({
 
   return (
     <form onSubmit={handleSubmit}>
-      <Card className="flex max-w-xl flex-col gap-6 p-6">
-        <div className="flex flex-col gap-2">
+      <Card className="card-padding flex max-w-xl flex-col gap-component">
+        <div className="flex flex-col gap-tight">
           <h2 className="text-[16px] font-semibold text-fg">Organization Details</h2>
           <p className="text-[13.5px] leading-6 text-fg-3">
             Enter a name for your organization. You can invite members after creation.
           </p>
         </div>
-        <div className="flex flex-col gap-2">
-          <label htmlFor="name" className={labelClass}>
-            Organization Name
-          </label>
-          <input
+        <div className="flex flex-col gap-tight">
+          <Input
             id="name"
             type="text"
-            className={inputClass}
+            label="Organization Name"
             value={organizationName}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
               setOrganizationName(e.currentTarget.value)

--- a/packages/dashboard/src/components/dashboard/organizations/create/_create-org-header.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/_create-org-header.tsx
@@ -1,20 +1,23 @@
 import { ArrowLeftIcon } from "@phosphor-icons/react";
 import Link from "next/link";
+import { PageHeader } from "@/components/dashboard/page-header";
 
 export function CreateOrgHeader() {
   return (
-    <header className="flex items-center gap-3 border-b border-edge-soft pb-5">
+    <div className="flex items-start gap-3">
       <Link
         href="/dashboard/settings/organizations"
         aria-label="Back to organizations"
-        className="grid size-8 place-items-center rounded-[var(--radius)] text-fg-3 transition-colors hover:bg-panel2 hover:text-fg"
+        className="mt-0.5 grid size-8 shrink-0 place-items-center rounded-[var(--radius)] text-fg-3 transition-colors hover:bg-panel2 hover:text-fg"
       >
         <ArrowLeftIcon className="size-4" aria-hidden="true" />
       </Link>
-      <div className="flex flex-col gap-1">
-        <h1 className="text-[26px] tracking-tight text-fg">Create Organization</h1>
-        <p className="text-[14.5px] leading-6 text-fg-3">Set up a new organization for your team</p>
+      <div className="min-w-0 flex-1">
+        <PageHeader
+          title="Create Organization"
+          description="Set up a new organization for your team"
+        />
       </div>
-    </header>
+    </div>
   );
 }

--- a/packages/dashboard/src/components/dashboard/organizations/create/_create-org-loading.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/_create-org-loading.tsx
@@ -3,18 +3,18 @@ import { Card } from "@/components/ui/card";
 
 export function CreateOrgLoading() {
   return (
-    <div className="flex flex-col gap-6 px-4 py-7 lg:px-6">
-      <div className="flex items-center gap-3 border-b border-edge-soft pb-5">
-        <span className="grid size-8 place-items-center rounded-[var(--radius)] text-fg-4">
+    <div className="page-padding flex flex-col gap-section py-7">
+      <div className="flex items-start gap-3">
+        <span className="mt-0.5 grid size-8 shrink-0 place-items-center rounded-[var(--radius)] text-fg-4">
           <ArrowLeftIcon className="size-4" aria-hidden="true" />
         </span>
-        <div className="flex flex-col gap-1.5">
+        <div className="flex flex-col gap-tight">
           <div className="h-5 w-44 animate-pulse rounded bg-panel2" />
           <div className="h-3.5 w-60 animate-pulse rounded bg-panel2" />
         </div>
       </div>
-      <Card className="flex max-w-xl flex-col gap-6 p-6">
-        <div className="flex flex-col gap-2">
+      <Card className="card-padding flex max-w-xl flex-col gap-component">
+        <div className="flex flex-col gap-tight">
           <div className="h-4 w-40 animate-pulse rounded bg-panel2" />
           <div className="h-3.5 w-72 animate-pulse rounded bg-panel2" />
         </div>

--- a/packages/dashboard/src/components/dashboard/organizations/create/create-org-content.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/create-org-content.tsx
@@ -31,7 +31,7 @@ export function CreateOrgContent() {
   const existingOrgDomain = advisory?.meta?.organization_domain;
 
   return (
-    <div className="flex flex-col gap-6 px-4 lg:px-6">
+    <div className="page-padding flex flex-col gap-section py-7">
       <CreateOrgHeader />
       <CreateOrgForm
         organizationName={organizationName}

--- a/packages/dashboard/src/components/dashboard/organizations/list/organizations-list-content.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/list/organizations-list-content.tsx
@@ -92,7 +92,7 @@ export function OrganizationsListContent() {
                         </Badge>
                       )}
                     </div>
-                    <p className="as-mono-sm truncate text-fg-3">
+                    <p className="as-mono-sm truncate text-fg-3" suppressHydrationWarning>
                       Created {new Date(org.createdAt).toLocaleDateString()}
                     </p>
                   </div>

--- a/packages/dashboard/src/components/dashboard/organizations/list/organizations-list-content.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/list/organizations-list-content.tsx
@@ -2,6 +2,7 @@ import { useOrganization, useUser } from "@clerk/react";
 import { BuildingsIcon, CaretRightIcon, PlusIcon } from "@phosphor-icons/react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { PageHeader } from "@/components/dashboard/page-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -9,7 +10,7 @@ import { useOrganizationsList } from "@/hooks/_use-organizations-list";
 
 function OrgListSkeleton() {
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-component">
       {[0, 1, 2].map((i) => (
         <Card key={i} className="h-[72px] animate-pulse">
           <div className="h-full w-full" />
@@ -27,8 +28,8 @@ export function OrganizationsListContent() {
 
   if (!isUserLoaded || !isOrgListLoaded) {
     return (
-      <div className="flex flex-col gap-6 px-4 py-7 lg:px-6">
-        <Header />
+      <div className="page-padding flex flex-col gap-section py-7">
+        <PageHeader title="Organizations" description="Manage your organizations and members" />
         <OrgListSkeleton />
       </div>
     );
@@ -39,8 +40,10 @@ export function OrganizationsListContent() {
   }
 
   return (
-    <div className="flex flex-col gap-6 px-4 py-7 lg:px-6">
-      <Header
+    <div className="page-padding flex flex-col gap-section py-7">
+      <PageHeader
+        title="Organizations"
+        description="Manage your organizations and members"
         actions={
           <Link href="/dashboard/settings/organizations/create">
             <Button variant="primary">
@@ -52,11 +55,11 @@ export function OrganizationsListContent() {
       />
 
       {organizations.length === 0 ? (
-        <Card className="flex flex-col items-center gap-3 px-6 py-14 text-center">
+        <Card className="flex flex-col items-center gap-element px-6 py-14 text-center">
           <span className="grid size-10 place-items-center rounded-[var(--radius)] border border-edge bg-panel2 text-fg-3">
             <BuildingsIcon className="size-5" aria-hidden="true" />
           </span>
-          <div className="flex flex-col gap-1">
+          <div className="flex flex-col gap-tight">
             <p className="text-[15px] font-medium text-fg">No organizations</p>
             <p className="text-[13.5px] text-fg-3">
               You don&rsquo;t belong to any organizations yet. Create one to get started.
@@ -71,12 +74,12 @@ export function OrganizationsListContent() {
           </Button>
         </Card>
       ) : (
-        <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-component">
           {organizations.map((org) => {
             const isActive = activeOrg?.id === org.id;
             return (
               <Card key={org.id} className="px-4 py-3.5">
-                <div className="flex items-center gap-4">
+                <div className="flex items-center gap-element">
                   <span className="grid size-10 shrink-0 place-items-center rounded-[var(--radius)] border border-edge bg-panel2 text-fg-3">
                     <BuildingsIcon className="size-5" aria-hidden="true" />
                   </span>
@@ -89,7 +92,7 @@ export function OrganizationsListContent() {
                         </Badge>
                       )}
                     </div>
-                    <p className="num truncate font-mono text-[12.5px] text-fg-3">
+                    <p className="as-mono-sm truncate text-fg-3">
                       Created {new Date(org.createdAt).toLocaleDateString()}
                     </p>
                   </div>
@@ -107,17 +110,5 @@ export function OrganizationsListContent() {
         </div>
       )}
     </div>
-  );
-}
-
-function Header({ actions }: { actions?: React.ReactNode }) {
-  return (
-    <header className="flex items-end justify-between gap-4 border-b border-edge-soft pb-5">
-      <div className="flex flex-col gap-1">
-        <h1 className="text-[26px] tracking-tight text-fg">Organizations</h1>
-        <p className="text-[14.5px] leading-6 text-fg-3">Manage your organizations and members</p>
-      </div>
-      {actions}
-    </header>
   );
 }

--- a/packages/dashboard/src/components/dashboard/organizations/members/_invite-member-form.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_invite-member-form.tsx
@@ -2,6 +2,7 @@ import { PlusIcon } from "@phosphor-icons/react";
 import * as React from "react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Input, Select } from "@/components/ui/input";
 
 export type Role = "org:member" | "org:admin";
 
@@ -9,11 +10,6 @@ export interface InviteMemberFormProps {
   readonly isInviting: boolean;
   readonly onInvite: (email: string, role: Role) => Promise<void>;
 }
-
-const inputClass =
-  "h-9 w-full rounded-[var(--radius)] border border-edge bg-panel px-3 text-[13.5px] text-fg placeholder:text-fg-4 outline-none transition-colors focus:border-accent/60 disabled:opacity-50";
-
-const labelClass = "font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4";
 
 export function InviteMemberForm({ isInviting, onInvite }: InviteMemberFormProps) {
   const [emailAddress, setEmailAddress] = React.useState("");
@@ -32,47 +28,39 @@ export function InviteMemberForm({ isInviting, onInvite }: InviteMemberFormProps
   );
 
   return (
-    <Card className="flex flex-col gap-4 p-6">
-      <div className="flex flex-col gap-2">
+    <Card className="card-padding flex flex-col gap-component">
+      <div className="flex flex-col gap-tight">
         <h2 className="text-[16px] font-semibold text-fg">Invite Member</h2>
         <p className="text-[13.5px] leading-6 text-fg-3">
           Send an invitation to join this organization
         </p>
       </div>
-      <form onSubmit={handleSubmit} className="flex flex-col gap-3">
-        <div className="flex flex-col gap-2">
-          <label htmlFor="email" className={labelClass}>
-            Email address
-          </label>
-          <input
-            id="email"
-            type="email"
-            className={inputClass}
-            placeholder="colleague@example.com"
-            value={emailAddress}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setEmailAddress(e.currentTarget.value)
-            }
+      <form onSubmit={handleSubmit} className="flex flex-col gap-element">
+        <Input
+          id="email"
+          type="email"
+          label="Email address"
+          placeholder="colleague@example.com"
+          value={emailAddress}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setEmailAddress(e.currentTarget.value)
+          }
+          disabled={isInviting}
+          required
+        />
+        <div className="flex flex-col gap-element sm:flex-row sm:items-end">
+          <Select
+            id="role"
+            label="Role"
+            className="sm:w-[180px]"
+            value={selectedRole}
+            onChange={(e) => setSelectedRole(e.currentTarget.value as Role)}
             disabled={isInviting}
-            required
+            options={[
+              { value: "org:member", label: "Member" },
+              { value: "org:admin", label: "Admin" },
+            ]}
           />
-        </div>
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
-          <div className="flex w-full flex-col gap-2 sm:w-[180px]">
-            <label htmlFor="role" className={labelClass}>
-              Role
-            </label>
-            <select
-              id="role"
-              className={inputClass}
-              value={selectedRole}
-              onChange={(e) => setSelectedRole(e.currentTarget.value as Role)}
-              disabled={isInviting}
-            >
-              <option value="org:member">Member</option>
-              <option value="org:admin">Admin</option>
-            </select>
-          </div>
           <Button type="submit" variant="primary" disabled={isInviting} className="sm:mb-px">
             {isInviting ? (
               "Sending..."

--- a/packages/dashboard/src/components/dashboard/organizations/members/_member-cell.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_member-cell.tsx
@@ -13,7 +13,7 @@ export function MemberCell({ name, email, iconType, subtitle }: MemberCellProps)
       <AvatarIcon icon={iconType} />
       <div className="min-w-0">
         <p className="truncate text-[13.5px] font-medium text-fg">{name}</p>
-        <p className="num truncate font-mono text-[12px] text-fg-3">{subtitle ?? email}</p>
+        <p className="as-mono-sm truncate text-fg-3">{subtitle ?? email}</p>
       </div>
     </div>
   );

--- a/packages/dashboard/src/components/dashboard/organizations/members/_member-list-card.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_member-list-card.tsx
@@ -1,5 +1,13 @@
 import type { ReactNode } from "react";
 import { Card } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 
 export interface Column<T> {
   key: string;
@@ -35,10 +43,10 @@ export function MemberListCard<T>({
   const total = count ?? data.length;
 
   return (
-    <Card className="flex flex-col gap-4 p-6">
-      <div className="flex flex-col gap-1">
+    <Card className="card-padding flex flex-col gap-component">
+      <div className="flex flex-col gap-tight">
         <h2 className="text-[16px] font-semibold text-fg">{title}</h2>
-        <p className="num font-mono text-[12.5px] text-fg-3">
+        <p className="as-mono-sm text-fg-3">
           {total} {countLabel ?? "item"}
           {total !== 1 ? "s" : ""}
         </p>
@@ -54,7 +62,7 @@ export function MemberListCard<T>({
           ))}
         </div>
       ) : data.length === 0 ? (
-        <div className="flex flex-col items-center gap-2 py-10 text-center">
+        <div className="flex flex-col items-center gap-tight py-10 text-center">
           <span className="grid size-9 place-items-center rounded-[var(--radius)] border border-edge bg-panel2 text-fg-4">
             {empty.icon}
           </span>
@@ -62,36 +70,24 @@ export function MemberListCard<T>({
           {empty.description && <p className="text-[12.5px] text-fg-3">{empty.description}</p>}
         </div>
       ) : (
-        <div className="overflow-x-auto">
-          <table className="w-full border-collapse">
-            <thead>
-              <tr className="border-b border-edge">
-                {columns.map((c) => (
-                  <th
-                    key={c.key}
-                    className="px-3 py-2 text-left font-mono text-[10.5px] uppercase tracking-[0.1em] text-fg-4 first:pl-0 last:pr-0"
-                  >
-                    {c.label}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {data.map((row) => (
-                <tr
-                  key={rowKey(row)}
-                  className="border-b border-edge-soft transition-colors last:border-0 hover:bg-panel2/50"
-                >
-                  {columns.map((c) => (
-                    <td key={c.key} className="px-3 py-3 first:pl-0 last:pr-0">
-                      {c.render(row)}
-                    </td>
-                  ))}
-                </tr>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {columns.map((c) => (
+                <TableHead key={c.key}>{c.label}</TableHead>
               ))}
-            </tbody>
-          </table>
-        </div>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {data.map((row) => (
+              <TableRow key={rowKey(row)}>
+                {columns.map((c) => (
+                  <TableCell key={c.key}>{c.render(row)}</TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
       )}
     </Card>
   );

--- a/packages/dashboard/src/components/dashboard/organizations/members/_members-skeleton.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_members-skeleton.tsx
@@ -2,7 +2,7 @@ import { Card } from "@/components/ui/card";
 
 export function _MembersSkeleton() {
   return (
-    <Card className="flex flex-col gap-4 p-6">
+    <Card className="card-padding flex flex-col gap-component">
       {[0, 1, 2].map((i) => (
         <div key={i} className="h-10 w-full animate-pulse rounded-[var(--radius)] bg-panel2" />
       ))}

--- a/packages/dashboard/src/components/dashboard/organizations/members/_page-header.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_page-header.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeftIcon } from "@phosphor-icons/react";
 import Link from "next/link";
+import { PageHeader } from "@/components/dashboard/page-header";
 
 export interface _PageHeaderProps {
   readonly organizationName?: string;
@@ -8,23 +9,23 @@ export interface _PageHeaderProps {
 
 export function _PageHeader({ organizationName, isLoading }: _PageHeaderProps) {
   return (
-    <header className="flex items-center gap-3 border-b border-edge-soft pb-5">
+    <div className="flex items-start gap-3">
       <Link
         href="/dashboard/settings/organizations"
         aria-label="Back to organizations"
         aria-disabled={isLoading}
-        className={`grid size-8 place-items-center rounded-[var(--radius)] text-fg-3 transition-colors hover:bg-panel2 hover:text-fg ${
+        className={`mt-0.5 grid size-8 shrink-0 place-items-center rounded-[var(--radius)] text-fg-3 transition-colors hover:bg-panel2 hover:text-fg ${
           isLoading ? "pointer-events-none opacity-50" : ""
         }`}
       >
         <ArrowLeftIcon className="size-4" aria-hidden="true" />
       </Link>
       <div className="min-w-0 flex-1">
-        <h1 className="text-[26px] tracking-tight text-fg">Members</h1>
-        <p className="text-[14.5px] leading-6 text-fg-3">
-          {organizationName ? `${organizationName} · ` : ""}Manage organization members
-        </p>
+        <PageHeader
+          title="Members"
+          description={`${organizationName ? `${organizationName} · ` : ""}Manage organization members`}
+        />
       </div>
-    </header>
+    </div>
   );
 }

--- a/packages/dashboard/src/components/dashboard/organizations/members/_page-header.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/_page-header.tsx
@@ -14,6 +14,10 @@ export function _PageHeader({ organizationName, isLoading }: _PageHeaderProps) {
         href="/dashboard/settings/organizations"
         aria-label="Back to organizations"
         aria-disabled={isLoading}
+        tabIndex={isLoading ? -1 : undefined}
+        onClick={(e) => {
+          if (isLoading) e.preventDefault();
+        }}
         className={`mt-0.5 grid size-8 shrink-0 place-items-center rounded-[var(--radius)] text-fg-3 transition-colors hover:bg-panel2 hover:text-fg ${
           isLoading ? "pointer-events-none opacity-50" : ""
         }`}

--- a/packages/dashboard/src/components/dashboard/organizations/members/members-content.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/members-content.tsx
@@ -65,7 +65,7 @@ export function MembersContent() {
   // Loading state
   if (!isUserLoaded || !isOrgListLoaded || !isOrgLoaded) {
     return (
-      <div className="flex flex-col gap-6 px-4 py-7 lg:px-6">
+      <div className="page-padding flex flex-col gap-section py-7">
         <_PageHeader isLoading />
         <_MembersSkeleton />
       </div>
@@ -75,9 +75,9 @@ export function MembersContent() {
   // Not signed in or no organization
   if (!isSignedIn || !organization) {
     return (
-      <div className="flex flex-col gap-6 px-4 py-7 lg:px-6">
+      <div className="page-padding flex flex-col gap-section py-7">
         <_PageHeader />
-        <Card className="flex flex-col gap-1 p-6">
+        <Card className="card-padding flex flex-col gap-tight">
           <h2 className="text-[16px] font-semibold text-fg">No organization selected</h2>
           <p className="text-[13.5px] leading-6 text-fg-3">
             Select an organization to manage its members.
@@ -88,7 +88,7 @@ export function MembersContent() {
   }
 
   return (
-    <div className="flex flex-col gap-6 px-4 py-7 lg:px-6">
+    <div className="page-padding flex flex-col gap-section py-7">
       <_PageHeader organizationName={organization.name} />
       <InviteMemberForm isInviting={isInviting} onInvite={inviteMember} />
       <MembersList


### PR DESCRIPTION
Part of the bold dashboard redesign (Wave B / unit D7). Redesigns all organization settings routes (list, create, members) to AgentState design-system v2 per `packages/dashboard/DESIGN.md`: shared `PageHeader`, `Input`/`Select`/`Table` primitives, semantic spacing utilities, `as-mono` for data values. No behavior/prop changes — markup/styling only. Originally targeted the (now-deleted) `redesign/v2`; retargeted to main.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Update all organization settings dashboard views to use the new design-system v2 layout components and spacing tokens without changing behavior.

Enhancements:
- Replace custom inputs, selects, and tables in organization create and members views with shared Input, Select, Table, and PageHeader components.
- Align organizations list, members, and create-organization pages with standardized page padding, card spacing, and mono text utility classes for data values.
- Simplify local header implementations by delegating title/description rendering to the shared PageHeader component across relevant routes.