### PR TITLE
style(dashboard): align docs/brand/oauth pages to design-system v2 (D2)

### DIFF
--- a/packages/dashboard/src/components/brand/bits.tsx
+++ b/packages/dashboard/src/components/brand/bits.tsx
@@ -11,7 +11,7 @@ export function Pill({ children, className }: { children: ReactNode; className?:
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-[5px] font-mono text-[11.5px] font-medium uppercase tracking-[0.04em] text-muted-foreground",
+        "inline-flex items-center gap-1.5 rounded-full border border-edge bg-panel px-2.5 py-[5px] font-mono text-[11.5px] font-medium uppercase tracking-[0.04em] text-fg-3",
         className,
       )}
     >
@@ -25,7 +25,7 @@ export function Tag({ children, className }: { children: ReactNode; className?: 
   return (
     <span
       className={cn(
-        "rounded-[5px] border border-border bg-muted px-[7px] py-[3px] font-mono text-[11px] font-medium text-muted-foreground",
+        "rounded-[var(--radius-sm)] border border-edge bg-panel2 px-[7px] py-[3px] font-mono text-[11px] font-medium text-fg-3",
         className,
       )}
     >
@@ -39,7 +39,7 @@ export function MethodTag({ children, className }: { children: ReactNode; classN
   return (
     <span
       className={cn(
-        "inline-block rounded-[5px] border border-border bg-muted px-[7px] py-[3px] text-center font-mono text-[11px] font-semibold text-foreground",
+        "inline-block rounded-[var(--radius-sm)] border border-edge bg-panel2 px-[7px] py-[3px] text-center font-mono text-[11px] font-semibold text-fg",
         className,
       )}
     >

--- a/packages/dashboard/src/components/brand/code-block.tsx
+++ b/packages/dashboard/src/components/brand/code-block.tsx
@@ -11,17 +11,17 @@ function highlight(line: string): string {
   const t = line.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
   const trimmed = t.trimStart();
   if (trimmed.startsWith("//") || trimmed.startsWith("#")) {
-    return `<span style="color:var(--faint)">${t}</span>`;
+    return `<span style="color:var(--color-fg-4)">${t}</span>`;
   }
   return t
-    .replace(/("[^"]*"|'[^']*'|`[^`]*`)/g, '<span style="color:var(--brand-ink)">$1</span>')
+    .replace(/("[^"]*"|'[^']*'|`[^`]*`)/g, '<span style="color:var(--color-accent)">$1</span>')
     .replace(
       /\b(POST|GET|PATCH|PUT|DELETE)\b/g,
-      '<span style="color:var(--brand-ink);font-weight:600">$1</span>',
+      '<span style="color:var(--color-accent);font-weight:600">$1</span>',
     )
     .replace(
       /\b(const|await|async|function|return|import|from|export|new|let)\b/g,
-      '<span style="color:var(--chart-3)">$1</span>',
+      '<span style="color:var(--color-fg-2)">$1</span>',
     );
 }
 
@@ -42,13 +42,18 @@ export function CodeBlock({
   const lines = code.replace(/\n$/, "").split("\n");
 
   return (
-    <div className={cn("overflow-hidden rounded-[9px] border border-border bg-card", className)}>
-      <div className="flex items-center justify-between border-b border-line-soft bg-background px-3 py-2">
+    <div
+      className={cn(
+        "overflow-hidden rounded-[var(--radius)] border border-edge bg-panel",
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between border-b border-edge-soft bg-base px-3 py-2">
         <span className="as-label text-[10.5px]">{title || "code"}</span>
         {copyable && (
           <button
             type="button"
-            className="inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-muted-foreground transition-colors hover:bg-muted"
+            className="inline-flex items-center gap-1.5 rounded-[var(--radius)] px-2 py-0.5 text-fg-3 transition-colors hover:bg-panel2"
             onClick={async () => {
               try {
                 await navigator.clipboard.writeText(code);
@@ -59,14 +64,14 @@ export function CodeBlock({
               }
             }}
           >
-            {copied ? <Check size={12} className="text-brand" /> : <Copy size={12} />}
+            {copied ? <Check size={12} className="text-accent" /> : <Copy size={12} />}
             <span className="font-mono text-[11px]">{copied ? "copied" : "copy"}</span>
           </button>
         )}
       </div>
       <pre
         className={cn(
-          "overflow-x-auto font-mono text-ink-2",
+          "overflow-x-auto font-mono text-fg-2",
           dense ? "px-3.5 py-3 text-[12px]" : "p-4 text-[12.5px]",
         )}
         style={{ lineHeight: 1.7 }}
@@ -74,7 +79,7 @@ export function CodeBlock({
         {lines.map((line, i) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: index included with line content for uniqueness; duplicate lines are possible
           <div key={`${i}-${line}`} className="flex gap-3.5">
-            <span className="w-4 flex-shrink-0 select-none text-right text-faint">{i + 1}</span>
+            <span className="w-4 flex-shrink-0 select-none text-right text-fg-4">{i + 1}</span>
             <code
               className="whitespace-pre"
               // biome-ignore lint/security/noDangerouslySetInnerHtml: input is HTML-escaped in highlight() before tokens are wrapped

--- a/packages/dashboard/src/components/brand/frameworks.tsx
+++ b/packages/dashboard/src/components/brand/frameworks.tsx
@@ -61,7 +61,7 @@ export function FwGlyph({
         height={size}
         viewBox="0 0 24 24"
         fill="currentColor"
-        className={cn("text-foreground", className)}
+        className={cn("text-fg", className)}
         aria-hidden="true"
       >
         <path d={brand} />
@@ -78,7 +78,7 @@ export function FwGlyph({
     strokeWidth: 1.6,
     strokeLinecap: "round" as const,
     strokeLinejoin: "round" as const,
-    className: cn("text-foreground", className),
+    className: cn("text-fg", className),
   };
   switch (kind) {
     case "stack":

--- a/packages/dashboard/src/components/docs/docs-nav.tsx
+++ b/packages/dashboard/src/components/docs/docs-nav.tsx
@@ -49,10 +49,10 @@ export function DocsNav() {
                 aria-current={active === id ? "true" : undefined}
                 onClick={() => setActive(id)}
                 className={cn(
-                  "rounded-md px-2.5 py-1.5 text-left text-[13.5px] transition-colors",
+                  "rounded-[var(--radius)] px-2.5 py-1.5 text-left text-[13.5px] transition-colors",
                   active === id
-                    ? "bg-brand-soft font-semibold text-brand-ink"
-                    : "font-medium text-ink-2 hover:text-foreground",
+                    ? "bg-panel2 font-semibold text-fg"
+                    : "font-medium text-fg-3 hover:text-fg",
                 )}
               >
                 {label}

--- a/packages/dashboard/src/components/docs/on-this-page.tsx
+++ b/packages/dashboard/src/components/docs/on-this-page.tsx
@@ -4,12 +4,12 @@ export function OnThisPage() {
   return (
     <aside aria-label="On this page" className="sticky top-[88px] hidden xl:block">
       <div className="as-label mb-2.5 block text-[10px]">ON THIS PAGE</div>
-      <div className="flex flex-col gap-[7px] border-l border-border pl-3">
+      <div className="flex flex-col gap-[7px] border-l border-edge pl-3">
         {ON_THIS_PAGE.map(([id, label]) => (
           <a
             key={id}
             href={`#${id}`}
-            className="text-[12.5px] text-muted-foreground transition-colors hover:text-foreground"
+            className="text-[12.5px] text-fg-4 transition-colors hover:text-fg"
           >
             {label}
           </a>

--- a/packages/dashboard/src/pages/brand.astro
+++ b/packages/dashboard/src/pages/brand.astro
@@ -370,7 +370,7 @@ const iconAssets = [
     <script>
       // Copy-URL for brand asset buttons (event-delegated; works regardless of load order)
       document.addEventListener("click", (e) => {
-        const btn = (e.target as Element).closest<HTMLElement>("[data-copy-url]");
+        const btn = e.target instanceof Element ? e.target.closest<HTMLElement>("[data-copy-url]") : null;
         if (!btn) return;
         const url = btn.getAttribute("data-copy-url") || "";
         const label = btn.querySelector("[data-copy-label]");

--- a/packages/dashboard/src/pages/brand.astro
+++ b/packages/dashboard/src/pages/brand.astro
@@ -22,7 +22,7 @@ const textColors = [
 ] as const;
 
 const accents = [
-  { name: "accent", hex: "#3b82f6", note: "primary interactive" },
+  { name: "accent", hex: "#e2664d", note: "primary interactive" },
   { name: "pos", hex: "#34d399", note: "positive / live" },
   { name: "warn", hex: "#f59e0b", note: "warn / rate-limited" },
   { name: "neg", hex: "#f87171", note: "negative / over-budget" },
@@ -235,7 +235,7 @@ const iconAssets = [
         </div>
         <div class="flex flex-col bg-panel">
           <div class="flex h-40 items-center justify-center">
-            <div class="flex size-[64px] items-center justify-center rounded-[14px] border border-edge bg-panel2"><Logo size={34} /></div>
+            <div class="flex size-[64px] items-center justify-center rounded-[var(--radius-xl)] border border-edge bg-panel2"><Logo size={34} /></div>
           </div>
           <div class="border-t border-edge-soft px-4 py-2.5 font-mono text-[10.5px] uppercase tracking-wider text-fg-4">Icon tile</div>
         </div>
@@ -307,18 +307,22 @@ const iconAssets = [
     <!-- shape: radius -->
     <section data-reveal class="mx-auto max-w-[1040px] px-5 pb-24">
       <div class="mb-6 font-mono text-[11px] uppercase tracking-[0.15em] text-fg-4">Shape</div>
-      <div class="grid grid-cols-2 gap-3 sm:grid-cols-3">
+      <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
         <Card class="p-6">
-          <div class="flex h-16 items-center justify-center rounded-[6px] border border-edge bg-panel2"></div>
+          <div class="flex h-16 items-center justify-center rounded-[var(--radius-sm)] border border-edge bg-panel2"></div>
           <div class="mt-3 flex items-baseline justify-between"><span class="font-mono text-[12px] text-fg">radius-sm</span><span class="font-mono text-[11px] text-fg-4">6px</span></div>
         </Card>
         <Card class="p-6">
-          <div class="flex h-16 items-center justify-center rounded-[8px] border border-edge bg-panel2"></div>
-          <div class="mt-3 flex items-baseline justify-between"><span class="font-mono text-[12px] text-fg">radius</span><span class="font-mono text-[11px] text-fg-4">8px</span></div>
+          <div class="flex h-16 items-center justify-center rounded-[var(--radius)] border border-edge bg-panel2"></div>
+          <div class="mt-3 flex items-baseline justify-between"><span class="font-mono text-[12px] text-fg">radius</span><span class="font-mono text-[11px] text-fg-4">9px</span></div>
         </Card>
         <Card class="p-6">
-          <div class="flex h-16 items-center justify-center rounded-[12px] border border-edge bg-panel2"></div>
+          <div class="flex h-16 items-center justify-center rounded-[var(--radius-lg)] border border-edge bg-panel2"></div>
           <div class="mt-3 flex items-baseline justify-between"><span class="font-mono text-[12px] text-fg">radius-lg</span><span class="font-mono text-[11px] text-fg-4">12px</span></div>
+        </Card>
+        <Card class="p-6">
+          <div class="flex h-16 items-center justify-center rounded-[var(--radius-xl)] border border-edge bg-panel2"></div>
+          <div class="mt-3 flex items-baseline justify-between"><span class="font-mono text-[12px] text-fg">radius-xl</span><span class="font-mono text-[11px] text-fg-4">14px</span></div>
         </Card>
       </div>
     </section>
@@ -337,7 +341,7 @@ const iconAssets = [
               <li>Use the mark in its original proportions.</li>
               <li>Give it clear space equal to one layer height.</li>
               <li>Let it inherit <span class="font-mono text-fg-3">currentColor</span> — recolor via parent text.</li>
-              <li>Use the accent blue to highlight interactive moments.</li>
+              <li>Use the vermilion accent to highlight interactive moments.</li>
             </ul>
           </Card>
           <Card class="p-6">
@@ -366,7 +370,7 @@ const iconAssets = [
     <script>
       // Copy-URL for brand asset buttons (event-delegated; works regardless of load order)
       document.addEventListener("click", (e) => {
-        const btn = e.target.closest("[data-copy-url]");
+        const btn = (e.target as Element).closest<HTMLElement>("[data-copy-url]");
         if (!btn) return;
         const url = btn.getAttribute("data-copy-url") || "";
         const label = btn.querySelector("[data-copy-label]");

--- a/packages/dashboard/src/pages/docs.astro
+++ b/packages/dashboard/src/pages/docs.astro
@@ -234,19 +234,19 @@ const permissionScopes: [scope: string, grants: string][] = [
         <p class="mt-2 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
           Copy this prompt into Claude Code, Cursor, or any coding agent. It will discover the API and wire up AgentState for you.
         </p>
-        <div class="mt-3.5 overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-[#0c0c0e]">
+        <div class="mt-3.5 overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-panel">
           <div class="flex h-9 items-center justify-between border-b border-edge-soft px-4">
             <span class="font-mono text-[11px] text-fg-4">agent-prompt.txt</span>
             <button
               type="button"
               data-copy-text={agentPromptCode}
-              class="inline-flex items-center gap-1.5 rounded-[var(--radius)] px-2 py-0.5 font-mono text-[11px] text-fg-4 transition-colors hover:bg-white/5 hover:text-fg"
+              class="inline-flex items-center gap-1.5 rounded-[var(--radius)] px-2 py-0.5 font-mono text-[11px] text-fg-4 transition-colors hover:bg-panel2 hover:text-fg"
               aria-label="Copy prompt to clipboard"
             >
               <span data-copy-label>Copy</span>
             </button>
           </div>
-          <pre class="overflow-auto bg-[#0c0c0e] p-4 font-mono text-[12.5px] leading-[1.75] text-zinc-300"><code>{agentPromptCode}</code></pre>
+          <pre class="overflow-auto bg-panel p-4 font-mono text-[12.5px] leading-[1.75] text-fg-2"><code>{agentPromptCode}</code></pre>
         </div>
 
         <!-- Install the skill -->
@@ -254,19 +254,19 @@ const permissionScopes: [scope: string, grants: string][] = [
         <p class="mt-1.5 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
           Install the AgentState skill so your agent always knows how to use the API.
         </p>
-        <div class="mt-3 overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-[#0c0c0e]">
+        <div class="mt-3 overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-panel">
           <div class="flex h-9 items-center justify-between border-b border-edge-soft px-4">
             <span class="font-mono text-[11px] text-fg-4">terminal</span>
             <button
               type="button"
               data-copy-text={installSkillCode}
-              class="inline-flex items-center gap-1.5 rounded-[var(--radius)] px-2 py-0.5 font-mono text-[11px] text-fg-4 transition-colors hover:bg-white/5 hover:text-fg"
+              class="inline-flex items-center gap-1.5 rounded-[var(--radius)] px-2 py-0.5 font-mono text-[11px] text-fg-4 transition-colors hover:bg-panel2 hover:text-fg"
               aria-label="Copy install command to clipboard"
             >
               <span data-copy-label>Copy</span>
             </button>
           </div>
-          <pre class="overflow-auto bg-[#0c0c0e] p-4 font-mono text-[12.5px] leading-[1.75] text-zinc-300"><code>{installSkillCode}</code></pre>
+          <pre class="overflow-auto bg-panel p-4 font-mono text-[12.5px] leading-[1.75] text-fg-2"><code>{installSkillCode}</code></pre>
         </div>
 
         <!-- Quickstart -->
@@ -274,9 +274,9 @@ const permissionScopes: [scope: string, grants: string][] = [
         <p class="mt-2 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
           Install the SDK, create a project key in the dashboard, and store your first conversation.
         </p>
-        <div class="mt-3.5 overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-[#0c0c0e]">
+        <div class="mt-3.5 overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-panel">
           <div class="flex h-9 items-center border-b border-edge-soft px-4 font-mono text-[11px] text-fg-4">quickstart.ts</div>
-          <pre class="overflow-auto bg-[#0c0c0e] p-4 font-mono text-[12.5px] leading-[1.75] text-zinc-300"><code>{quickCode}</code></pre>
+          <pre class="overflow-auto bg-panel p-4 font-mono text-[12.5px] leading-[1.75] text-fg-2"><code>{quickCode}</code></pre>
         </div>
 
         <!-- Authentication -->
@@ -285,9 +285,9 @@ const permissionScopes: [scope: string, grants: string][] = [
           Every request is authenticated with a project-scoped bearer key. Keys are SHA-256 hashed
           at rest and can be rotated or revoked from the dashboard.
         </p>
-        <div class="mt-3.5 overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-[#0c0c0e]">
+        <div class="mt-3.5 overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-panel">
           <div class="flex h-9 items-center border-b border-edge-soft px-4 font-mono text-[11px] text-fg-4">auth.sh</div>
-          <pre class="overflow-auto bg-[#0c0c0e] p-4 font-mono text-[12.5px] leading-[1.75] text-zinc-300"><code>{authCode}</code></pre>
+          <pre class="overflow-auto bg-panel p-4 font-mono text-[12.5px] leading-[1.75] text-fg-2"><code>{authCode}</code></pre>
         </div>
         <div class="mt-3.5 flex gap-2.5 rounded-[var(--radius-lg)] border border-edge bg-panel2 px-3.5 py-3">
           <span class="mt-px size-1.5 flex-shrink-0 rounded-full bg-accent"></span>
@@ -322,9 +322,9 @@ const permissionScopes: [scope: string, grants: string][] = [
           Skip the wiring. Adapters map your framework's native state shape onto AgentState v2
           state — the same store powers Vercel AI SDK, TanStack, LangGraph and Cloudflare Agents.
         </p>
-        <div class="mt-3.5 overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-[#0c0c0e]">
+        <div class="mt-3.5 overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-panel">
           <div class="flex h-9 items-center border-b border-edge-soft px-4 font-mono text-[11px] text-fg-4">ai-sdk.ts</div>
-          <pre class="overflow-auto bg-[#0c0c0e] p-4 font-mono text-[12.5px] leading-[1.75] text-zinc-300"><code>{adapterCode}</code></pre>
+          <pre class="overflow-auto bg-panel p-4 font-mono text-[12.5px] leading-[1.75] text-fg-2"><code>{adapterCode}</code></pre>
         </div>
         <div class="mt-3.5 grid grid-cols-1 gap-px overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-edge sm:grid-cols-2">
           {
@@ -346,9 +346,9 @@ const permissionScopes: [scope: string, grants: string][] = [
           <code class="font-mono text-fg">https://agentstate.app/api/mcp</code> — no install. Authenticate with a Bearer
           API key or capability token, or let the client run the OAuth flow.
         </p>
-        <div class="mt-3.5 overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-[#0c0c0e]">
+        <div class="mt-3.5 overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-panel">
           <div class="flex h-9 items-center border-b border-edge-soft px-4 font-mono text-[11px] text-fg-4">mcp.json</div>
-          <pre class="overflow-auto bg-[#0c0c0e] p-4 font-mono text-[12.5px] leading-[1.75] text-zinc-300"><code>{mcpConfig}</code></pre>
+          <pre class="overflow-auto bg-panel p-4 font-mono text-[12.5px] leading-[1.75] text-fg-2"><code>{mcpConfig}</code></pre>
         </div>
         <div class="mt-3.5 flex gap-2.5 rounded-[var(--radius-lg)] border border-edge bg-panel2 px-3.5 py-3">
           <span class="mt-px size-1.5 flex-shrink-0 rounded-full bg-accent"></span>


### PR DESCRIPTION
Part of the bold dashboard redesign (Wave B / unit D2). Migrates docs, brand, and OAuth-consent pages fully onto canonical design-system v2 tokens per `packages/dashboard/DESIGN.md`: replaces hardcoded blue `#3b82f6` → vermilion accent, removes remaining shadcn-alias/legacy CSS vars in brand/docs components, theme-reactive code-block backgrounds, and aligns the brand radius showcase with the real scale. No `docs-data.ts` or foundation files touched. Originally targeted the (now-deleted) `redesign/v2`; retargeted to main.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>