### PR TITLE
style(dashboard): redesign Analytics page to design-system v2 (D5)

### DIFF
--- a/packages/dashboard/src/components/analytics/area-chart.tsx
+++ b/packages/dashboard/src/components/analytics/area-chart.tsx
@@ -2,16 +2,17 @@
 
 import type { EChartsType, TooltipComponentFormatterCallbackParams } from "echarts";
 import * as echarts from "echarts";
+import { useTheme } from "next-themes";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Card } from "@/components/ui/card";
-import type { DataPoint } from "./chart-utils";
-import { fillDateGaps } from "./chart-utils";
+import type { ChartToken, DataPoint } from "./chart-utils";
+import { fillDateGaps, resolveChartColor, withAlpha } from "./chart-utils";
 
 interface AreaChartCardProps {
   title: string;
   data: DataPoint[];
-  /** CSS color value for the stroke/fill. Defaults to accent blue. */
-  color?: string;
+  /** Named `chart-*` design token for the stroke/fill. Defaults to `chart-1` (brand accent). */
+  colorToken?: ChartToken;
   valueLabel?: string;
   formatValue?: (value: number) => string;
   /** Show time-range filter. */
@@ -32,12 +33,16 @@ type TimeRangeKey = keyof typeof TIME_RANGE_ITEMS;
  * Time-series area chart rendered with echarts (the design-system primitives have
  * no Chart component; echarts is a peer dep). Preserves the prior behavior: date-gap
  * filling, 7d/30d/90d filtering, gradient area, and a value total in the header.
- * Recolored to the AgentState token palette.
+ *
+ * Colors are resolved from the `chart-*` design tokens (never hardcoded hex) via
+ * `resolveChartColor`, which reads the live CSS custom property — so series and
+ * chrome colors automatically match the current light/dark theme. `resolvedTheme`
+ * is only consumed to force a redraw when the user toggles theme.
  */
 export function AreaChartCard({
   title,
   data,
-  color = "#3b82f6",
+  colorToken = "chart-1",
   valueLabel = "value",
   formatValue,
   showTimeRange = false,
@@ -46,6 +51,7 @@ export function AreaChartCard({
   const [timeRange, setTimeRange] = useState<TimeRangeKey>("30d");
   const chartRef = useRef<HTMLDivElement>(null);
   const chartInstance = useRef<EChartsType | null>(null);
+  const { resolvedTheme } = useTheme();
 
   const filled = useMemo(() => fillDateGaps(data, 90), [data]);
   const total = filled.reduce((sum, d) => sum + d.value, 0);
@@ -67,14 +73,31 @@ export function AreaChartCard({
     }
     const chart = chartInstance.current;
 
+    // Clear stale gradients/colors before repainting for the current theme —
+    // echarts caches canvas gradients by reference, so a bare setOption() can
+    // leave the previous theme's colors on screen after a light/dark toggle.
+    // (resolvedTheme itself doesn't affect the option shape; it only drives
+    // *when* this effect re-runs via the dependency array below.)
+    void resolvedTheme;
+    chart.clear();
+
+    // Resolve token colors fresh on every draw so theme toggles repaint with
+    // the currently active light/dark palette.
+    const seriesColor = resolveChartColor(colorToken);
+    const panelColor = resolveChartColor("panel");
+    const edgeColor = resolveChartColor("edge");
+    const fgColor = resolveChartColor("fg");
+    const axisLabelColor = resolveChartColor("fg-3");
+    const splitLineColor = withAlpha(axisLabelColor, 0.16);
+
     chart.setOption({
       grid: { left: 8, right: 8, top: 8, bottom: 0, containLabel: true },
       tooltip: {
         trigger: "axis",
-        backgroundColor: "rgba(9,9,11,0.92)",
+        backgroundColor: panelColor,
         borderWidth: 1,
-        borderColor: "#262629",
-        textStyle: { color: "#fafafa", fontSize: 12 },
+        borderColor: edgeColor,
+        textStyle: { color: fgColor, fontSize: 12 },
         formatter: (params: TooltipComponentFormatterCallbackParams) => {
           const p = Array.isArray(params) ? params[0] : params;
           if (!p) return "";
@@ -99,7 +122,7 @@ export function AreaChartCard({
         axisLine: { show: false },
         axisTick: { show: false },
         axisLabel: {
-          color: "#a1a1aa",
+          color: axisLabelColor,
           fontSize: 11,
           margin: 8,
           hideOverlap: true,
@@ -109,9 +132,9 @@ export function AreaChartCard({
       },
       yAxis: {
         type: "value",
-        splitLine: { lineStyle: { color: "rgba(255,255,255,0.08)" } },
+        splitLine: { lineStyle: { color: splitLineColor } },
         axisLabel: {
-          color: "#a1a1aa",
+          color: axisLabelColor,
           fontSize: 11,
           hideOverlap: true,
         },
@@ -123,11 +146,11 @@ export function AreaChartCard({
           smooth: true,
           symbol: "none",
           stack: "a",
-          lineStyle: { width: 2, color },
+          lineStyle: { width: 2, color: seriesColor },
           areaStyle: {
             color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-              { offset: 0, color: withAlpha(color, 0.35) },
-              { offset: 1, color: withAlpha(color, 0.02) },
+              { offset: 0, color: withAlpha(seriesColor, 0.35) },
+              { offset: 1, color: withAlpha(seriesColor, 0.02) },
             ]),
           },
           data: filteredData.map((d) => d.value),
@@ -136,7 +159,7 @@ export function AreaChartCard({
     });
 
     return undefined;
-  }, [filteredData, color, valueLabel, formatValue]);
+  }, [filteredData, colorToken, valueLabel, formatValue, resolvedTheme]);
 
   // Responsive resize
   useEffect(() => {
@@ -175,23 +198,4 @@ export function AreaChartCard({
       <div ref={chartRef} className="h-[250px] w-full" />
     </Card>
   );
-}
-
-/** Converts a hex/rgb color to an rgba string with the given alpha. */
-function withAlpha(color: string, alpha: number): string {
-  if (color.startsWith("#")) {
-    const hex = color.slice(1);
-    const full =
-      hex.length === 3
-        ? hex
-            .split("")
-            .map((c) => c + c)
-            .join("")
-        : hex;
-    const r = Number.parseInt(full.slice(0, 2), 16);
-    const g = Number.parseInt(full.slice(2, 4), 16);
-    const b = Number.parseInt(full.slice(4, 6), 16);
-    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-  }
-  return color;
 }

--- a/packages/dashboard/src/components/analytics/chart-utils.ts
+++ b/packages/dashboard/src/components/analytics/chart-utils.ts
@@ -8,6 +8,48 @@ export interface DataPoint {
   value: number;
 }
 
+/** Named `chart-*` series tokens defined in `src/styles/global.css`. */
+export type ChartToken = "chart-1" | "chart-2" | "chart-3" | "chart-4" | "chart-5";
+
+/** Any `--color-*` design token defined in `tokens.css` / `global.css`. */
+export type ColorToken = ChartToken | "panel" | "edge" | "fg" | "fg-3";
+
+/**
+ * Resolves a `--color-*` custom property to its current computed value (a
+ * real hex/rgb string) so it can be handed to canvas-based chart libraries
+ * (echarts) that can't read CSS `var()`.
+ *
+ * Reads from `document.documentElement`, so it automatically reflects the
+ * light/dark value currently active via the `.dark` class (see tokens.css).
+ * Call again (e.g. on theme change) to pick up the flipped palette.
+ */
+export function resolveChartColor(token: ColorToken): string {
+  if (typeof document === "undefined") return "#e2664d";
+  const value = getComputedStyle(document.documentElement)
+    .getPropertyValue(`--color-${token}`)
+    .trim();
+  return value || "#e2664d";
+}
+
+/** Converts a resolved hex/rgb color string to an rgba string with the given alpha. */
+export function withAlpha(color: string, alpha: number): string {
+  if (color.startsWith("#")) {
+    const hex = color.slice(1);
+    const full =
+      hex.length === 3
+        ? hex
+            .split("")
+            .map((c) => c + c)
+            .join("")
+        : hex;
+    const r = Number.parseInt(full.slice(0, 2), 16);
+    const g = Number.parseInt(full.slice(2, 4), 16);
+    const b = Number.parseInt(full.slice(4, 6), 16);
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+  return color;
+}
+
 /**
  * Fills missing dates in time-series data with zero values.
  * Ensures continuous date ranges for accurate chart rendering.

--- a/packages/dashboard/src/components/analytics/recent-activity.tsx
+++ b/packages/dashboard/src/components/analytics/recent-activity.tsx
@@ -2,6 +2,14 @@
 
 import { ChatCircleIcon } from "@phosphor-icons/react";
 import { Card } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { timeAgo } from "@/lib/format";
 
 interface RecentConversation {
@@ -35,40 +43,34 @@ export function RecentActivity({ conversations }: RecentActivityProps) {
 
   return (
     <Card className="overflow-hidden p-0">
-      <table className="w-full border-collapse text-[13px]">
-        <thead>
-          <tr className="border-b border-edge bg-panel2/50">
-            <th className="px-4 py-2.5 text-left font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4">
-              Title
-            </th>
-            <th className="hidden px-4 py-2.5 text-left font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4 sm:table-cell">
-              Messages
-            </th>
-            <th className="hidden px-4 py-2.5 text-left font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4 sm:table-cell">
-              Tokens
-            </th>
-            <th className="px-4 py-2.5 text-right font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4">
-              Updated
-            </th>
-          </tr>
-        </thead>
-        <tbody>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Title</TableHead>
+            <TableHead className="hidden sm:table-cell">Messages</TableHead>
+            <TableHead className="hidden sm:table-cell">Tokens</TableHead>
+            <TableHead align="right">Updated</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
           {conversations.map((conv) => (
-            <tr key={conv.id} className="border-b border-edge-soft last:border-0">
-              <td className="max-w-[200px] truncate px-4 py-2.5 text-fg">
+            <TableRow key={conv.id}>
+              <TableCell className="max-w-[200px] truncate text-fg">
                 {conv.title || "Untitled"}
-              </td>
-              <td className="num hidden px-4 py-2.5 text-fg-3 sm:table-cell">
+              </TableCell>
+              <TableCell className="hidden sm:table-cell" mono>
                 {conv.message_count}
-              </td>
-              <td className="num hidden px-4 py-2.5 text-fg-3 sm:table-cell">
+              </TableCell>
+              <TableCell className="hidden sm:table-cell" mono>
                 {conv.token_count.toLocaleString()}
-              </td>
-              <td className="num px-4 py-2.5 text-right text-fg-3">{timeAgo(conv.updated_at)}</td>
-            </tr>
+              </TableCell>
+              <TableCell align="right" mono>
+                {timeAgo(conv.updated_at)}
+              </TableCell>
+            </TableRow>
           ))}
-        </tbody>
-      </table>
+        </TableBody>
+      </Table>
     </Card>
   );
 }

--- a/packages/dashboard/src/components/analytics/time-range-select.tsx
+++ b/packages/dashboard/src/components/analytics/time-range-select.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Toggle } from "@/components/ui/toggle";
+
 const RANGES = [
   { label: "7d", value: "7d" },
   { label: "30d", value: "30d" },
@@ -18,19 +20,16 @@ export function TimeRangeSelect({ value, onChange }: TimeRangeSelectProps) {
     <fieldset className="flex overflow-hidden rounded-[var(--radius)] border border-edge">
       <legend className="sr-only">Select time range</legend>
       {RANGES.map((r) => (
-        <button
+        <Toggle
           key={r.value}
-          type="button"
-          aria-pressed={value === r.value}
+          variant="ghost"
+          size="sm"
+          pressed={value === r.value}
           onClick={() => onChange(r.value)}
-          className={`min-h-[34px] px-3 font-mono text-[12px] transition-colors ${
-            value === r.value
-              ? "bg-fg text-[var(--color-base)]"
-              : "bg-panel text-fg-3 hover:bg-panel2 hover:text-fg"
-          }`}
+          className="rounded-none font-mono"
         >
           {r.label}
-        </button>
+        </Toggle>
       ))}
     </fieldset>
   );

--- a/packages/dashboard/src/components/dashboard/analytics/_analytics-content.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_analytics-content.tsx
@@ -32,13 +32,13 @@ export function AnalyticsContent({ data }: AnalyticsContentProps) {
         <AreaChartCard
           title="Conversations"
           data={data.conversations_per_day.map((d) => ({ date: d.date, value: d.count }))}
-          color="#3b82f6"
+          colorToken="chart-1"
           valueLabel="Conversations"
         />
         <AreaChartCard
           title="Messages"
           data={data.messages_per_day.map((d) => ({ date: d.date, value: d.count }))}
-          color="#34d399"
+          colorToken="chart-3"
           valueLabel="Messages"
         />
       </div>
@@ -47,7 +47,7 @@ export function AnalyticsContent({ data }: AnalyticsContentProps) {
       <AreaChartCard
         title="Token usage"
         data={data.tokens_per_day.map((d) => ({ date: d.date, value: d.total }))}
-        color="#f59e0b"
+        colorToken="chart-2"
         valueLabel="Tokens"
         showTimeRange
       />
@@ -59,7 +59,7 @@ export function AnalyticsContent({ data }: AnalyticsContentProps) {
             date: d.date,
             value: d.total_cost_microdollars / 1_000_000,
           }))}
-          color="#f87171"
+          colorToken="chart-4"
           valueLabel="Cost ($)"
           formatValue={(v) => formatCostMicrodollars(v * 1_000_000)}
           showTimeRange
@@ -81,10 +81,8 @@ export function AnalyticsContent({ data }: AnalyticsContentProps) {
           <h3 className="text-[14px] font-medium text-fg">Recent activity</h3>
           <RecentActivity conversations={data.recent_conversations} />
         </div>
-        <div className="flex flex-col gap-3">
-          <h3 className="text-[14px] font-medium text-fg">Top conversations</h3>
-          <TopConversations conversations={data.recent_conversations} />
-        </div>
+        {/* TopConversations renders its own "Top Conversations" title inside the card. */}
+        <TopConversations conversations={data.recent_conversations} />
       </div>
     </div>
   );

--- a/packages/dashboard/src/components/dashboard/analytics/_peak-usage.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_peak-usage.tsx
@@ -31,7 +31,7 @@ export function PeakUsage({ messagesPerDay }: PeakUsageProps) {
       footnote={
         <>
           Average: {average.toLocaleString()}/day
-          <span className="ml-2 text-neg">(+{aboveAverage}% above avg)</span>
+          <span className="ml-2 text-pos">(+{aboveAverage}% above avg)</span>
         </>
       }
       icon={ChartLineUpIcon}


### PR DESCRIPTION
## Summary
- D5 — Analytics unit of the dashboard v2 redesign (`redesign/v2` was already merged into `main` via #245, so this targets `main` directly like the sibling D2/D6/D7/D8 redesign PRs).
- Removes all hardcoded hex chart colors and migrates the analytics page's components onto the `chart-1..5` design tokens and shared primitives per `packages/dashboard/DESIGN.md`.
- `area-chart.tsx`: `colorToken` prop (named `chart-*` token) replaces the raw hex `color` prop. Tooltip/axis/gridline colors now resolve from `panel`/`edge`/`fg`/`fg-3` tokens via a new `resolveChartColor` helper (reads live CSS custom properties, so echarts — a canvas renderer that can't read `var()` — stays in sync with light/dark theme). Chart clears and redraws on theme toggle via `next-themes`.
- `chart-utils.ts`: adds `resolveChartColor` + `withAlpha` (deduped from `area-chart.tsx`).
- `recent-activity.tsx`: migrates the raw `<table>` to the shared `Table`/`TableHeader`/`TableRow`/`TableCell` primitive family, matching the pattern used by other redesigned tables (e.g. conversations).
- `time-range-select.tsx`: swaps the hand-rolled segmented button (`bg-fg` active state) for the `Toggle` primitive (accent-tinted), keeping "one vermilion accent" consistent with DESIGN.md.
- `_analytics-content.tsx`: charts now pass `colorToken` (chart-1 conversations, chart-3 messages, chart-2 tokens, chart-4 cost) instead of hex; removes a duplicate "Top conversations" heading (the `TopConversations` card already renders its own title).
- `_peak-usage.tsx`: fixes `text-neg` (red/error) being used for a "+X% above avg" stat that isn't negative — now `text-pos`, matching the sibling `TokenTrendSummary` card's correct up/down semantics.

No foundation-owned files touched (`styles/*`, `layouts/*`, `ui/*`, `app-shell.tsx`, `page-header.tsx`, `providers.tsx`, `theme-script.astro`, `reveal-script.astro`, `astro.config.mjs`, `package.json`).

## Test plan
- [x] `bunx biome check` on all owned files — clean
- [x] `bunx astro check` — 0 errors/warnings in analytics files (2 pre-existing unrelated errors remain in `brand.astro`, untouched by this PR)
- [x] `PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_placeholder bun run build` — passes, `/dashboard/analytics/index.html` generated
- [x] `bun run dev` + browser check — `/dashboard/analytics` returns 200, no console errors beyond the expected `pk_test_placeholder` Clerk-JS-load failure (verified identical on the unmodified `/dashboard/conversations` route, confirming it's a pre-existing sandbox/placeholder-key limitation, not a regression)
- [x] Route confirmed Clerk-gated (not publicly reachable) — no screenshot required per task instructions