### PR TITLE
refactor(dashboard): redesign traces page to design-system v2 (D4)

### DIFF
--- a/packages/dashboard/src/components/dashboard/traces/_observation-row.tsx
+++ b/packages/dashboard/src/components/dashboard/traces/_observation-row.tsx
@@ -1,0 +1,83 @@
+import type { TraceDetailResponse } from "@agentstate/shared";
+import { Badge, type Tone } from "@/components/ui/badge";
+import { formatCostMicrodollars } from "@/lib/format-cost";
+import { formatObservationDuration, formatTraceTokens } from "./_trace-format";
+
+// Badge tone per observation type (mapped to the design-system token palette).
+const TYPE_TONE: Record<string, Tone> = {
+  generation: "live",
+  tool: "warn",
+  agent: "live",
+  chain: "warn",
+  span: "idle",
+  event: "warn",
+};
+
+// Waterfall bar fill per observation type — single accent + functional tokens only.
+const BAR_COLOR: Record<string, string> = {
+  generation: "bg-accent",
+  tool: "bg-warn",
+  agent: "bg-accent",
+  chain: "bg-pos",
+  span: "bg-fg-4",
+  event: "bg-warn",
+};
+
+export function ObservationRow({
+  obs,
+  depth,
+  traceStart,
+  traceDuration,
+}: {
+  obs: TraceDetailResponse["observations"][number];
+  depth: number;
+  traceStart: number;
+  traceDuration: number;
+}) {
+  const type = obs.observation_type ?? "span";
+  const duration = obs.start_time && obs.end_time ? obs.end_time - obs.start_time : 0;
+  const barWidth =
+    traceDuration > 0 && duration > 0 ? Math.max(2, (duration / traceDuration) * 100) : 0;
+  const barOffset =
+    traceDuration > 0 && obs.start_time ? ((obs.start_time - traceStart) / traceDuration) * 100 : 0;
+
+  return (
+    <>
+      <div
+        className="flex items-center gap-tight border-b border-edge-soft py-1.5 pr-3 text-[12px] text-fg-3"
+        style={{ paddingLeft: `${depth * 24 + 12}px` }}
+      >
+        <Badge tone={TYPE_TONE[type] ?? "idle"} className="shrink-0">
+          {type}
+        </Badge>
+        <span className="max-w-[140px] truncate text-fg-3">{obs.model ?? obs.role}</span>
+        <span className="flex-1" />
+        <div className="relative h-1.5 w-28 shrink-0 overflow-hidden rounded-full bg-panel2">
+          <div
+            className={`absolute inset-y-0 left-0 rounded-full ${BAR_COLOR[type] ?? BAR_COLOR.span}`}
+            style={{
+              width: `${Math.min(barWidth, 100)}%`,
+              marginLeft: `${Math.min(barOffset, 100)}%`,
+            }}
+          />
+        </div>
+        <span className="num w-12 text-right text-fg-3">
+          {formatObservationDuration(obs.start_time, obs.end_time)}
+        </span>
+        <span className="num w-14 text-right text-fg-3">{formatTraceTokens(obs.token_count)}</span>
+        <span className="num w-14 text-right text-fg-3">
+          {formatCostMicrodollars(obs.cost_microdollars)}
+        </span>
+      </div>
+      {obs.children?.map((child) => (
+        <ObservationRow
+          key={child.id}
+          obs={child}
+          depth={depth + 1}
+          traceStart={traceStart}
+          traceDuration={traceDuration}
+        />
+      ))}
+    </>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/traces/_observation-row.tsx
+++ b/packages/dashboard/src/components/dashboard/traces/_observation-row.tsx
@@ -35,11 +35,14 @@ export function ObservationRow({
   traceDuration: number;
 }) {
   const type = obs.observation_type ?? "span";
-  const duration = obs.start_time && obs.end_time ? obs.end_time - obs.start_time : 0;
+  const duration =
+    obs.start_time !== null && obs.end_time !== null ? obs.end_time - obs.start_time : 0;
   const barWidth =
     traceDuration > 0 && duration > 0 ? Math.max(2, (duration / traceDuration) * 100) : 0;
   const barOffset =
-    traceDuration > 0 && obs.start_time ? ((obs.start_time - traceStart) / traceDuration) * 100 : 0;
+    traceDuration > 0 && obs.start_time !== null
+      ? ((obs.start_time - traceStart) / traceDuration) * 100
+      : 0;
 
   return (
     <>

--- a/packages/dashboard/src/components/dashboard/traces/_trace-detail.tsx
+++ b/packages/dashboard/src/components/dashboard/traces/_trace-detail.tsx
@@ -1,0 +1,95 @@
+import type { TraceDetailResponse } from "@agentstate/shared";
+import { Card } from "@/components/ui/card";
+import { ObservationRow } from "./_observation-row";
+
+// Stable keys for the detail-loading skeleton (avoids array-index keys).
+const DETAIL_SKEL = ["detail-skel-1", "detail-skel-2", "detail-skel-3", "detail-skel-4"] as const;
+
+// Matches TableHead's label styling (font-mono, uppercase, fg-4) for a
+// non-<table> column header row (the waterfall body isn't a real <table>).
+function ColLabel({ className = "", children }: { className?: string; children: React.ReactNode }) {
+  return (
+    <span
+      className={`font-mono text-[10.5px] font-normal uppercase tracking-[0.12em] text-fg-4 ${className}`}
+    >
+      {children}
+    </span>
+  );
+}
+
+export interface TraceDetailProps {
+  detail: TraceDetailResponse | null;
+  loadingDetail: boolean;
+}
+
+/**
+ * Trace detail waterfall — observation tree with per-row duration bars,
+ * token counts, and cost. Rendered below the traces table when a row is
+ * selected (see traces-page.tsx).
+ */
+export function TraceDetail({ detail, loadingDetail }: TraceDetailProps) {
+  const observations = detail?.observations ?? [];
+  const traceStart =
+    observations.length > 0
+      ? observations.reduce(
+          (min, o) => Math.min(min, o.start_time ?? Number.POSITIVE_INFINITY),
+          Number.POSITIVE_INFINITY,
+        )
+      : 0;
+  const traceEnd =
+    observations.length > 0
+      ? observations.reduce(
+          (max, o) => Math.max(max, o.end_time ?? Number.NEGATIVE_INFINITY),
+          Number.NEGATIVE_INFINITY,
+        )
+      : 0;
+  const traceDuration = traceEnd > traceStart ? traceEnd - traceStart : 0;
+
+  return (
+    <div className="mt-section">
+      <div className="mb-element flex items-center gap-tight">
+        <h2 className="text-[14px] font-semibold text-fg">Trace Detail</h2>
+        {detail && (
+          <span className="font-mono text-[12px] text-fg-4">{detail.title ?? detail.id}</span>
+        )}
+      </div>
+
+      {loadingDetail && (
+        <div className="flex flex-col gap-tight">
+          {DETAIL_SKEL.map((k) => (
+            <div key={k} className="h-6 w-full animate-pulse rounded-[var(--radius)] bg-panel2" />
+          ))}
+        </div>
+      )}
+
+      {!loadingDetail && detail && (
+        <Card className="overflow-hidden p-0">
+          {/* Column headers */}
+          <div className="flex items-center gap-tight border-b border-edge px-3 py-1.5">
+            <ColLabel className="w-[40%]">Type</ColLabel>
+            <span className="flex-1" />
+            <ColLabel className="w-28">Timeline</ColLabel>
+            <ColLabel className="w-12 text-right">Duration</ColLabel>
+            <ColLabel className="w-14 text-right">Tokens</ColLabel>
+            <ColLabel className="w-14 text-right">Cost</ColLabel>
+          </div>
+          {observations.length > 0 ? (
+            observations.map((obs) => (
+              <ObservationRow
+                key={obs.id}
+                obs={obs}
+                depth={0}
+                traceStart={traceStart}
+                traceDuration={traceDuration}
+              />
+            ))
+          ) : (
+            <div className="py-6 text-center text-[13px] text-fg-4">
+              No observations in this trace.
+            </div>
+          )}
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/traces/_trace-detail.tsx
+++ b/packages/dashboard/src/components/dashboard/traces/_trace-detail.tsx
@@ -23,26 +23,40 @@ export interface TraceDetailProps {
 }
 
 /**
+ * Recursively finds the min start_time / max end_time across the observation
+ * tree (including nested `children`), ignoring null timestamps. Falls back to
+ * 0/0 when no timed observations exist.
+ */
+function getTimelineBounds(nodes: TraceDetailResponse["observations"]): {
+  start: number;
+  end: number;
+} {
+  let start = Number.POSITIVE_INFINITY;
+  let end = Number.NEGATIVE_INFINITY;
+  const traverse = (node: TraceDetailResponse["observations"][number]) => {
+    if (node.start_time !== null && node.start_time !== undefined) {
+      start = Math.min(start, node.start_time);
+    }
+    if (node.end_time !== null && node.end_time !== undefined) {
+      end = Math.max(end, node.end_time);
+    }
+    node.children?.forEach(traverse);
+  };
+  nodes.forEach(traverse);
+  return {
+    start: Number.isFinite(start) ? start : 0,
+    end: Number.isFinite(end) ? end : 0,
+  };
+}
+
+/**
  * Trace detail waterfall — observation tree with per-row duration bars,
  * token counts, and cost. Rendered below the traces table when a row is
  * selected (see traces-page.tsx).
  */
 export function TraceDetail({ detail, loadingDetail }: TraceDetailProps) {
   const observations = detail?.observations ?? [];
-  const traceStart =
-    observations.length > 0
-      ? observations.reduce(
-          (min, o) => Math.min(min, o.start_time ?? Number.POSITIVE_INFINITY),
-          Number.POSITIVE_INFINITY,
-        )
-      : 0;
-  const traceEnd =
-    observations.length > 0
-      ? observations.reduce(
-          (max, o) => Math.max(max, o.end_time ?? Number.NEGATIVE_INFINITY),
-          Number.NEGATIVE_INFINITY,
-        )
-      : 0;
+  const { start: traceStart, end: traceEnd } = getTimelineBounds(observations);
   const traceDuration = traceEnd > traceStart ? traceEnd - traceStart : 0;
 
   return (

--- a/packages/dashboard/src/components/dashboard/traces/_trace-format.ts
+++ b/packages/dashboard/src/components/dashboard/traces/_trace-format.ts
@@ -1,0 +1,21 @@
+/**
+ * Formatting helpers specific to trace/observation data (tokens, duration).
+ * Cost and date formatting reuse the shared dashboard utilities in `@/lib`.
+ */
+
+export function formatTraceTokens(tokens: number): string {
+  if (tokens === 0) return "-";
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
+  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}K`;
+  return String(tokens);
+}
+
+export function formatObservationDuration(
+  startTime: number | null,
+  endTime: number | null,
+): string {
+  if (!startTime || !endTime) return "-";
+  const ms = endTime - startTime;
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}

--- a/packages/dashboard/src/components/dashboard/traces/_trace-format.ts
+++ b/packages/dashboard/src/components/dashboard/traces/_trace-format.ts
@@ -14,7 +14,7 @@ export function formatObservationDuration(
   startTime: number | null,
   endTime: number | null,
 ): string {
-  if (!startTime || !endTime) return "-";
+  if (startTime === null || endTime === null) return "-";
   const ms = endTime - startTime;
   if (ms < 1000) return `${ms}ms`;
   return `${(ms / 1000).toFixed(1)}s`;

--- a/packages/dashboard/src/components/dashboard/traces/_traces-table.tsx
+++ b/packages/dashboard/src/components/dashboard/traces/_traces-table.tsx
@@ -1,0 +1,87 @@
+import { Card } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableSkeleton,
+} from "@/components/ui/table";
+import { formatDate } from "@/lib/format";
+import { formatCostMicrodollars } from "@/lib/format-cost";
+import { formatTraceTokens } from "./_trace-format";
+import type { TraceItem } from "./_use-traces-data";
+
+export interface TracesTableProps {
+  traces: TraceItem[];
+  loading: boolean;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}
+
+const COLUMNS = ["Title", "Observations", "Tokens", "Cost", "Created"] as const;
+
+/**
+ * Traces table — canonical Table primitives on design tokens, mirrors
+ * `_ConversationsTable` in ../conversations. Rows are clickable and toggle
+ * the trace-detail waterfall rendered below by the parent page.
+ */
+export function TracesTable({ traces, loading, selectedId, onSelect }: TracesTableProps) {
+  return (
+    <Card className="overflow-hidden p-0">
+      <Table responsive>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[40%]">{COLUMNS[0]}</TableHead>
+            <TableHead align="right">{COLUMNS[1]}</TableHead>
+            <TableHead align="right">{COLUMNS[2]}</TableHead>
+            <TableHead align="right">{COLUMNS[3]}</TableHead>
+            <TableHead align="right">{COLUMNS[4]}</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {loading && <TableSkeleton columns={COLUMNS.length} rows={5} />}
+
+          {!loading && traces.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={COLUMNS.length} className="py-8 text-center text-fg-4">
+                No traces found.
+              </TableCell>
+            </TableRow>
+          )}
+
+          {!loading &&
+            traces.map((t) => {
+              const isActive = selectedId === t.id;
+              return (
+                <TableRow
+                  key={t.id}
+                  clickable
+                  className={isActive ? "bg-panel2" : ""}
+                  onClick={() => onSelect(t.id)}
+                  aria-selected={isActive}
+                >
+                  <TableCell className="font-medium text-fg">
+                    {t.title ?? <span className="text-fg-4">Untitled</span>}
+                  </TableCell>
+                  <TableCell align="right" mono>
+                    {t.message_count}
+                  </TableCell>
+                  <TableCell align="right" mono>
+                    {formatTraceTokens(t.total_tokens)}
+                  </TableCell>
+                  <TableCell align="right" mono>
+                    {formatCostMicrodollars(t.total_cost_microdollars)}
+                  </TableCell>
+                  <TableCell align="right" mono>
+                    {formatDate(t.created_at)}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+        </TableBody>
+      </Table>
+    </Card>
+  );
+}

--- a/packages/dashboard/src/components/dashboard/traces/_use-traces-data.ts
+++ b/packages/dashboard/src/components/dashboard/traces/_use-traces-data.ts
@@ -1,5 +1,5 @@
 import type { ConversationResponse, TraceDetailResponse } from "@agentstate/shared";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { api } from "@/lib/api";
 
@@ -25,9 +25,12 @@ export function useTracesData(selectedProjectId: string): UseTracesDataResult {
   const [loading, setLoading] = useState(false);
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
+  const projectIdRef = useRef(selectedProjectId);
 
   useEffect(() => {
+    projectIdRef.current = selectedProjectId;
     if (!selectedProjectId) return;
+    let active = true;
     setLoading(true);
     setTraces([]);
     setHasMore(false);
@@ -35,11 +38,21 @@ export function useTracesData(selectedProjectId: string): UseTracesDataResult {
       `/v1/projects/${selectedProjectId}/traces?limit=50`,
     )
       .then((res) => {
+        if (!active) return;
         setTraces(res.data);
         setHasMore(res.has_more);
       })
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load traces"))
-      .finally(() => setLoading(false));
+      .catch((e) => {
+        if (!active) return;
+        toast.error(e instanceof Error ? e.message : "Failed to load traces");
+      })
+      .finally(() => {
+        if (!active) return;
+        setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
   }, [selectedProjectId]);
 
   const loadMore = useCallback(() => {
@@ -50,11 +63,18 @@ export function useTracesData(selectedProjectId: string): UseTracesDataResult {
       `/v1/projects/${selectedProjectId}/traces?limit=50&cursor=${cursor}`,
     )
       .then((res) => {
+        if (projectIdRef.current !== selectedProjectId) return;
         setTraces((prev) => [...prev, ...res.data]);
         setHasMore(res.has_more);
       })
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load more"))
-      .finally(() => setLoadingMore(false));
+      .catch((e) => {
+        if (projectIdRef.current !== selectedProjectId) return;
+        toast.error(e instanceof Error ? e.message : "Failed to load more");
+      })
+      .finally(() => {
+        if (projectIdRef.current !== selectedProjectId) return;
+        setLoadingMore(false);
+      });
   }, [loadingMore, hasMore, traces, selectedProjectId]);
 
   return { traces, loading, hasMore, loadingMore, loadMore };
@@ -72,11 +92,24 @@ export function useTraceDetail(selectedProjectId: string, selectedId: string | n
       setDetail(null);
       return;
     }
+    let active = true;
     setLoadingDetail(true);
     api<TraceDetailResponse>(`/v1/projects/${selectedProjectId}/traces/${selectedId}`)
-      .then(setDetail)
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load trace detail"))
-      .finally(() => setLoadingDetail(false));
+      .then((res) => {
+        if (!active) return;
+        setDetail(res);
+      })
+      .catch((e) => {
+        if (!active) return;
+        toast.error(e instanceof Error ? e.message : "Failed to load trace detail");
+      })
+      .finally(() => {
+        if (!active) return;
+        setLoadingDetail(false);
+      });
+    return () => {
+      active = false;
+    };
   }, [selectedId, selectedProjectId]);
 
   return { detail, loadingDetail };

--- a/packages/dashboard/src/components/dashboard/traces/_use-traces-data.ts
+++ b/packages/dashboard/src/components/dashboard/traces/_use-traces-data.ts
@@ -1,0 +1,83 @@
+import type { ConversationResponse, TraceDetailResponse } from "@agentstate/shared";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+
+export type TraceItem = Pick<
+  ConversationResponse,
+  "id" | "title" | "message_count" | "total_tokens" | "total_cost_microdollars" | "created_at"
+>;
+
+interface UseTracesDataResult {
+  traces: TraceItem[];
+  loading: boolean;
+  hasMore: boolean;
+  loadingMore: boolean;
+  loadMore: () => void;
+}
+
+/**
+ * Fetches the trace list for the active project and exposes cursor pagination.
+ * Mirrors `useConversationsData`/`useConversationsPagination` in ../conversations.
+ */
+export function useTracesData(selectedProjectId: string): UseTracesDataResult {
+  const [traces, setTraces] = useState<TraceItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  useEffect(() => {
+    if (!selectedProjectId) return;
+    setLoading(true);
+    setTraces([]);
+    setHasMore(false);
+    api<{ data: TraceItem[]; has_more: boolean }>(
+      `/v1/projects/${selectedProjectId}/traces?limit=50`,
+    )
+      .then((res) => {
+        setTraces(res.data);
+        setHasMore(res.has_more);
+      })
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load traces"))
+      .finally(() => setLoading(false));
+  }, [selectedProjectId]);
+
+  const loadMore = useCallback(() => {
+    if (loadingMore || !hasMore || traces.length === 0 || !selectedProjectId) return;
+    const cursor = traces[traces.length - 1].created_at.toString();
+    setLoadingMore(true);
+    api<{ data: TraceItem[]; has_more: boolean }>(
+      `/v1/projects/${selectedProjectId}/traces?limit=50&cursor=${cursor}`,
+    )
+      .then((res) => {
+        setTraces((prev) => [...prev, ...res.data]);
+        setHasMore(res.has_more);
+      })
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load more"))
+      .finally(() => setLoadingMore(false));
+  }, [loadingMore, hasMore, traces, selectedProjectId]);
+
+  return { traces, loading, hasMore, loadingMore, loadMore };
+}
+
+/**
+ * Fetches the observation-tree detail for the selected trace id.
+ */
+export function useTraceDetail(selectedProjectId: string, selectedId: string | null) {
+  const [detail, setDetail] = useState<TraceDetailResponse | null>(null);
+  const [loadingDetail, setLoadingDetail] = useState(false);
+
+  useEffect(() => {
+    if (!selectedId || !selectedProjectId) {
+      setDetail(null);
+      return;
+    }
+    setLoadingDetail(true);
+    api<TraceDetailResponse>(`/v1/projects/${selectedProjectId}/traces/${selectedId}`)
+      .then(setDetail)
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load trace detail"))
+      .finally(() => setLoadingDetail(false));
+  }, [selectedId, selectedProjectId]);
+
+  return { detail, loadingDetail };
+}

--- a/packages/dashboard/src/components/dashboard/traces/traces-page.tsx
+++ b/packages/dashboard/src/components/dashboard/traces/traces-page.tsx
@@ -1,180 +1,14 @@
-import type { ConversationResponse, TraceDetailResponse } from "@agentstate/shared";
 import { useSearchParams } from "next/navigation";
-import { Suspense, useCallback, useEffect, useState } from "react";
-import { toast } from "sonner";
+import { Suspense, useCallback } from "react";
 import { AppShell } from "@/components/app-shell";
 import { _EmptyProjects } from "@/components/dashboard/conversations/_components";
+import { PageHeader } from "@/components/dashboard/page-header";
 import { useProjectScope } from "@/components/project-scope";
 import { Providers } from "@/components/providers";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { api } from "@/lib/api";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-type TraceItem = Pick<
-  ConversationResponse,
-  "id" | "title" | "message_count" | "total_tokens" | "total_cost_microdollars" | "created_at"
->;
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-// Stable keys for loading skeletons (avoids array-index keys).
-const ROW_SKEL = ["row-skel-1", "row-skel-2", "row-skel-3", "row-skel-4", "row-skel-5"] as const;
-const DETAIL_SKEL = ["detail-skel-1", "detail-skel-2", "detail-skel-3", "detail-skel-4"] as const;
-
-function formatCost(microdollars: number): string {
-  if (microdollars === 0) return "-";
-  const dollars = microdollars / 1_000_000;
-  if (dollars < 0.01) return `$${dollars.toFixed(4)}`;
-  return `$${dollars.toFixed(2)}`;
-}
-
-function formatTokens(tokens: number): string {
-  if (tokens === 0) return "-";
-  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
-  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}K`;
-  return String(tokens);
-}
-
-function formatDuration(startTime: number | null, endTime: number | null): string {
-  if (!startTime || !endTime) return "-";
-  const ms = endTime - startTime;
-  if (ms < 1000) return `${ms}ms`;
-  return `${(ms / 1000).toFixed(1)}s`;
-}
-
-function formatDate(ts: number): string {
-  return new Date(ts).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
-
-// ---------------------------------------------------------------------------
-// PageHeader (matches conversations layout)
-// ---------------------------------------------------------------------------
-
-function PageHeader({
-  title,
-  description,
-  actions,
-}: {
-  title: string;
-  description: string;
-  actions?: React.ReactNode;
-}) {
-  return (
-    <header className="mb-[22px] flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-      <div className="flex max-w-2xl flex-col gap-1.5">
-        <h1 className="text-[26px] tracking-tight text-fg">{title}</h1>
-        <p className="text-[14.5px] leading-6 text-fg-3">{description}</p>
-      </div>
-      {actions && <div className="flex flex-wrap items-center gap-2 sm:justify-end">{actions}</div>}
-    </header>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Observation waterfall
-// ---------------------------------------------------------------------------
-
-// Badge tones per observation type (mapped to the design-system token palette).
-const TYPE_TONE: Record<string, "default" | "live" | "warn" | "idle"> = {
-  generation: "live",
-  tool: "warn",
-  agent: "live",
-  chain: "warn",
-  span: "idle",
-  event: "warn",
-};
-
-// Bar fill per observation type — single accent + functional tokens only.
-const BAR_COLOR: Record<string, string> = {
-  generation: "bg-accent",
-  tool: "bg-warn",
-  agent: "bg-accent",
-  chain: "bg-pos",
-  span: "bg-fg-4",
-  event: "bg-warn",
-};
-
-function ObservationRow({
-  obs,
-  depth,
-  traceStart,
-  traceDuration,
-}: {
-  obs: TraceDetailResponse["observations"][number];
-  depth: number;
-  traceStart: number;
-  traceDuration: number;
-}) {
-  const type = obs.observation_type ?? "span";
-  const duration = obs.start_time && obs.end_time ? obs.end_time - obs.start_time : 0;
-  const barWidth =
-    traceDuration > 0 && duration > 0 ? Math.max(2, (duration / traceDuration) * 100) : 0;
-  const barOffset =
-    traceDuration > 0 && obs.start_time ? ((obs.start_time - traceStart) / traceDuration) * 100 : 0;
-
-  return (
-    <>
-      <div
-        className="flex items-center gap-2 border-b border-edge-soft py-1.5 pr-3 text-[12px] text-fg-3"
-        style={{ paddingLeft: `${depth * 24 + 12}px` }}
-      >
-        <Badge tone={TYPE_TONE[type] ?? "idle"} className="shrink-0">
-          {type}
-        </Badge>
-        <span className="max-w-[140px] truncate text-fg-3">{obs.model ?? obs.role}</span>
-        <span className="flex-1" />
-        <div className="relative h-1.5 w-28 shrink-0 overflow-hidden rounded-full bg-panel2">
-          <div
-            className={`absolute inset-y-0 left-0 rounded-full ${BAR_COLOR[type] ?? BAR_COLOR.span}`}
-            style={{
-              width: `${Math.min(barWidth, 100)}%`,
-              marginLeft: `${Math.min(barOffset, 100)}%`,
-            }}
-          />
-        </div>
-        <span className="num w-12 text-right text-fg-3">
-          {obs.start_time && obs.end_time ? formatDuration(obs.start_time, obs.end_time) : "-"}
-        </span>
-        <span className="num w-14 text-right text-fg-3">{formatTokens(obs.token_count)}</span>
-        <span className="num w-14 text-right text-fg-3">
-          {formatCost(obs.cost_microdollars ?? 0)}
-        </span>
-      </div>
-      {obs.children?.map((child) => (
-        <ObservationRow
-          key={child.id}
-          obs={child}
-          depth={depth + 1}
-          traceStart={traceStart}
-          traceDuration={traceDuration}
-        />
-      ))}
-    </>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Mono uppercase column header label
-// ---------------------------------------------------------------------------
-
-function ColLabel({ className = "", children }: { className?: string; children: React.ReactNode }) {
-  return (
-    <span className={`font-mono text-[10.5px] uppercase tracking-[0.12em] text-fg-4 ${className}`}>
-      {children}
-    </span>
-  );
-}
+import { TraceDetail } from "./_trace-detail";
+import { TracesTable } from "./_traces-table";
+import { useTraceDetail, useTracesData } from "./_use-traces-data";
 
 // ---------------------------------------------------------------------------
 // Trace content (uses useSearchParams, must be inside Suspense)
@@ -187,72 +21,24 @@ function TracesContent() {
   // The active project comes from the sidebar-driven global scope.
   const { projects, selectedProjectId, loadingProjects } = useProjectScope();
 
-  // Trace list
-  const [traces, setTraces] = useState<TraceItem[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [hasMore, setHasMore] = useState(false);
-  const [loadingMore, setLoadingMore] = useState(false);
-
-  useEffect(() => {
-    if (!selectedProjectId) return;
-    setLoading(true);
-    setTraces([]);
-    setHasMore(false);
-    api<{ data: TraceItem[]; has_more: boolean }>(
-      `/v1/projects/${selectedProjectId}/traces?limit=50`,
-    )
-      .then((res) => {
-        setTraces(res.data);
-        setHasMore(res.has_more);
-      })
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load traces"))
-      .finally(() => setLoading(false));
-  }, [selectedProjectId]);
-
-  const loadMore = useCallback(() => {
-    if (loadingMore || !hasMore || traces.length === 0 || !selectedProjectId) return;
-    const cursor = traces[traces.length - 1].created_at.toString();
-    setLoadingMore(true);
-    api<{ data: TraceItem[]; has_more: boolean }>(
-      `/v1/projects/${selectedProjectId}/traces?limit=50&cursor=${cursor}`,
-    )
-      .then((res) => {
-        setTraces((prev) => [...prev, ...res.data]);
-        setHasMore(res.has_more);
-      })
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load more"))
-      .finally(() => setLoadingMore(false));
-  }, [loadingMore, hasMore, traces, selectedProjectId]);
-
-  // Trace detail
-  const [detail, setDetail] = useState<TraceDetailResponse | null>(null);
-  const [loadingDetail, setLoadingDetail] = useState(false);
-
-  useEffect(() => {
-    if (!selectedId || !selectedProjectId) {
-      setDetail(null);
-      return;
-    }
-    setLoadingDetail(true);
-    api<TraceDetailResponse>(`/v1/projects/${selectedProjectId}/traces/${selectedId}`)
-      .then(setDetail)
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load trace detail"))
-      .finally(() => setLoadingDetail(false));
-  }, [selectedId, selectedProjectId]);
-
-  // Compute trace timeline bounds for waterfall bars
-  const observations = detail?.observations ?? [];
-  const traceStart =
-    observations.length > 0
-      ? observations.reduce((min, o) => Math.min(min, o.start_time ?? Infinity), Infinity)
-      : 0;
-  const traceEnd =
-    observations.length > 0
-      ? observations.reduce((max, o) => Math.max(max, o.end_time ?? -Infinity), -Infinity)
-      : 0;
-  const traceDuration = traceEnd > traceStart ? traceEnd - traceStart : 0;
+  const { traces, loading, hasMore, loadingMore, loadMore } = useTracesData(selectedProjectId);
+  const { detail, loadingDetail } = useTraceDetail(selectedProjectId, selectedId);
 
   const handleCreateProject = useCallback(() => window.location.assign("/dashboard"), []);
+
+  const handleSelect = useCallback(
+    (id: string) => {
+      const url = new URL(window.location.href);
+      if (selectedId === id) {
+        url.searchParams.delete("id");
+      } else {
+        url.searchParams.set("id", id);
+      }
+      window.history.pushState({}, "", url.toString());
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    },
+    [selectedId],
+  );
 
   return (
     <div className="px-5 sm:px-7">
@@ -281,142 +67,22 @@ function TracesContent() {
 
       {!loadingProjects && projects.length > 0 && (
         <>
-          {/* Traces table */}
-          <div className="overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-panel">
-            <div className="overflow-x-auto">
-              <table className="w-full border-collapse">
-                <thead>
-                  <tr className="border-b border-edge">
-                    <th className="w-[40%] px-3 py-2 text-left">
-                      <ColLabel>Title</ColLabel>
-                    </th>
-                    <th className="px-3 py-2 text-left">
-                      <ColLabel>Observations</ColLabel>
-                    </th>
-                    <th className="px-3 py-2 text-left">
-                      <ColLabel>Tokens</ColLabel>
-                    </th>
-                    <th className="px-3 py-2 text-left">
-                      <ColLabel>Cost</ColLabel>
-                    </th>
-                    <th className="px-3 py-2 text-left">
-                      <ColLabel>Created</ColLabel>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {loading &&
-                    ROW_SKEL.map((k) => (
-                      <tr key={k} className="border-b border-edge-soft">
-                        <td colSpan={5} className="px-3 py-2">
-                          <div className="h-4 w-full animate-pulse rounded-[var(--radius)] bg-panel2" />
-                        </td>
-                      </tr>
-                    ))}
-                  {!loading && traces.length === 0 && (
-                    <tr>
-                      <td colSpan={5} className="py-8 text-center text-[13px] text-fg-4">
-                        No traces found.
-                      </td>
-                    </tr>
-                  )}
-                  {traces.map((t) => {
-                    const isActive = selectedId === t.id;
-                    return (
-                      <tr
-                        key={t.id}
-                        className={`cursor-pointer border-b border-edge-soft text-[13px] transition-[background-color] duration-150 hover:bg-panel2 ${
-                          isActive ? "bg-panel2" : ""
-                        }`}
-                        onClick={() => {
-                          const url = new URL(window.location.href);
-                          if (isActive) {
-                            url.searchParams.delete("id");
-                          } else {
-                            url.searchParams.set("id", t.id);
-                          }
-                          window.history.pushState({}, "", url.toString());
-                          window.dispatchEvent(new PopStateEvent("popstate"));
-                        }}
-                      >
-                        <td className="px-3 py-2 font-medium text-fg">
-                          {t.title ?? <span className="text-fg-4">Untitled</span>}
-                        </td>
-                        <td className="num px-3 py-2 text-fg-2">{t.message_count}</td>
-                        <td className="num px-3 py-2 text-fg-2">{formatTokens(t.total_tokens)}</td>
-                        <td className="num px-3 py-2 text-fg-2">
-                          {formatCost(t.total_cost_microdollars)}
-                        </td>
-                        <td className="num px-3 py-2 text-fg-3">{formatDate(t.created_at)}</td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          </div>
+          <TracesTable
+            traces={traces}
+            loading={loading}
+            selectedId={selectedId}
+            onSelect={handleSelect}
+          />
 
           {hasMore && (
-            <div className="mt-3 flex justify-center">
+            <div className="mt-component flex justify-center">
               <Button variant="secondary" disabled={loadingMore} onClick={loadMore}>
                 {loadingMore ? "Loading..." : "Load more"}
               </Button>
             </div>
           )}
 
-          {/* Trace detail waterfall */}
-          {selectedId && (
-            <div className="mt-6">
-              <div className="mb-3 flex items-center gap-2">
-                <h2 className="text-[14px] font-semibold text-fg">Trace Detail</h2>
-                {detail && (
-                  <span className="font-mono text-[12px] text-fg-4">
-                    {detail.title ?? detail.id}
-                  </span>
-                )}
-              </div>
-
-              {loadingDetail && (
-                <div className="space-y-2">
-                  {DETAIL_SKEL.map((k) => (
-                    <div
-                      key={k}
-                      className="h-6 w-full animate-pulse rounded-[var(--radius)] bg-panel2"
-                    />
-                  ))}
-                </div>
-              )}
-
-              {!loadingDetail && detail && (
-                <div className="overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-panel">
-                  {/* Column headers */}
-                  <div className="flex items-center gap-2 border-b border-edge px-3 py-1.5">
-                    <ColLabel className="w-[40%]">Type</ColLabel>
-                    <span className="flex-1" />
-                    <ColLabel className="w-28">Timeline</ColLabel>
-                    <ColLabel className="w-12 text-right">Duration</ColLabel>
-                    <ColLabel className="w-14 text-right">Tokens</ColLabel>
-                    <ColLabel className="w-14 text-right">Cost</ColLabel>
-                  </div>
-                  {observations.length > 0 ? (
-                    observations.map((obs) => (
-                      <ObservationRow
-                        key={obs.id}
-                        obs={obs}
-                        depth={0}
-                        traceStart={traceStart}
-                        traceDuration={traceDuration}
-                      />
-                    ))
-                  ) : (
-                    <div className="py-6 text-center text-[13px] text-fg-4">
-                      No observations in this trace.
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-          )}
+          {selectedId && <TraceDetail detail={detail} loadingDetail={loadingDetail} />}
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary
- D4 unit of the dashboard redesign: conversations + traces (see #248, #247, #250, #249, #246, #251 for sibling units — following the same base-branch convention since `redesign/v2` was never pushed to the remote).
- `traces-page.tsx` had an inline duplicate `PageHeader` — replaced with the shared `components/dashboard/page-header` (import only, unmodified).
- Replaced the hand-rolled `<table>` waterfall/list markup with the canonical `Table`/`TableHeader`/`TableBody`/`TableRow`/`TableHead`/`TableCell`/`TableSkeleton` primitives wrapped in `Card`, matching the already-redesigned conversations table (unified row hover, pagination, badges).
- Split the 443-line `traces-page.tsx` into focused modules mirroring the `conversations/` pattern: `_traces-table.tsx`, `_trace-detail.tsx`, `_observation-row.tsx`, `_use-traces-data.ts`, `_trace-format.ts`.
- Reused shared `formatCostMicrodollars`/`formatDate` utilities from `@/lib` instead of duplicating local formatters (converges cost/date display with the rest of the dashboard).
- Conversations pages (`conversations.astro` + `components/dashboard/conversations/*`) required **no changes** — already fully compliant with the v2 token/primitive conventions (canonical tokens, `Table`/`Card`/`Badge` primitives, no hardcoded hex, no shadcn aliases).

## Scope
Touched only: `src/pages/dashboard/conversations.astro`, `src/pages/dashboard/traces.astro`, `src/components/dashboard/conversations/*`, `src/components/dashboard/traces/*`. No foundation-owned files (`styles/*`, `layouts/*`, `components/ui/*`, `app-shell.tsx`, `page-header.tsx`, `providers.tsx`, `theme-script.astro`, `reveal-script.astro`, `astro.config.mjs`, `package.json`) were modified.

## Test plan
- [x] `bunx biome check` on owned files — clean, zero errors
- [x] `bunx astro check` — zero errors in owned files (2 pre-existing unrelated errors remain in `brand.astro`, outside scope)
- [x] `PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_placeholder bun run build` — passes, both `/dashboard/conversations` and `/dashboard/traces` generate cleanly
- [x] `bun run dev` (isolated port) — both routes return 200, dev server log shows no runtime/hydration errors, all touched `.tsx`/`.ts` modules transform cleanly via Vite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a traces list with clickable rows, loading states, and an empty-state message.
  * Added a detailed trace timeline view with nested observations, visual timing bars, and summary metrics.
  * Improved trace values with cleaner duration, token, and cost formatting.

* **Bug Fixes**
  * Trace loading and detail fetching now handle stale requests more reliably when switching projects or selections.
  * Selection changes update the page state more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->