### PR TITLE
fix: address codebase-analysis findings across API, SDKs, MCP, and dashboard

### DIFF
--- a/packages/api/drizzle/0008_amusing_nightshade.sql
+++ b/packages/api/drizzle/0008_amusing_nightshade.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX `state_leases_active_unique_idx` ON `state_leases` (`project_id`,`state_key`) WHERE "state_leases"."released_at" IS NULL;

--- a/packages/api/drizzle/meta/0008_snapshot.json
+++ b/packages/api/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,2287 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b28b33af-3f81-41e3-8c2e-dc7ffa6910a4",
+  "prevId": "1f389746-8125-4ee4-800c-0f9f085d61d4",
+  "tables": {
+    "agent_states": {
+      "name": "agent_states",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "latest_sequence": {
+          "name": "latest_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_states_project_id_state_key_idx": {
+          "name": "agent_states_project_id_state_key_idx",
+          "columns": [
+            "project_id",
+            "state_key"
+          ],
+          "isUnique": true
+        },
+        "agent_states_project_id_agent_id_idx": {
+          "name": "agent_states_project_id_agent_id_idx",
+          "columns": [
+            "project_id",
+            "agent_id"
+          ],
+          "isUnique": false
+        },
+        "agent_states_project_id_updated_at_idx": {
+          "name": "agent_states_project_id_updated_at_idx",
+          "columns": [
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "agent_states_project_id_latest_sequence_idx": {
+          "name": "agent_states_project_id_latest_sequence_idx",
+          "columns": [
+            "project_id",
+            "latest_sequence"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_states_project_id_projects_id_fk": {
+          "name": "agent_states_project_id_projects_id_fk",
+          "tableFrom": "agent_states",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_idx": {
+          "name": "api_keys_key_hash_idx",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": false
+        },
+        "api_keys_project_id_idx": {
+          "name": "api_keys_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "capability_tokens": {
+      "name": "capability_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "capability_tokens_key_hash_idx": {
+          "name": "capability_tokens_key_hash_idx",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": false
+        },
+        "capability_tokens_project_id_idx": {
+          "name": "capability_tokens_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "capability_tokens_project_id_projects_id_fk": {
+          "name": "capability_tokens_project_id_projects_id_fk",
+          "tableFrom": "capability_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "claim_evidence": {
+      "name": "claim_evidence",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "json_path": {
+          "name": "json_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expected_value": {
+          "name": "expected_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "claim_evidence_project_id_claim_id_idx": {
+          "name": "claim_evidence_project_id_claim_id_idx",
+          "columns": [
+            "project_id",
+            "claim_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "claim_evidence_project_id_projects_id_fk": {
+          "name": "claim_evidence_project_id_projects_id_fk",
+          "tableFrom": "claim_evidence",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claim_evidence_claim_id_claims_id_fk": {
+          "name": "claim_evidence_claim_id_claims_id_fk",
+          "tableFrom": "claim_evidence",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "claim_verification_runs": {
+      "name": "claim_verification_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "claim_verification_runs_project_id_claim_id_idx": {
+          "name": "claim_verification_runs_project_id_claim_id_idx",
+          "columns": [
+            "project_id",
+            "claim_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "claim_verification_runs_project_id_projects_id_fk": {
+          "name": "claim_verification_runs_project_id_projects_id_fk",
+          "tableFrom": "claim_verification_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "claim_verification_runs_claim_id_claims_id_fk": {
+          "name": "claim_verification_runs_claim_id_claims_id_fk",
+          "tableFrom": "claim_verification_runs",
+          "tableTo": "claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "claims": {
+      "name": "claims",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "claims_project_id_created_at_idx": {
+          "name": "claims_project_id_created_at_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "claims_project_id_subject_idx": {
+          "name": "claims_project_id_subject_idx",
+          "columns": [
+            "project_id",
+            "subject_type",
+            "subject_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "claims_project_id_projects_id_fk": {
+          "name": "claims_project_id_projects_id_fk",
+          "tableFrom": "claims",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversation_tags": {
+      "name": "conversation_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "conversation_tags_conversation_id_tag_idx": {
+          "name": "conversation_tags_conversation_id_tag_idx",
+          "columns": [
+            "conversation_id",
+            "tag"
+          ],
+          "isUnique": true
+        },
+        "conversation_tags_tag_idx": {
+          "name": "conversation_tags_tag_idx",
+          "columns": [
+            "tag"
+          ],
+          "isUnique": false
+        },
+        "conversation_tags_tag_conversation_id_idx": {
+          "name": "conversation_tags_tag_conversation_id_idx",
+          "columns": [
+            "tag",
+            "conversation_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "conversation_tags_conversation_id_conversations_id_fk": {
+          "name": "conversation_tags_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_tags",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_microdollars": {
+          "name": "total_cost_microdollars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "conversations_project_id_idx": {
+          "name": "conversations_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "conversations_project_id_created_at_idx": {
+          "name": "conversations_project_id_created_at_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "conversations_project_id_external_id_idx": {
+          "name": "conversations_project_id_external_id_idx",
+          "columns": [
+            "project_id",
+            "external_id"
+          ],
+          "isUnique": false
+        },
+        "conversations_project_id_updated_at_idx": {
+          "name": "conversations_project_id_updated_at_idx",
+          "columns": [
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "conversations_project_id_external_id_unique_idx": {
+          "name": "conversations_project_id_external_id_unique_idx",
+          "columns": [
+            "project_id",
+            "external_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "conversations_project_id_projects_id_fk": {
+          "name": "conversations_project_id_projects_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_domains": {
+      "name": "custom_domains",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "custom_domains_domain_unique": {
+          "name": "custom_domains_domain_unique",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": true
+        },
+        "custom_domains_project_id_idx": {
+          "name": "custom_domains_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "custom_domains_verification_status_idx": {
+          "name": "custom_domains_verification_status_idx",
+          "columns": [
+            "verification_status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "custom_domains_project_id_projects_id_fk": {
+          "name": "custom_domains_project_id_projects_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "idempotency_keys": {
+      "name": "idempotency_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idempotency_keys_project_id_key_idx": {
+          "name": "idempotency_keys_project_id_key_idx",
+          "columns": [
+            "project_id",
+            "key"
+          ],
+          "isUnique": true
+        },
+        "idempotency_keys_project_id_created_at_idx": {
+          "name": "idempotency_keys_project_id_created_at_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "idempotency_keys_project_id_projects_id_fk": {
+          "name": "idempotency_keys_project_id_projects_id_fk",
+          "tableFrom": "idempotency_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_microdollars": {
+          "name": "cost_microdollars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "observation_type": {
+          "name": "observation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_idx": {
+          "name": "messages_conversation_id_idx",
+          "columns": [
+            "conversation_id"
+          ],
+          "isUnique": false
+        },
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            "conversation_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "messages_parent_message_id_idx": {
+          "name": "messages_parent_message_id_idx",
+          "columns": [
+            "parent_message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'S256'"
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_authorization_codes_code_hash_idx": {
+          "name": "oauth_authorization_codes_code_hash_idx",
+          "columns": [
+            "code_hash"
+          ],
+          "isUnique": true
+        },
+        "oauth_authorization_codes_expires_at_idx": {
+          "name": "oauth_authorization_codes_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_project_id_projects_id_fk": {
+          "name": "oauth_authorization_codes_project_id_projects_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_clients": {
+      "name": "oauth_clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"authorization_code\",\"refresh_token\"]'"
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_clients_created_at_idx": {
+          "name": "oauth_clients_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token_id": {
+          "name": "access_token_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_token_hash_idx": {
+          "name": "oauth_refresh_tokens_token_hash_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "oauth_refresh_tokens_client_id_idx": {
+          "name": "oauth_refresh_tokens_client_id_idx",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_project_id_projects_id_fk": {
+          "name": "oauth_refresh_tokens_project_id_projects_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_clerk_org_id_unique": {
+          "name": "organizations_clerk_org_id_unique",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_org_id_slug_idx": {
+          "name": "projects_org_id_slug_idx",
+          "columns": [
+            "org_id",
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "projects_org_id_organizations_id_fk": {
+          "name": "projects_org_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "projects_retention_days_range_check": {
+          "name": "projects_retention_days_range_check",
+          "value": "\"projects\".\"retention_days\" IS NULL OR (\"projects\".\"retention_days\" BETWEEN 1 AND 3650)"
+        }
+      }
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_key_window_idx": {
+          "name": "rate_limits_key_window_idx",
+          "columns": [
+            "api_key_hash",
+            "window_start"
+          ],
+          "isUnique": true
+        },
+        "rate_limits_window_start_idx": {
+          "name": "rate_limits_window_start_idx",
+          "columns": [
+            "window_start"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "state_events": {
+      "name": "state_events",
+      "columns": {
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "state_events_id_idx": {
+          "name": "state_events_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "state_events_project_id_sequence_idx": {
+          "name": "state_events_project_id_sequence_idx",
+          "columns": [
+            "project_id",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "state_events_project_id_state_key_idx": {
+          "name": "state_events_project_id_state_key_idx",
+          "columns": [
+            "project_id",
+            "state_key"
+          ],
+          "isUnique": false
+        },
+        "state_events_project_id_created_at_idx": {
+          "name": "state_events_project_id_created_at_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "state_events_project_id_projects_id_fk": {
+          "name": "state_events_project_id_projects_id_fk",
+          "tableFrom": "state_events",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "state_leases": {
+      "name": "state_leases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "holder": {
+          "name": "holder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "renewed_at": {
+          "name": "renewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "state_leases_project_id_state_key_idx": {
+          "name": "state_leases_project_id_state_key_idx",
+          "columns": [
+            "project_id",
+            "state_key"
+          ],
+          "isUnique": false
+        },
+        "state_leases_project_id_expires_at_idx": {
+          "name": "state_leases_project_id_expires_at_idx",
+          "columns": [
+            "project_id",
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "state_leases_active_unique_idx": {
+          "name": "state_leases_active_unique_idx",
+          "columns": [
+            "project_id",
+            "state_key"
+          ],
+          "isUnique": true,
+          "where": "\"state_leases\".\"released_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "state_leases_project_id_projects_id_fk": {
+          "name": "state_leases_project_id_projects_id_fk",
+          "tableFrom": "state_leases",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "state_snapshots": {
+      "name": "state_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "state_snapshots_project_id_state_key_sequence_idx": {
+          "name": "state_snapshots_project_id_state_key_sequence_idx",
+          "columns": [
+            "project_id",
+            "state_key",
+            "sequence"
+          ],
+          "isUnique": true
+        },
+        "state_snapshots_project_id_sequence_idx": {
+          "name": "state_snapshots_project_id_sequence_idx",
+          "columns": [
+            "project_id",
+            "sequence"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "state_snapshots_project_id_projects_id_fk": {
+          "name": "state_snapshots_project_id_projects_id_fk",
+          "tableFrom": "state_snapshots",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "state_tags": {
+      "name": "state_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "state_tags_project_id_state_key_tag_idx": {
+          "name": "state_tags_project_id_state_key_tag_idx",
+          "columns": [
+            "project_id",
+            "state_key",
+            "tag"
+          ],
+          "isUnique": true
+        },
+        "state_tags_project_id_tag_idx": {
+          "name": "state_tags_project_id_tag_idx",
+          "columns": [
+            "project_id",
+            "tag"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "state_tags_project_id_projects_id_fk": {
+          "name": "state_tags_project_id_projects_id_fk",
+          "tableFrom": "state_tags",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhooks": {
+      "name": "webhooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhooks_project_id_idx": {
+          "name": "webhooks_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "webhooks_project_id_active_idx": {
+          "name": "webhooks_project_id_active_idx",
+          "columns": [
+            "project_id",
+            "active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webhooks_project_id_projects_id_fk": {
+          "name": "webhooks_project_id_projects_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1781779218292,
       "tag": "0007_whole_meggan",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1782995518760,
+      "tag": "0008_amusing_nightshade",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -468,6 +468,12 @@ export const stateLeases = sqliteTable(
   (table) => [
     index("state_leases_project_id_state_key_idx").on(table.projectId, table.stateKey),
     index("state_leases_project_id_expires_at_idx").on(table.projectId, table.expiresAt),
+    // At most one *active* (not-yet-released) lease per (project, state_key).
+    // Makes lease acquisition atomic: a concurrent second acquire hits this
+    // unique constraint and is rejected instead of racing a check-then-insert.
+    uniqueIndex("state_leases_active_unique_idx")
+      .on(table.projectId, table.stateKey)
+      .where(sql`${table.releasedAt} IS NULL`),
   ],
 );
 

--- a/packages/api/src/lib/clerk-session.ts
+++ b/packages/api/src/lib/clerk-session.ts
@@ -33,7 +33,11 @@ export interface VerifiedSession {
  * Verify a Clerk session token and return the verified claims.
  *
  * Returns the user id (`sub`) and active org id (`o_id`, falling back to
- * `org_id`, then to the default org). Throws on any verification failure so
+ * `org_id`). When the session has NO active Clerk organization, the org id is
+ * derived per-user as `personal:${clerkUserId}` so that each personal account
+ * maps to its OWN internal organization. This avoids collapsing every org-less
+ * user into a single shared sentinel org (which would allow cross-tenant reads
+ * between unrelated personal accounts). Throws on any verification failure so
  * callers can translate to a single 401.
  *
  * This is a thin seam over `@clerk/backend`'s `verifyToken`, extracted so it
@@ -68,6 +72,7 @@ export async function verifyDashboardSession(
 
   return {
     clerkUserId,
-    orgId: claims.o_id ?? claims.org_id ?? "default",
+    // Per-user discriminator when no active Clerk org — never a shared default.
+    orgId: claims.o_id ?? claims.org_id ?? `personal:${clerkUserId}`,
   };
 }

--- a/packages/api/src/lib/url-safety.ts
+++ b/packages/api/src/lib/url-safety.ts
@@ -39,6 +39,7 @@ function isBlockedIPv4(octets: [number, number, number, number]): boolean {
   if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 private
   if (a === 192 && b === 168) return true; // 192.168.0.0/16 private
   if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local (+ metadata)
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT (RFC 6598)
   return false;
 }
 
@@ -60,9 +61,10 @@ function isBlockedIPv6(host: string): boolean {
 
   const firstHextet = h.split(":")[0];
   if (firstHextet.length > 0) {
-    // fc00::/7 → first byte 0xfc or 0xfd; fe80::/10 → fe80..febf.
+    // fc00::/7 → first byte 0xfc or 0xfd; fe80::/10 link-local (fe80..febf) and
+    // fec0::/10 site-local (fec0..feff) together span fe80..feff → /^fe[8-f]/.
     if (firstHextet.startsWith("fc") || firstHextet.startsWith("fd")) return true;
-    if (/^fe[89ab]/.test(firstHextet)) return true;
+    if (/^fe[8-f]/.test(firstHextet)) return true;
   }
   return false;
 }

--- a/packages/api/src/lib/url-safety.ts
+++ b/packages/api/src/lib/url-safety.ts
@@ -1,0 +1,100 @@
+// ---------------------------------------------------------------------------
+// URL safety — SSRF guards for user-supplied outbound URLs (webhooks)
+// ---------------------------------------------------------------------------
+//
+// Webhook URLs are user-controlled and are fetched server-side, so they are a
+// classic SSRF vector. We enforce two rules, both at registration time and
+// again immediately before delivery (defense in depth):
+//
+//   1. The scheme MUST be https.
+//   2. The host MUST NOT be a loopback / private / link-local / cloud-metadata
+//      address, nor "localhost".
+//
+// This is a *literal-address* check: it blocks URLs whose host is already an
+// IP in a blocked range (or localhost). It cannot stop a public hostname that
+// resolves (or is rebound) to a private IP — that requires resolve-then-pin at
+// fetch time, which the Workers runtime does not expose. Blocking the literal
+// ranges removes the trivial exploit paths (127.0.0.1, 169.254.169.254, etc.).
+
+/** Parse a dotted-quad IPv4 literal into its four octets, or null if not IPv4. */
+function parseIPv4(host: string): [number, number, number, number] | null {
+  const parts = host.split(".");
+  if (parts.length !== 4) return null;
+  const octets: number[] = [];
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const n = Number(part);
+    if (n < 0 || n > 255) return null;
+    octets.push(n);
+  }
+  return octets as [number, number, number, number];
+}
+
+/** Is an IPv4 literal in a loopback / private / link-local / unspecified range? */
+function isBlockedIPv4(octets: [number, number, number, number]): boolean {
+  const [a, b] = octets;
+  if (a === 0) return true; // 0.0.0.0/8 (includes unspecified)
+  if (a === 127) return true; // 127.0.0.0/8 loopback
+  if (a === 10) return true; // 10.0.0.0/8 private
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 private
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16 private
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local (+ metadata)
+  return false;
+}
+
+/**
+ * Is an IPv6 host (as URL.hostname returns it — no brackets) in a blocked
+ * range: ::1 loopback, :: unspecified, fc00::/7 unique-local, fe80::/10
+ * link-local, or an IPv4-mapped address whose embedded v4 is blocked.
+ */
+function isBlockedIPv6(host: string): boolean {
+  const h = host.toLowerCase();
+  if (h === "::1" || h === "::") return true;
+
+  // IPv4-mapped / -translated (e.g. ::ffff:127.0.0.1) — inspect the embedded v4.
+  const mapped = h.match(/:((?:\d{1,3}\.){3}\d{1,3})$/);
+  if (mapped) {
+    const v4 = parseIPv4(mapped[1]);
+    if (v4 && isBlockedIPv4(v4)) return true;
+  }
+
+  const firstHextet = h.split(":")[0];
+  if (firstHextet.length > 0) {
+    // fc00::/7 → first byte 0xfc or 0xfd; fe80::/10 → fe80..febf.
+    if (firstHextet.startsWith("fc") || firstHextet.startsWith("fd")) return true;
+    if (/^fe[89ab]/.test(firstHextet)) return true;
+  }
+  return false;
+}
+
+/** Is `hostname` a blocked host (localhost or a private/loopback/link-local IP)? */
+export function isBlockedWebhookHost(hostname: string): boolean {
+  let host = hostname.toLowerCase().trim();
+  if (host.length === 0) return true;
+  // URL.hostname keeps IPv6 without brackets, but be defensive.
+  if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1);
+
+  if (host === "localhost" || host.endsWith(".localhost")) return true;
+
+  const v4 = parseIPv4(host);
+  if (v4) return isBlockedIPv4(v4);
+
+  if (host.includes(":")) return isBlockedIPv6(host);
+
+  return false;
+}
+
+/**
+ * Is `raw` a webhook URL that is safe to register and deliver to?
+ * Requires an https URL whose host is not blocked (see {@link isBlockedWebhookHost}).
+ */
+export function isSafeWebhookUrl(raw: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "https:") return false;
+  return !isBlockedWebhookHost(url.hostname);
+}

--- a/packages/api/src/lib/validation.ts
+++ b/packages/api/src/lib/validation.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { GrantableScopeSchema } from "./scopes";
+import { isSafeWebhookUrl } from "./url-safety";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -160,14 +161,26 @@ export type UpdateProjectInput = z.infer<typeof UpdateProjectSchema>;
 export const WEBHOOK_EVENT_TYPES = ["conversation.created"] as const;
 export const WebhookEventSchema = z.enum(WEBHOOK_EVENT_TYPES);
 
+/**
+ * A webhook URL must be https and must not point at a loopback / private /
+ * link-local / metadata host (SSRF guard). See lib/url-safety.ts.
+ */
+const WebhookUrlSchema = z
+  .string()
+  .url("Invalid webhook URL")
+  .refine(isSafeWebhookUrl, {
+    message:
+      "Webhook URL must be https and must not target a private, loopback, link-local, or metadata host",
+  });
+
 export const CreateWebhookSchema = z.object({
-  url: z.string().url("Invalid webhook URL"),
+  url: WebhookUrlSchema,
   events: z.array(WebhookEventSchema).min(1, "At least one event is required").max(10),
 });
 export type CreateWebhookInput = z.infer<typeof CreateWebhookSchema>;
 
 export const UpdateWebhookSchema = z.object({
-  url: z.string().url("Invalid webhook URL").optional(),
+  url: WebhookUrlSchema.optional(),
   events: z.array(WebhookEventSchema).min(1).max(10).optional(),
   active: z.boolean().optional(),
 });

--- a/packages/api/src/lib/webhook.ts
+++ b/packages/api/src/lib/webhook.ts
@@ -1,4 +1,5 @@
 import type { SQL } from "drizzle-orm";
+import { isSafeWebhookUrl } from "./url-safety";
 
 /**
  * Valid webhook event types.
@@ -59,6 +60,20 @@ export async function sendWebhookWithRetry(
   secret: string,
   payload: string,
 ): Promise<WebhookDeliveryResult> {
+  // Re-check the URL immediately before delivery (defense in depth): the stored
+  // URL passed validation at registration, but re-validating here guards against
+  // stale rows written before the SSRF guard existed and keeps delivery from
+  // ever hitting a private/loopback/metadata host or a non-https scheme.
+  if (!isSafeWebhookUrl(url)) {
+    return {
+      webhookId: "",
+      url,
+      success: false,
+      error: "Webhook URL blocked: must be https and not a private/loopback/metadata host",
+      attempts: 0,
+    };
+  }
+
   const signature = await signWebhookPayload(secret, payload);
   const maxAttempts = 3;
   const delays = [1000, 2000, 4000]; // Exponential backoff: 1s, 2s, 4s

--- a/packages/api/src/middleware/rate-limit.ts
+++ b/packages/api/src/middleware/rate-limit.ts
@@ -30,11 +30,21 @@ interface SlidingWindowState {
 }
 
 // ---------------------------------------------------------------------------
-// Sliding Window Rate Limiter (Workers KV)
+// Sliding Window Rate Limiter (Workers KV) — OPT-IN, best-effort only
 // ---------------------------------------------------------------------------
 // Algorithm: Track individual request timestamps in a rolling window.
 // Count requests where timestamp > (now - window_size).
 // Prevents the fixed-window boundary bypass (2× burst at window transitions).
+//
+// ⚠️ NON-ATOMIC: this is a read-modify-write against KV with no compare-and-swap,
+// so concurrent requests can read the same state and each write back a count
+// that omits the others — under burst concurrency the effective limit can be
+// exceeded (the limiter is bypassable). KV is also only eventually consistent.
+// It is therefore gated behind the USE_SLIDING_WINDOW flag and is NOT the
+// default. The default path is the D1 fixed-window limiter below, whose
+// increment is a single atomic UPDATE ... RETURNING (or an ON CONFLICT upsert),
+// so it cannot be raced. Prefer a Durable Object or the Cloudflare Rate
+// Limiting binding for a limiter that is both atomic AND sliding.
 //
 // Fallback: Falls back to D1 fixed-window if KV is not configured.
 // ---------------------------------------------------------------------------

--- a/packages/api/src/routes/analytics-public.ts
+++ b/packages/api/src/routes/analytics-public.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { parseLimitParam } from "../lib/helpers";
 import { apiKeyAuth } from "../middleware/auth";
 import { rateLimitMiddleware } from "../middleware/rate-limit";
+import { requireScope } from "../middleware/require-scope";
 import { handleSummary, handleTags, handleTimeseries } from "../services/public-analytics";
 import type { Bindings, Variables } from "../types";
 
@@ -17,6 +18,9 @@ const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
 app.use("*", apiKeyAuth);
 app.use("*", rateLimitMiddleware);
+// Public analytics expose aggregate project data — require an explicit read scope
+// so a narrowly-scoped key (e.g. state:write only) cannot read analytics.
+app.use("*", requireScope("analytics:read"));
 
 // ---------------------------------------------------------------------------
 // GET /summary

--- a/packages/api/src/routes/conversations/crud.ts
+++ b/packages/api/src/routes/conversations/crud.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { asc, eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { messages } from "../../db/schema";
 import {
@@ -18,6 +18,13 @@ import * as ConversationService from "../../services/conversations";
 import type { Bindings, Variables } from "../../types";
 
 const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+/**
+ * Upper bound on messages returned inline with a single conversation. Prevents
+ * an unbounded load (and unordered result) for very large conversations while
+ * keeping the response shape unchanged for the common case.
+ */
+const MAX_INLINE_MESSAGES = 1000;
 
 // ---------------------------------------------------------------------------
 // POST / — Create conversation
@@ -135,7 +142,14 @@ router.get("/:id", requireScope("conversations:read"), async (c) => {
   // Only fetch messages if requested
   const shouldIncludeMessages = !fields || fields.includes("messages");
   const msgs = shouldIncludeMessages
-    ? await db.select().from(messages).where(eq(messages.conversationId, id))
+    ? await db
+        .select()
+        .from(messages)
+        .where(eq(messages.conversationId, id))
+        // Deterministic order (created_at, then rowid to break ties on identical
+        // timestamps) and a bound so a huge conversation can't load unboundedly.
+        .orderBy(asc(messages.createdAt), asc(sql`rowid`))
+        .limit(MAX_INLINE_MESSAGES)
     : [];
 
   const response = {

--- a/packages/api/src/routes/conversations/search.ts
+++ b/packages/api/src/routes/conversations/search.ts
@@ -31,9 +31,12 @@ router.get("/search", requireScope("conversations:read"), async (c) => {
 
   const cursor = c.req.query("cursor");
 
-  // Validate cursor if provided (must be a valid Unix timestamp in milliseconds)
+  // Validate cursor if provided. Composite format "<updatedAt>.<id>" (tie-break
+  // by id); a bare "<updatedAt>" timestamp is still accepted for back-compat.
   if (cursor !== undefined) {
-    const cursorNum = Number(cursor);
+    const dot = cursor.lastIndexOf(".");
+    const tsStr = dot === -1 ? cursor : cursor.slice(0, dot);
+    const cursorNum = Number(tsStr);
     if (
       Number.isNaN(cursorNum) ||
       !Number.isFinite(cursorNum) ||

--- a/packages/api/src/routes/oauth/index.ts
+++ b/packages/api/src/routes/oauth/index.ts
@@ -4,7 +4,9 @@ import { organizations, projects } from "../../db/schema";
 import { type AppContext, errorResponse } from "../../lib/helpers";
 import { isGrantableScope, WILDCARD_SCOPE } from "../../lib/scopes";
 import { clerkDashboardAuth } from "../../middleware/clerk-dashboard-auth";
+import { projectCreationRateLimit } from "../../middleware/project-creation-rate-limit";
 import {
+  authenticateClient,
   createAuthorizationCode,
   exchangeAuthorizationCode,
   getClient,
@@ -42,6 +44,37 @@ function oauthError(c: AppContext, error: string, description: string, status: 4
 }
 
 /**
+ * Extract client credentials from the token request. Supports both
+ * `client_secret_basic` (HTTP Basic auth header) and `client_secret_post`
+ * (credentials in the request body). The Basic header, when present, takes
+ * precedence for the client id (RFC 6749 §2.3.1).
+ */
+function extractClientCredentials(
+  c: AppContext,
+  body: Record<string, string>,
+): { clientId: string; clientSecret: string | undefined } {
+  const authHeader = c.req.header("Authorization") ?? "";
+  if (authHeader.startsWith("Basic ")) {
+    try {
+      const decoded = atob(authHeader.slice(6).trim());
+      const sep = decoded.indexOf(":");
+      if (sep !== -1) {
+        // credentials are form-urlencoded per RFC 6749 §2.3.1.
+        const id = decodeURIComponent(decoded.slice(0, sep));
+        const secret = decodeURIComponent(decoded.slice(sep + 1));
+        return { clientId: id || body.client_id || "", clientSecret: secret };
+      }
+    } catch {
+      // Malformed Basic header — fall through to body credentials.
+    }
+  }
+  return {
+    clientId: body.client_id ?? "",
+    clientSecret: typeof body.client_secret === "string" ? body.client_secret : undefined,
+  };
+}
+
+/**
  * Parse a token-endpoint body that may be form-encoded or JSON.
  * Returns a flat record of string values.
  */
@@ -70,7 +103,10 @@ async function parseTokenBody(c: AppContext): Promise<Record<string, string>> {
 // POST /api/oauth/register — Dynamic Client Registration (RFC 7591, public)
 // ---------------------------------------------------------------------------
 
-app.post("/register", async (c) => {
+// Dynamic Client Registration is unauthenticated, so throttle it per-IP with
+// the same fixed-window limiter used for project creation to blunt automated
+// client-spam / resource exhaustion.
+app.post("/register", projectCreationRateLimit, async (c) => {
   const body = await c.req.json().catch(() => null);
   if (!body || typeof body !== "object") {
     return errorResponse(c, "BAD_REQUEST", "Invalid JSON body", 400);
@@ -285,10 +321,12 @@ app.post("/token", async (c) => {
   const body = await parseTokenBody(c);
   const grantType = body.grant_type;
   const db = c.get("db");
+  const { clientId: authClientId, clientSecret } = extractClientCredentials(c, body);
 
   try {
     if (grantType === "authorization_code") {
-      const { code, code_verifier, client_id, redirect_uri } = body;
+      const { code, code_verifier, redirect_uri } = body;
+      const client_id = authClientId || body.client_id;
       if (!code || !code_verifier || !client_id || !redirect_uri) {
         return oauthError(
           c,
@@ -296,6 +334,9 @@ app.post("/token", async (c) => {
           "code, code_verifier, client_id and redirect_uri are required",
         );
       }
+      // Confidential clients must prove possession of their client_secret;
+      // public (PKCE, auth method "none") clients pass through unchanged.
+      await authenticateClient(db, client_id, clientSecret);
       const tokens = await exchangeAuthorizationCode(db, {
         code,
         codeVerifier: code_verifier,
@@ -306,10 +347,12 @@ app.post("/token", async (c) => {
     }
 
     if (grantType === "refresh_token") {
-      const { refresh_token, client_id } = body;
+      const { refresh_token } = body;
+      const client_id = authClientId || body.client_id;
       if (!refresh_token || !client_id) {
         return oauthError(c, "invalid_request", "refresh_token and client_id are required");
       }
+      await authenticateClient(db, client_id, clientSecret);
       const tokens = await refreshAccessToken(db, {
         refreshToken: refresh_token,
         clientId: client_id,

--- a/packages/api/src/routes/projects.ts
+++ b/packages/api/src/routes/projects.ts
@@ -82,9 +82,10 @@ app.post("/", projectCreationRateLimit, async (c) => {
   }
 
   // org_id is taken from the verified Clerk session, NOT the request body.
+  // The auth middleware always sets a non-empty per-org (or per-user) value.
   const name = parsed.data.name;
   const slug = parsed.data.slug;
-  const sessionOrgId = c.get("orgId") ?? "default";
+  const sessionOrgId = c.get("orgId");
 
   try {
     const result = await createProject(db, name, slug, sessionOrgId);

--- a/packages/api/src/services/claims.ts
+++ b/packages/api/src/services/claims.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, lt } from "drizzle-orm";
+import { and, asc, desc, eq, gt, lt, or } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { claimEvidence, claims, claimVerificationRuns, stateEvents } from "../db/schema";
 import { generateId } from "../lib/id";
@@ -91,7 +91,11 @@ export function validateClaimCursor(
     return { valid: true };
   }
 
-  const cursorNum = Number(cursorParam);
+  // Composite cursor "<createdAt>.<id>" (tie-break by id); a bare "<createdAt>"
+  // timestamp is still accepted for backward compatibility.
+  const dot = cursorParam.lastIndexOf(".");
+  const tsStr = dot === -1 ? cursorParam : cursorParam.slice(0, dot);
+  const cursorNum = Number(tsStr);
   if (
     Number.isNaN(cursorNum) ||
     !Number.isFinite(cursorNum) ||
@@ -167,11 +171,28 @@ export async function listClaims(
   const conditions = [eq(claims.projectId, projectId)];
 
   if (options.cursor) {
-    const cursorTs = parseInt(options.cursor, 10);
+    // Composite cursor "<createdAt>.<id>" (tie-break by id) so claims sharing a
+    // created_at timestamp are neither skipped nor duplicated across pages.
+    const dot = options.cursor.lastIndexOf(".");
+    const tsStr = dot === -1 ? options.cursor : options.cursor.slice(0, dot);
+    const cursorId = dot === -1 ? undefined : options.cursor.slice(dot + 1);
+    const cursorTs = parseInt(tsStr, 10);
     if (!Number.isNaN(cursorTs)) {
-      conditions.push(
-        options.order === "desc" ? lt(claims.createdAt, cursorTs) : gt(claims.createdAt, cursorTs),
-      );
+      const cursorCond =
+        options.order === "desc"
+          ? cursorId !== undefined
+            ? or(
+                lt(claims.createdAt, cursorTs),
+                and(eq(claims.createdAt, cursorTs), lt(claims.id, cursorId)),
+              )
+            : lt(claims.createdAt, cursorTs)
+          : cursorId !== undefined
+            ? or(
+                gt(claims.createdAt, cursorTs),
+                and(eq(claims.createdAt, cursorTs), gt(claims.id, cursorId)),
+              )
+            : gt(claims.createdAt, cursorTs);
+      if (cursorCond) conditions.push(cursorCond);
     }
   }
 
@@ -183,16 +204,22 @@ export async function listClaims(
     conditions.push(eq(claims.subjectId, options.subjectId));
   }
 
+  const ordering =
+    options.order === "desc"
+      ? [desc(claims.createdAt), desc(claims.id)]
+      : [asc(claims.createdAt), asc(claims.id)];
+
   const rows = await db
     .select()
     .from(claims)
     .where(and(...conditions))
-    .orderBy(options.order === "desc" ? desc(claims.createdAt) : asc(claims.createdAt))
+    .orderBy(...ordering)
     .limit(options.limit);
 
+  const last = rows[rows.length - 1];
   return {
     rows: rows.map(mapClaimRow),
-    nextCursor: rows.length === options.limit ? String(rows[rows.length - 1].createdAt) : null,
+    nextCursor: rows.length === options.limit && last ? `${last.createdAt}.${last.id}` : null,
   };
 }
 

--- a/packages/api/src/services/conversation-search.ts
+++ b/packages/api/src/services/conversation-search.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, like, lt, sql } from "drizzle-orm";
+import { and, desc, eq, lt, or, sql } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { conversations, messages } from "../db/schema";
 
@@ -83,15 +83,26 @@ export function validateLimit(raw: string | undefined): number {
 }
 
 /**
- * Validate cursor parameter if provided.
- * @throws {Error} if cursor is not a valid Unix timestamp
+ * Parse and validate a search cursor.
+ *
+ * Composite format `"<updatedAt>.<id>"` (tie-break by conversation id) so rows
+ * that share an `updated_at` timestamp are neither skipped nor duplicated across
+ * pages. A bare `"<updatedAt>"` is still accepted for backward compatibility.
+ *
+ * @throws {Error} if the timestamp portion is not a valid Unix timestamp.
  */
-export function validateCursor(raw: string | undefined): string | undefined {
+export function validateCursor(
+  raw: string | undefined,
+): { cursorTs: number; cursorId: string | undefined } | undefined {
   if (raw === undefined) {
     return undefined;
   }
 
-  const cursorNum = Number(raw);
+  const dot = raw.lastIndexOf(".");
+  const tsStr = dot === -1 ? raw : raw.slice(0, dot);
+  const idStr = dot === -1 ? undefined : raw.slice(dot + 1);
+
+  const cursorNum = Number(tsStr);
   if (
     Number.isNaN(cursorNum) ||
     !Number.isFinite(cursorNum) ||
@@ -101,7 +112,7 @@ export function validateCursor(raw: string | undefined): string | undefined {
     throw new Error("Cursor must be a valid positive number (Unix timestamp in milliseconds)");
   }
 
-  return raw;
+  return { cursorTs: cursorNum, cursorId: idStr };
 }
 
 // ---------------------------------------------------------------------------
@@ -110,17 +121,18 @@ export function validateCursor(raw: string | undefined): string | undefined {
 
 /**
  * Escape SQL LIKE wildcard characters to prevent injection.
- * Must escape backslash first, then the special characters.
+ * Must escape backslash first, then the special characters. The escaped pattern
+ * MUST be used with an explicit `ESCAPE '\'` clause (see {@link buildSearchConditions}).
+ *
+ * Note: SQLite's `LIKE` only treats `%` and `_` as wildcards — `[` is a literal
+ * character (unlike SQL Server), so it must NOT be escaped or searches for `[`
+ * would silently fail to match.
  *
  * @param input - User input to escape
- * @returns Escaped string safe for use in LIKE patterns
+ * @returns Escaped string safe for use in LIKE patterns with `ESCAPE '\'`
  */
 export function escapeLikePattern(input: string): string {
-  return input
-    .replace(/\\/g, "\\\\")
-    .replace(/%/g, "\\%")
-    .replace(/_/g, "\\_")
-    .replace(/\[/g, "\\[");
+  return input.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
 }
 
 /**
@@ -159,14 +171,26 @@ export function buildSearchConditions(
   projectId: string,
   escapedQuery: string,
   cursorTs: number | undefined,
+  cursorId?: string,
 ): ReturnType<typeof and>[] {
   const conditions: ReturnType<typeof and>[] = [
     eq(conversations.projectId, projectId),
-    like(messages.content, `%${escapedQuery}%`),
+    // Explicit ESCAPE so the backslash-escaped wildcards above are treated as
+    // literals (e.g. searching for "100%" matches only the literal string).
+    sql`${messages.content} LIKE ${`%${escapedQuery}%`} ESCAPE '\\'`,
   ];
 
   if (cursorTs !== undefined) {
-    conditions.push(lt(conversations.updatedAt, cursorTs));
+    // Composite (updated_at, id) comparison mirroring listConversations so rows
+    // sharing the cursor's timestamp are paginated deterministically.
+    conditions.push(
+      cursorId !== undefined
+        ? or(
+            lt(conversations.updatedAt, cursorTs),
+            and(eq(conversations.updatedAt, cursorTs), lt(conversations.id, cursorId)),
+          )
+        : lt(conversations.updatedAt, cursorTs),
+    );
   }
 
   return conditions;
@@ -182,8 +206,9 @@ export async function executeSearch(
   escapedQuery: string,
   limit: number,
   cursorTs: number | undefined,
+  cursorId?: string,
 ): Promise<SearchRow[]> {
-  const conditions = buildSearchConditions(projectId, escapedQuery, cursorTs);
+  const conditions = buildSearchConditions(projectId, escapedQuery, cursorTs, cursorId);
 
   return (
     db
@@ -202,7 +227,8 @@ export async function executeSearch(
       .innerJoin(messages, eq(messages.conversationId, conversations.id))
       .where(and(...conditions))
       .groupBy(conversations.id)
-      .orderBy(desc(conversations.updatedAt))
+      // Composite ordering (updated_at, id) to match the composite cursor.
+      .orderBy(desc(conversations.updatedAt), desc(conversations.id))
       // Fetch one extra row to determine if a next page exists.
       .limit(limit + 1)
   );
@@ -224,7 +250,8 @@ export function buildSearchResult(
   const hasNextPage = rows.length > limit;
   const pageRows = hasNextPage ? rows.slice(0, limit) : rows;
 
-  const nextCursor = hasNextPage ? String(pageRows[pageRows.length - 1].updatedAt) : null;
+  const last = pageRows[pageRows.length - 1];
+  const nextCursor = hasNextPage && last ? `${last.updatedAt}.${last.id}` : null;
 
   const data = pageRows.map((row) => ({
     id: row.id,
@@ -267,11 +294,15 @@ export async function searchConversations(
   // Escape query for safe LIKE pattern matching
   const escapedQuery = escapeLikePattern(query);
 
-  // Parse cursor timestamp
-  const cursorTs = cursor !== undefined ? parseInt(cursor, 10) : undefined;
-
-  // Execute search
-  const rows = await executeSearch(db, projectId, escapedQuery, limit, cursorTs);
+  // Execute search (composite cursor: updated_at + id)
+  const rows = await executeSearch(
+    db,
+    projectId,
+    escapedQuery,
+    limit,
+    cursor?.cursorTs,
+    cursor?.cursorId,
+  );
 
   // Build response
   return buildSearchResult(rows, limit, escapedQuery);

--- a/packages/api/src/services/leases.ts
+++ b/packages/api/src/services/leases.ts
@@ -1,8 +1,26 @@
-import { and, desc, eq, gt, isNull } from "drizzle-orm";
+import { and, desc, eq, isNull, lte } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { stateLeases } from "../db/schema";
 import { LEASE_DEFAULT_TTL_MS } from "../lib/config";
 import { generateId } from "../lib/id";
+
+/**
+ * True if a DB error is a SQLite/D1 UNIQUE constraint violation. Used to turn
+ * the atomic active-lease uniqueness collision into a clean LEASE_CONFLICT.
+ *
+ * Drizzle wraps driver errors in a generic `Failed query: …` Error and attaches
+ * the original (whose message carries "UNIQUE constraint failed") as `.cause`,
+ * so the whole cause chain is inspected.
+ */
+function isUniqueViolation(err: unknown): boolean {
+  let current: unknown = err;
+  for (let depth = 0; current != null && depth < 5; depth++) {
+    const message = current instanceof Error ? current.message : String(current);
+    if (/unique constraint failed/i.test(message)) return true;
+    current = current instanceof Error ? current.cause : undefined;
+  }
+  return false;
+}
 
 export interface LeaseResponse {
   id: string;
@@ -40,30 +58,26 @@ export async function createLease(
   ttlMs = LEASE_DEFAULT_TTL_MS,
 ): Promise<{ lease?: LeaseResponse; error?: LeaseError }> {
   const now = Date.now();
-  const [active] = await db
-    .select()
-    .from(stateLeases)
+
+  // Release any expired-but-not-released lease so a fresh lease can be acquired.
+  // Live (unexpired) leases keep their `released_at IS NULL` row, which the
+  // partial unique index below uses to reject a concurrent acquire.
+  await db
+    .update(stateLeases)
+    .set({ releasedAt: now })
     .where(
       and(
         eq(stateLeases.projectId, projectId),
         eq(stateLeases.stateKey, stateKey),
         isNull(stateLeases.releasedAt),
-        gt(stateLeases.expiresAt, now),
+        lte(stateLeases.expiresAt, now),
       ),
-    )
-    .orderBy(desc(stateLeases.fencingToken))
-    .limit(1);
+    );
 
-  if (active) {
-    return {
-      error: {
-        code: "LEASE_CONFLICT",
-        message: "State already has an active lease",
-        status: 409,
-      },
-    };
-  }
-
+  // Next fencing token is monotonic across ALL leases for this key (released or
+  // not). The read is safe under contention because the INSERT below is the
+  // real arbiter: two racers compute the same token, but the partial unique
+  // index (project_id, state_key) WHERE released_at IS NULL lets only one win.
   const [lastLease] = await db
     .select({ fencingToken: stateLeases.fencingToken })
     .from(stateLeases)
@@ -83,7 +97,23 @@ export async function createLease(
     releasedAt: null,
   };
 
-  await db.insert(stateLeases).values(row);
+  try {
+    await db.insert(stateLeases).values(row);
+  } catch (err) {
+    // A live active lease already exists for this (project, state_key) — the
+    // partial unique index rejected the insert. Report the contention.
+    if (isUniqueViolation(err)) {
+      return {
+        error: {
+          code: "LEASE_CONFLICT",
+          message: "State already has an active lease",
+          status: 409,
+        },
+      };
+    }
+    throw err;
+  }
+
   return { lease: toResponse(row) };
 }
 

--- a/packages/api/src/services/oauth.ts
+++ b/packages/api/src/services/oauth.ts
@@ -105,6 +105,55 @@ export async function getClient(
   return client ?? null;
 }
 
+/** Constant-time comparison of two equal-length hex strings. */
+function timingSafeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+/**
+ * Authenticate the client at the token endpoint (client_secret verification).
+ *
+ * Public clients (`token_endpoint_auth_method: "none"`, no stored secret) rely
+ * on PKCE and need no secret. Confidential clients MUST present the correct
+ * `client_secret` (via client_secret_basic or client_secret_post) — its SHA-256
+ * is compared, in constant time, against the stored hash; a missing/incorrect
+ * secret throws `OAuthError("invalid_client", …, 401)`.
+ *
+ * An UNKNOWN client_id is intentionally not rejected here: the grant handlers
+ * bind the client to the code/refresh-token and surface an `invalid_grant`, so
+ * this function leaves that path unchanged and only adds secret enforcement for
+ * confidential clients that actually exist.
+ */
+export async function authenticateClient(
+  db: DrizzleD1Database,
+  clientId: string,
+  providedSecret: string | undefined,
+): Promise<void> {
+  const client = await getClient(db, clientId);
+  if (!client) {
+    return;
+  }
+
+  const isConfidential =
+    client.tokenEndpointAuthMethod !== "none" && client.clientSecretHash != null;
+  if (!isConfidential) {
+    return;
+  }
+
+  if (!providedSecret) {
+    throw new OAuthError("invalid_client", "client authentication required", 401);
+  }
+  const providedHash = await hashApiKey(providedSecret);
+  if (!client.clientSecretHash || !timingSafeEqualHex(providedHash, client.clientSecretHash)) {
+    throw new OAuthError("invalid_client", "invalid client credentials", 401);
+  }
+}
+
 export interface RegisterClientInput {
   client_name: string;
   redirect_uris: string[];

--- a/packages/api/src/services/projects.ts
+++ b/packages/api/src/services/projects.ts
@@ -5,13 +5,27 @@
 import { and, asc, desc, eq, inArray, isNull, lt, sql } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import {
+  agentStates,
   apiKeys,
+  capabilityTokens,
+  claimEvidence,
+  claims,
+  claimVerificationRuns,
   conversations,
   conversationTags,
+  customDomains,
+  idempotencyKeys,
   messages,
+  oauthAuthorizationCodes,
+  oauthRefreshTokens,
   organizations,
   projects,
   rateLimits,
+  stateEvents,
+  stateLeases,
+  stateSnapshots,
+  stateTags,
+  webhooks,
 } from "../db/schema";
 import { buildApiKey } from "../lib/api-key";
 import { DEFAULT_CLERK_ORG_ID } from "../lib/constants";
@@ -366,9 +380,17 @@ export async function getProjectBySlug(
 }
 
 /**
- * Delete a project and all related data (cascade).
- * Returns the list of key hashes for the project's API keys (so callers can
- * invalidate the corresponding auth-cache entries).
+ * Delete a project and ALL related data.
+ *
+ * D1 does not reliably enforce `ON DELETE CASCADE` (foreign-key enforcement is
+ * off by default), so every child table is deleted explicitly rather than
+ * relying on the FK cascade. Missing any table would orphan rows that keep the
+ * data (and, for api_keys / capability_tokens, keep credentials usable).
+ *
+ * Returns the list of credential hashes (API keys AND capability tokens) for
+ * the project so callers can invalidate the corresponding auth-cache entries —
+ * without this a revoked/deleted credential could still authenticate until its
+ * cache entry expires.
  */
 export async function deleteProject(db: DrizzleD1Database, projectId: string): Promise<string[]> {
   const project = await db.select().from(projects).where(eq(projects.id, projectId)).get();
@@ -377,13 +399,16 @@ export async function deleteProject(db: DrizzleD1Database, projectId: string): P
     throw new Error("Project not found");
   }
 
-  // Collect key hashes BEFORE the cascade delete so the route can invalidate
-  // each one's auth-cache entry.
-  const keyRows = await db
-    .select({ keyHash: apiKeys.keyHash })
-    .from(apiKeys)
-    .where(eq(apiKeys.projectId, projectId));
-  const keyHashes = keyRows.map((r) => r.keyHash);
+  // Collect credential hashes BEFORE the delete so the route can invalidate each
+  // one's auth-cache entry (api keys and capability/OAuth access tokens).
+  const [keyRows, capRows] = await Promise.all([
+    db.select({ keyHash: apiKeys.keyHash }).from(apiKeys).where(eq(apiKeys.projectId, projectId)),
+    db
+      .select({ keyHash: capabilityTokens.keyHash })
+      .from(capabilityTokens)
+      .where(eq(capabilityTokens.projectId, projectId)),
+  ]);
+  const keyHashes = [...keyRows.map((r) => r.keyHash), ...capRows.map((r) => r.keyHash)];
 
   // Subquery for conversation IDs to avoid N+1 query
   const conversationIdSubquery = db
@@ -392,11 +417,30 @@ export async function deleteProject(db: DrizzleD1Database, projectId: string): P
     .where(eq(conversations.projectId, projectId));
 
   await db.batch([
+    // Conversation subtree (children first, then conversations).
     db
       .delete(conversationTags)
       .where(inArray(conversationTags.conversationId, conversationIdSubquery)),
     db.delete(messages).where(inArray(messages.conversationId, conversationIdSubquery)),
     db.delete(conversations).where(eq(conversations.projectId, projectId)),
+    // Claim subtree (evidence + verification runs reference claims).
+    db.delete(claimVerificationRuns).where(eq(claimVerificationRuns.projectId, projectId)),
+    db.delete(claimEvidence).where(eq(claimEvidence.projectId, projectId)),
+    db.delete(claims).where(eq(claims.projectId, projectId)),
+    // State platform tables.
+    db.delete(stateEvents).where(eq(stateEvents.projectId, projectId)),
+    db.delete(stateSnapshots).where(eq(stateSnapshots.projectId, projectId)),
+    db.delete(stateTags).where(eq(stateTags.projectId, projectId)),
+    db.delete(stateLeases).where(eq(stateLeases.projectId, projectId)),
+    db.delete(agentStates).where(eq(agentStates.projectId, projectId)),
+    db.delete(idempotencyKeys).where(eq(idempotencyKeys.projectId, projectId)),
+    // OAuth artifacts bound to the project.
+    db.delete(oauthRefreshTokens).where(eq(oauthRefreshTokens.projectId, projectId)),
+    db.delete(oauthAuthorizationCodes).where(eq(oauthAuthorizationCodes.projectId, projectId)),
+    // Credentials + config.
+    db.delete(capabilityTokens).where(eq(capabilityTokens.projectId, projectId)),
+    db.delete(webhooks).where(eq(webhooks.projectId, projectId)),
+    db.delete(customDomains).where(eq(customDomains.projectId, projectId)),
     db.delete(apiKeys).where(eq(apiKeys.projectId, projectId)),
     db.delete(projects).where(eq(projects.id, projectId)),
   ]);

--- a/packages/api/test/analytics-public.test.ts
+++ b/packages/api/test/analytics-public.test.ts
@@ -1,6 +1,30 @@
-import { SELF } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
 import { beforeAll, describe, expect, it } from "vitest";
-import { applyMigrations, authHeaders, seedProject } from "./setup";
+import { applyMigrations, authHeaders, seedProject, TEST_PROJECT_ID } from "./setup";
+
+/** Insert a scoped API key for TEST_PROJECT_ID and return its raw bearer value. */
+async function seedScopedKey(scopes: string[]): Promise<string> {
+  const raw = `as_live_Scoped${Math.random().toString(36).slice(2)}pad0000000000000000`;
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(raw));
+  const hash = Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  await env.DB.prepare(
+    `INSERT INTO api_keys (id, project_id, name, key_prefix, key_hash, scopes, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  )
+    .bind(
+      `key_scoped_${Math.random().toString(36).slice(2)}`,
+      TEST_PROJECT_ID,
+      "Scoped",
+      raw.substring(0, 12),
+      hash,
+      JSON.stringify(scopes),
+      Date.now(),
+    )
+    .run();
+  return raw;
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -95,6 +119,23 @@ describe("Public Analytics API", () => {
 
       const body = await res.json<{ error: { code: string } }>();
       expect(body.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("requires the analytics:read scope (#257)", async () => {
+      // A key scoped only to state:read must not read analytics.
+      const noAnalyticsKey = await seedScopedKey(["state:read"]);
+      const denied = await SELF.fetch("http://localhost/v1/analytics/summary", {
+        headers: { Authorization: `Bearer ${noAnalyticsKey}` },
+      });
+      expect(denied.status).toBe(403);
+      expect((await denied.json<{ error: { code: string } }>()).error.code).toBe("FORBIDDEN");
+
+      // A key with analytics:read is allowed.
+      const okKey = await seedScopedKey(["analytics:read"]);
+      const allowed = await SELF.fetch("http://localhost/v1/analytics/summary", {
+        headers: { Authorization: `Bearer ${okKey}` },
+      });
+      expect(allowed.status).toBe(200);
     });
 
     it("returns summary with correct shape", async () => {

--- a/packages/api/test/clerk-dashboard-auth.test.ts
+++ b/packages/api/test/clerk-dashboard-auth.test.ts
@@ -239,6 +239,61 @@ describe("Dashboard-management auth (clerkDashboardAuth)", () => {
   });
 
   // -------------------------------------------------------------------------
+  // Per-user tenancy for personal (org-less) accounts (#254)
+  // -------------------------------------------------------------------------
+
+  describe("org-less personal accounts are isolated per user (#254)", () => {
+    it("user A cannot see user B's org-less projects", async () => {
+      const tokenA = await signTestSessionToken({ userId: "user_personal_A", noOrg: true });
+      const tokenB = await signTestSessionToken({ userId: "user_personal_B", noOrg: true });
+
+      // User A creates a project (no active Clerk org → personal:user_personal_A org).
+      const slugA = `personal-a-${Date.now()}`;
+      const createA = await SELF.fetch("http://localhost/api/v1/projects", {
+        method: "POST",
+        headers: { ...JSON_HEADERS, Cookie: sessionCookie(tokenA) },
+        body: JSON.stringify({ name: "A Project", slug: slugA }),
+      });
+      expect(createA.status).toBe(201);
+      const { project: projectA } = await createA.json<{ project: { id: string } }>();
+
+      // User B creates their own project.
+      const slugB = `personal-b-${Date.now()}`;
+      const createB = await SELF.fetch("http://localhost/api/v1/projects", {
+        method: "POST",
+        headers: { ...JSON_HEADERS, Cookie: sessionCookie(tokenB) },
+        body: JSON.stringify({ name: "B Project", slug: slugB }),
+      });
+      expect(createB.status).toBe(201);
+
+      // User B lists projects — must NOT include user A's project.
+      const listB = await SELF.fetch("http://localhost/api/v1/projects", {
+        headers: { Cookie: sessionCookie(tokenB) },
+      });
+      expect(listB.status).toBe(200);
+      const bodyB = await listB.json<{ data: Array<{ id: string }> }>();
+      expect(bodyB.data.some((p) => p.id === projectA.id)).toBe(false);
+
+      // And B cannot fetch A's project by id (404, not leaked).
+      const getBofA = await SELF.fetch(`http://localhost/api/v1/projects/${projectA.id}`, {
+        headers: { Cookie: sessionCookie(tokenB) },
+      });
+      expect(getBofA.status).toBe(404);
+
+      // The two personal accounts resolved to DISTINCT internal orgs.
+      const orgA = await env.DB.prepare("SELECT id FROM organizations WHERE clerk_org_id = ?")
+        .bind("personal:user_personal_A")
+        .first<{ id: string }>();
+      const orgB = await env.DB.prepare("SELECT id FROM organizations WHERE clerk_org_id = ?")
+        .bind("personal:user_personal_B")
+        .first<{ id: string }>();
+      expect(orgA?.id).toBeTruthy();
+      expect(orgB?.id).toBeTruthy();
+      expect(orgA?.id).not.toBe(orgB?.id);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Intentionally-public routes remain open
   // -------------------------------------------------------------------------
 

--- a/packages/api/test/clerk-jwt.ts
+++ b/packages/api/test/clerk-jwt.ts
@@ -34,6 +34,8 @@ export interface TestSessionOptions {
   userId?: string;
   /** Clerk active org id (o_id claim). Defaults to a stable test org. */
   orgId?: string;
+  /** Omit the org claim entirely (simulates a personal account with no org). */
+  noOrg?: boolean;
   /** Authorized party (azp). Defaults to the dashboard origin. */
   azp?: string;
   /** Seconds until expiry. Defaults to 3600. */
@@ -51,7 +53,7 @@ export async function signTestSessionToken(opts: TestSessionOptions = {}): Promi
 
   const now = Math.floor(Date.now() / 1000);
   const header = { alg: "RS256", typ: "JWT" };
-  const payload = {
+  const payload: Record<string, unknown> = {
     iss: "https://test.clerk.accounts.dev",
     sub: userId,
     aud: "test-app",
@@ -60,11 +62,13 @@ export async function signTestSessionToken(opts: TestSessionOptions = {}): Promi
     nbf: now,
     exp: now + expiresInSec,
     sid: "sess_test_001",
-    // Clerk org claims
-    o_id: orgId,
-    o_slug: "test-org",
-    o_role: "org:admin",
   };
+  // Clerk org claims — omitted entirely for a personal account (no active org).
+  if (!opts.noOrg) {
+    payload.o_id = orgId;
+    payload.o_slug = "test-org";
+    payload.o_role = "org:admin";
+  }
 
   const encHeader = base64Url(strToBytes(JSON.stringify(header)));
   const encPayload = base64Url(strToBytes(JSON.stringify(payload)));

--- a/packages/api/test/oauth.test.ts
+++ b/packages/api/test/oauth.test.ts
@@ -466,6 +466,90 @@ describe("OAuth 2.1 server", () => {
       expect(body.error).toBe("invalid_grant");
     });
 
+    it("requires the client_secret for a confidential client (#263)", async () => {
+      const verifier = "conf-verifier-conf-verifier-conf-verifier-ok";
+      const challenge = await s256(verifier);
+      const secret = "super-secret-value-1234567890";
+      // Confidential client: client_secret_post, secret hash stored.
+      await env.DB.prepare(
+        `INSERT INTO oauth_clients (id, client_secret_hash, client_name, redirect_uris, grant_types, token_endpoint_auth_method, created_at)
+         VALUES (?, ?, 'Conf', ?, '["authorization_code","refresh_token"]', 'client_secret_post', ?)`,
+      )
+        .bind("client_conf", await hashApiKey(secret), JSON.stringify([REDIRECT]), Date.now())
+        .run();
+      await insertAuthCode({
+        code: "confcode1",
+        clientId: "client_conf",
+        redirectUri: REDIRECT,
+        codeChallenge: challenge,
+        scopes: ["conversations:read"],
+      });
+
+      const exchange = (extra: Record<string, string>) =>
+        SELF.fetch("http://localhost/api/oauth/token", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams({
+            grant_type: "authorization_code",
+            code: "confcode1",
+            code_verifier: verifier,
+            client_id: "client_conf",
+            redirect_uri: REDIRECT,
+            ...extra,
+          }).toString(),
+        });
+
+      // Missing secret → invalid_client (401), code NOT consumed.
+      const noSecret = await exchange({});
+      expect(noSecret.status).toBe(401);
+      expect((await noSecret.json<{ error: string }>()).error).toBe("invalid_client");
+
+      // Wrong secret → invalid_client (401).
+      const wrongSecret = await exchange({ client_secret: "nope" });
+      expect(wrongSecret.status).toBe(401);
+
+      // Correct secret → success.
+      const ok = await exchange({ client_secret: secret });
+      expect(ok.status).toBe(200);
+      expect((await ok.json<TokenResponse>()).access_token.startsWith("as_cap_")).toBe(true);
+    });
+
+    it("accepts client_secret_basic for a confidential client (#263)", async () => {
+      const verifier = "basic-verifier-basic-verifier-basic-verifier";
+      const challenge = await s256(verifier);
+      const secret = "basic-secret-abcdefghijklmnop";
+      await env.DB.prepare(
+        `INSERT INTO oauth_clients (id, client_secret_hash, client_name, redirect_uris, grant_types, token_endpoint_auth_method, created_at)
+         VALUES (?, ?, 'ConfBasic', ?, '["authorization_code","refresh_token"]', 'client_secret_basic', ?)`,
+      )
+        .bind("client_basic", await hashApiKey(secret), JSON.stringify([REDIRECT]), Date.now())
+        .run();
+      await insertAuthCode({
+        code: "basiccode1",
+        clientId: "client_basic",
+        redirectUri: REDIRECT,
+        codeChallenge: challenge,
+        scopes: ["conversations:read"],
+      });
+
+      const basic = btoa(`client_basic:${secret}`);
+      const res = await SELF.fetch("http://localhost/api/oauth/token", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Authorization: `Basic ${basic}`,
+        },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code: "basiccode1",
+          code_verifier: verifier,
+          client_id: "client_basic",
+          redirect_uri: REDIRECT,
+        }).toString(),
+      });
+      expect(res.status).toBe(200);
+    });
+
     it("rejects reusing a consumed code", async () => {
       const verifier = "reuse-verifier-reuse-verifier-reuse-verifier";
       const challenge = await s256(verifier);

--- a/packages/api/test/setup.ts
+++ b/packages/api/test/setup.ts
@@ -208,6 +208,7 @@ const DDL_STATEMENTS: string[] = [
   )`,
   `CREATE INDEX IF NOT EXISTS \`state_leases_project_id_state_key_idx\` ON \`state_leases\` (\`project_id\`,\`state_key\`)`,
   `CREATE INDEX IF NOT EXISTS \`state_leases_project_id_expires_at_idx\` ON \`state_leases\` (\`project_id\`,\`expires_at\`)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS \`state_leases_active_unique_idx\` ON \`state_leases\` (\`project_id\`,\`state_key\`) WHERE \`released_at\` IS NULL`,
   `CREATE TABLE IF NOT EXISTS \`claims\` (
     \`id\` text PRIMARY KEY NOT NULL,
     \`project_id\` text NOT NULL,

--- a/packages/api/test/webhooks.test.ts
+++ b/packages/api/test/webhooks.test.ts
@@ -90,6 +90,29 @@ describe("Webhooks", () => {
       expect(body.error.code).toBe("BAD_REQUEST");
     });
 
+    it("rejects a non-https (http) webhook URL (#255 SSRF)", async () => {
+      const res = await createWebhook({
+        url: "http://example.com/webhook",
+        events: ["conversation.created"],
+      });
+      expect(res.status).toBe(400);
+      expect((await res.json<{ error: { code: string } }>()).error.code).toBe("BAD_REQUEST");
+    });
+
+    it.each([
+      "https://127.0.0.1/webhook",
+      "https://localhost/webhook",
+      "https://10.0.0.5/webhook",
+      "https://192.168.1.10/webhook",
+      "https://172.16.5.5/webhook",
+      "https://169.254.169.254/latest/meta-data", // cloud metadata
+      "https://[::1]/webhook",
+    ])("rejects private/loopback/metadata host %s (#255 SSRF)", async (url) => {
+      const res = await createWebhook({ url, events: ["conversation.created"] });
+      expect(res.status).toBe(400);
+      expect((await res.json<{ error: { code: string } }>()).error.code).toBe("BAD_REQUEST");
+    });
+
     it("returns 400 for empty events array", async () => {
       const res = await createWebhook({
         url: "https://example.com/webhook",

--- a/packages/dashboard/src/components/dashboard/conversations/_use-messages.ts
+++ b/packages/dashboard/src/components/dashboard/conversations/_use-messages.ts
@@ -17,6 +17,9 @@ export function useMessages(projectId: string, conversationId: string): UseMessa
 
   useEffect(() => {
     let ignore = false;
+    // Clear immediately so the panel doesn't show the previous conversation's
+    // messages while the new ones load.
+    setMessages(null);
     (async () => {
       setLoading(true);
       setError(null);

--- a/packages/dashboard/src/components/dashboard/conversations/_use-messages.ts
+++ b/packages/dashboard/src/components/dashboard/conversations/_use-messages.ts
@@ -1,5 +1,5 @@
 import type { MessageResponse } from "@agentstate/shared";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { api } from "@/lib/api";
 
 export type Message = MessageResponse;
@@ -14,11 +14,9 @@ export function useMessages(projectId: string, conversationId: string): UseMessa
   const [messages, setMessages] = useState<Message[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const loaded = useRef(false);
 
   useEffect(() => {
-    if (loaded.current) return;
-    loaded.current = true;
+    let ignore = false;
     (async () => {
       setLoading(true);
       setError(null);
@@ -26,13 +24,18 @@ export function useMessages(projectId: string, conversationId: string): UseMessa
         const res = await api<{ data: Message[] }>(
           `/v1/projects/${projectId}/conversations/${conversationId}/messages`,
         );
-        setMessages(res.data);
+        if (!ignore) setMessages(res.data);
       } catch (err: unknown) {
-        setError(err instanceof Error ? err.message : "Failed to load messages");
+        if (!ignore) {
+          setError(err instanceof Error ? err.message : "Failed to load messages");
+        }
       } finally {
-        setLoading(false);
+        if (!ignore) setLoading(false);
       }
     })();
+    return () => {
+      ignore = true;
+    };
   }, [projectId, conversationId]);
 
   return { messages, loading, error };

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -13,6 +13,10 @@ const baseUrl = (process.env.AGENTSTATE_BASE_URL ?? "https://agentstate.app/api"
   "",
 );
 
+// Per-request timeout (ms). Configurable via AGENTSTATE_TIMEOUT_MS; defaults to 30s.
+const parsedTimeout = Number(process.env.AGENTSTATE_TIMEOUT_MS);
+const timeoutMs = Number.isFinite(parsedTimeout) && parsedTimeout > 0 ? parsedTimeout : 30_000;
+
 if (!apiKey) {
   process.stderr.write(
     "Error: AGENTSTATE_API_KEY environment variable is required.\n" +
@@ -43,7 +47,15 @@ async function apiRequest<T>(
     ...(fetchOptions.headers as Record<string, string> | undefined),
   };
 
-  const res = await fetch(url, { ...fetchOptions, headers });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  let res: Response;
+  try {
+    res = await fetch(url, { ...fetchOptions, headers, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
 
   if (res.status === 204) return undefined as T;
 

--- a/packages/python-sdk/agentstate/client.py
+++ b/packages/python-sdk/agentstate/client.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import random
 import time
 import urllib.parse
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import httpx
 
@@ -16,27 +17,85 @@ from agentstate.exceptions import (
     ValidationError,
 )
 
-BASE_URL = "https://api.agentstate.app"
+# Canonical default base URL shared across all AgentState SDKs.
+BASE_URL = "https://agentstate.app/api"
+
+# Default per-request timeout in seconds.
+DEFAULT_TIMEOUT = 30.0
 
 _RETRY_STATUSES = {429, 500, 502, 503, 504}
 
+# Methods that are safe to auto-retry. Non-idempotent methods (POST) are only
+# retried when an explicit Idempotency-Key is attached so the server can dedupe.
+_IDEMPOTENT_METHODS = {"GET", "PUT", "DELETE", "HEAD", "OPTIONS"}
+
+
+def _extract_error(response: httpx.Response) -> Tuple[Optional[str], Optional[str]]:
+    """Parse the ``{"error": {"code", "message"}}`` envelope from a response body."""
+    try:
+        body = response.json()
+    except Exception:  # noqa: BLE001 - body may be empty or non-JSON
+        return None, None
+    if not isinstance(body, dict):
+        return None, None
+    error = body.get("error")
+    if not isinstance(error, dict):
+        return None, None
+    code = error.get("code")
+    message = error.get("message")
+    return (
+        code if isinstance(code, str) else None,
+        message if isinstance(message, str) else None,
+    )
+
+
+def _parse_retry_after(value: Optional[str]) -> Optional[float]:
+    """Parse a ``Retry-After`` header value expressed in seconds.
+
+    Returns ``None`` for missing values or HTTP-date forms we do not honor.
+    """
+    if not value:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    return max(seconds, 0.0)
+
 
 def _handle_response(response: httpx.Response) -> Any:
-    """Handle API response and raise appropriate exceptions."""
-    if response.status_code == 401:
-        raise AuthenticationError("Invalid API key")
-    if response.status_code == 404:
-        raise NotFoundError("Resource not found")
-    if response.status_code == 422:
-        raise ValidationError("Request validation failed")
-    if response.status_code == 429:
-        raise RateLimitError("Rate limit exceeded")
+    """Handle an API response and raise appropriate exceptions.
 
-    response.raise_for_status()
+    Success (2xx) returns the parsed JSON body (or ``None`` for 204). Every
+    non-2xx response is mapped to an :class:`AgentStateError` subclass, carrying
+    the parsed error ``code`` and ``message`` when present.
+    """
+    status = response.status_code
 
-    if response.status_code == 204:
-        return None
-    return response.json()
+    if 200 <= status < 300:
+        if status == 204:
+            return None
+        try:
+            return response.json()
+        except Exception:  # noqa: BLE001 - tolerate empty success bodies
+            return None
+
+    code, message = _extract_error(response)
+
+    if status in (401, 403):
+        raise AuthenticationError(
+            message or ("Forbidden" if status == 403 else "Invalid API key"),
+            code=code,
+        )
+    if status == 404:
+        raise NotFoundError(message or "Resource not found", code=code)
+    if status in (400, 422):
+        raise ValidationError(message or "Request validation failed", code=code)
+    if status == 429:
+        raise RateLimitError(message or "Rate limit exceeded", code=code)
+
+    # Any other non-2xx status is wrapped rather than left to fall through.
+    raise AgentStateError(message or f"HTTP {status} error", code=code)
 
 
 class AgentStateClient:
@@ -48,23 +107,26 @@ class AgentStateClient:
         base_url: str = BASE_URL,
         max_retries: int = 3,
         retry_delay_ms: int = 1000,
+        timeout: float = DEFAULT_TIMEOUT,
     ):
         """Initialize the client.
 
         Args:
             api_key: AgentState API key (format: as_live_...)
-            base_url: API base URL (default: https://api.agentstate.app, an alias for
-                the TypeScript SDK default https://agentstate.app/api; both resolve to
-                the same API)
+            base_url: API base URL (default: https://agentstate.app/api, the
+                canonical default shared across all AgentState SDKs)
             max_retries: Max retry attempts for 429/5xx. Default: 3
             retry_delay_ms: Base delay in ms for exponential backoff. Default: 1000
+            timeout: Per-request timeout in seconds passed to httpx. Default: 30.0
         """
         self.api_key = api_key
         self.base_url = base_url.rstrip("/")
         self.max_retries = max_retries
         self.retry_delay_ms = retry_delay_ms
+        self.timeout = timeout
         self.client = httpx.Client(
-            headers={"Authorization": f"Bearer {api_key}"}
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=timeout,
         )
 
     def __enter__(self):
@@ -77,6 +139,19 @@ class AgentStateClient:
         """Close the HTTP client."""
         self.client.close()
 
+    def _backoff_delay(self, attempt: int, retry_after: Optional[float]) -> float:
+        """Compute a retry delay with exponential backoff and random jitter.
+
+        Honors a server-provided ``Retry-After`` (seconds) as the base delay when
+        present, otherwise falls back to exponential backoff. Random jitter is
+        added on top to avoid thundering-herd retries.
+        """
+        if retry_after is not None:
+            base = retry_after
+        else:
+            base = self.retry_delay_ms * (2 ** attempt) / 1000.0
+        return base + random.uniform(0.0, base * 0.5)
+
     def _request(
         self,
         method: str,
@@ -86,15 +161,23 @@ class AgentStateClient:
         json: Optional[Any] = None,
         headers: Optional[Dict[str, str]] = None,
     ) -> Any:
-        """Execute an HTTP request with exponential backoff retry on 429/5xx."""
+        """Execute an HTTP request with retry on 429/5xx for idempotent methods.
+
+        Retries are only performed for idempotent methods (GET/PUT/DELETE/HEAD).
+        A non-idempotent POST is retried only when it already carries an
+        ``Idempotency-Key`` header, letting the server safely dedupe the replay.
+        Backoff honors ``Retry-After`` and adds random jitter.
+        """
         url = f"{self.base_url}{path}"
         last_error: Optional[Exception] = None
 
-        for attempt in range(self.max_retries + 1):
-            if attempt > 0:
-                delay = self.retry_delay_ms * (2 ** (attempt - 1)) / 1000.0
-                time.sleep(delay)
+        method_upper = method.upper()
+        has_idempotency_key = bool(headers and headers.get("Idempotency-Key"))
+        retriable = method_upper in _IDEMPOTENT_METHODS or (
+            method_upper == "POST" and has_idempotency_key
+        )
 
+        for attempt in range(self.max_retries + 1):
             try:
                 response = self.client.request(
                     method,
@@ -103,23 +186,29 @@ class AgentStateClient:
                     json=json,
                     headers=headers,
                 )
-
-                # Retry on 429 and 5xx (except on final attempt)
-                if response.status_code in _RETRY_STATUSES and attempt < self.max_retries:
-                    last_error = AgentStateError(
-                        f"Retriable server error: {response.status_code}"
-                    )
-                    continue
-
-                return _handle_response(response)
-            except (AuthenticationError, NotFoundError, ValidationError, RateLimitError):
-                raise
             except AgentStateError:
                 raise
             except Exception as exc:
                 last_error = exc
-                if attempt == self.max_retries:
+                if not retriable or attempt == self.max_retries:
                     raise
+                time.sleep(self._backoff_delay(attempt, None))
+                continue
+
+            # Retry on 429 and 5xx (idempotent/keyed requests only, not final attempt)
+            if (
+                response.status_code in _RETRY_STATUSES
+                and retriable
+                and attempt < self.max_retries
+            ):
+                last_error = AgentStateError(
+                    f"Retriable server error: {response.status_code}"
+                )
+                retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+                time.sleep(self._backoff_delay(attempt, retry_after))
+                continue
+
+            return _handle_response(response)
 
         raise last_error  # type: ignore[misc]
 

--- a/packages/python-sdk/agentstate/client.py
+++ b/packages/python-sdk/agentstate/client.py
@@ -150,7 +150,9 @@ class AgentStateClient:
             base = retry_after
         else:
             base = self.retry_delay_ms * (2 ** attempt) / 1000.0
-        return base + random.uniform(0.0, base * 0.5)
+        delay = base + random.uniform(0.0, base * 0.5)
+        # Clamp so a misconfigured/huge Retry-After can't block the caller for long.
+        return min(delay, 30.0)
 
     def _request(
         self,

--- a/packages/python-sdk/agentstate/exceptions.py
+++ b/packages/python-sdk/agentstate/exceptions.py
@@ -1,10 +1,20 @@
 """AgentState SDK exceptions."""
 
+from typing import Optional
+
 
 class AgentStateError(Exception):
-    """Base exception for AgentState errors."""
+    """Base exception for AgentState errors.
 
-    pass
+    Carries the machine-readable ``code`` and human-readable ``message`` parsed
+    from the API error envelope ``{"error": {"code": ..., "message": ...}}`` when
+    available.
+    """
+
+    def __init__(self, message: str = "", *, code: Optional[str] = None):
+        super().__init__(message)
+        self.message = message
+        self.code = code
 
 
 class AuthenticationError(AgentStateError):

--- a/packages/python-sdk/agentstate/langgraph.py
+++ b/packages/python-sdk/agentstate/langgraph.py
@@ -11,16 +11,50 @@ from typing import Any, AsyncGenerator, Dict, Iterator, List, Optional, Sequence
 from agentstate.client import AgentStateClient
 from agentstate.exceptions import NotFoundError
 
+# Import each optional langgraph symbol in its OWN try/except so a single missing
+# name cannot disable the ones that do exist. Current langgraph exposes only
+# ``BaseCheckpointSaver`` (its async methods live on that same class); older
+# releases shipped a separate ``AsyncBaseCheckpointSaver``.
 try:  # pragma: no cover - optional runtime dependency
-    from langgraph.checkpoint.base import AsyncBaseCheckpointSaver as _AsyncBaseCheckpointSaver
     from langgraph.checkpoint.base import BaseCheckpointSaver as _BaseCheckpointSaver
 except ImportError:  # pragma: no cover - optional dependency missing
 
     class _BaseCheckpointSaver:  # noqa: D401
         """Fallback when langgraph-checkpoint is not installed."""
 
-    class _AsyncBaseCheckpointSaver:  # noqa: D401
-        """Fallback when langgraph-checkpoint is not installed."""
+
+try:  # pragma: no cover - optional runtime dependency
+    from langgraph.checkpoint.base import AsyncBaseCheckpointSaver as _AsyncBaseCheckpointSaver
+except ImportError:  # pragma: no cover - symbol removed in current langgraph
+    # The async checkpoint surface now lives on BaseCheckpointSaver, so fall back
+    # to it (real class when installed, stub otherwise) rather than a bare stub.
+    _AsyncBaseCheckpointSaver = _BaseCheckpointSaver
+
+
+try:  # pragma: no cover - optional runtime dependency
+    from langgraph.checkpoint.base import CheckpointTuple as _CheckpointTuple
+except ImportError:  # pragma: no cover - optional dependency missing
+    _CheckpointTuple = None
+
+
+def _make_checkpoint_tuple(
+    config: Dict[str, Any],
+    checkpoint: Dict[str, Any],
+    metadata: Dict[str, Any],
+    parent_config: Optional[Dict[str, Any]],
+    pending_writes: Optional[List[Tuple[str, str, Any]]],
+):
+    """Build langgraph's ``CheckpointTuple`` when available, else a plain tuple.
+
+    ``CheckpointTuple`` is a ``NamedTuple``, so positional unpacking and index
+    access keep working for callers that treat the result as a plain 5-tuple,
+    while langgraph's runtime (which accesses ``.checkpoint``, ``.config`` …)
+    also works.
+    """
+    fields = (config, checkpoint, metadata, parent_config, pending_writes)
+    if _CheckpointTuple is not None:
+        return _CheckpointTuple(*fields)
+    return fields
 
 
 CHECKPOINT_KIND = "checkpoint"
@@ -329,7 +363,7 @@ class AgentStateCheckpointSaver(_BaseCheckpointSaver):
         data = _safe_dict(state.get("data"))
         checkpoint_id = data.get("checkpoint_id")
         if not isinstance(checkpoint_id, str):
-            return (
+            return _make_checkpoint_tuple(
                 {"configurable": {"thread_id": thread_id, "checkpoint_ns": checkpoint_ns}},
                 {},
                 {},
@@ -352,7 +386,7 @@ class AgentStateCheckpointSaver(_BaseCheckpointSaver):
 
         pending_writes = self._parse_pending_writes(thread_id, checkpoint_ns, checkpoint_id)
 
-        return (
+        return _make_checkpoint_tuple(
             {"configurable": {"thread_id": thread_id, "checkpoint_ns": checkpoint_ns, "checkpoint_id": checkpoint_id}},
             _safe_dict(checkpoint),
             _safe_dict(metadata),
@@ -407,17 +441,19 @@ class AgentStateCheckpointSaver(_BaseCheckpointSaver):
     ]:
         thread_id = _get_thread_id(config if config is not None else {})
         checkpoint_ns = _get_checkpoint_ns(config if config is not None else {})
-        max_items = min(limit or LIST_LIMIT_DEFAULT, LIST_PAGE_SIZE)
+        # Follow cursors until the caller's requested limit is reached. A limit
+        # above LIST_PAGE_SIZE (or None for "all") is honored by paginating in
+        # _query_records rather than being clamped to a single 100-row page.
         rows = self._query_records(
             thread_id=thread_id,
             checkpoint_ns=checkpoint_ns,
             kind=CHECKPOINT_KIND,
-            limit=max_items,
+            limit=limit,
             before=before,
             after=after,
             filter_data=_normalize_filter(filter),
         )
-        for row in rows[:max_items]:
+        for row in rows:
             yield self._to_tuple(thread_id, checkpoint_ns, row)
 
     def put(
@@ -574,10 +610,10 @@ class AsyncAgentStateCheckpointSaver(_AsyncBaseCheckpointSaver):
         ],
         None,
     ]:
-        """Run self._sync.list in self._run and yield the finite items result.
+        """Run self._sync.list in self._run and yield the materialized items.
 
-        When limit is None, self._sync.list applies LIST_LIMIT_DEFAULT before
-        items is materialized.
+        When ``limit`` is None, self._sync.list paginates over all checkpoints;
+        otherwise it follows cursors until ``limit`` rows are collected.
         """
         items = await self._run(
             lambda: list(

--- a/packages/python-sdk/tests/test_client.py
+++ b/packages/python-sdk/tests/test_client.py
@@ -6,11 +6,24 @@ from unittest.mock import Mock, patch
 import pytest
 from agentstate import AgentStateClient
 from agentstate.exceptions import (
+    AgentStateError,
     AuthenticationError,
     NotFoundError,
     RateLimitError,
     ValidationError,
 )
+
+
+def _err(status, code=None, message=None, headers=None):
+    """Build a mock error response with an optional error envelope + headers."""
+    r = Mock()
+    r.status_code = status
+    r.headers = headers or {}
+    if code is not None or message is not None:
+        r.json.return_value = {"error": {"code": code, "message": message}}
+    else:
+        r.json.side_effect = ValueError("no body")
+    return r
 
 
 @pytest.fixture
@@ -53,7 +66,9 @@ def test_client_init():
     """Test client initialization."""
     client = AgentStateClient(api_key="as_live_test123")
     assert client.api_key == "as_live_test123"
-    assert client.base_url == "https://api.agentstate.app"
+    # Canonical default base URL shared across all AgentState SDKs.
+    assert client.base_url == "https://agentstate.app/api"
+    assert client.timeout == 30.0
 
 
 def test_client_init_custom_base_url():
@@ -584,3 +599,134 @@ def test_verify_claim():
     call_args = client.client.request.call_args
     assert call_args.args[0] == "POST"
     assert call_args.args[1].endswith("/v1/claims/claim_1/verify")
+
+
+# -------------------------------------------------------------------------
+# Error mapping (#267)
+# -------------------------------------------------------------------------
+
+
+def test_bad_request_maps_to_validation_error():
+    """HTTP 400 maps to ValidationError with parsed code + message."""
+    client = _make_client()
+    client.client.request = Mock(return_value=_err(400, "invalid_body", "bad field"))
+
+    with pytest.raises(ValidationError) as exc:
+        client.create_conversation(messages=[])
+
+    assert exc.value.code == "invalid_body"
+    assert "bad field" in str(exc.value)
+
+
+def test_forbidden_maps_to_authentication_error():
+    """HTTP 403 maps to AuthenticationError with parsed code + message."""
+    client = _make_client()
+    client.client.request = Mock(
+        return_value=_err(403, "insufficient_scope", "missing scope")
+    )
+
+    with pytest.raises(AuthenticationError) as exc:
+        client.get_conversation("c1")
+
+    assert exc.value.code == "insufficient_scope"
+    assert "missing scope" in str(exc.value)
+
+
+def test_unmapped_server_error_wrapped_in_agentstate_error():
+    """Any other non-2xx status is wrapped in AgentStateError (no fall-through)."""
+    client = AgentStateClient(api_key="k", max_retries=0)
+    client.client = Mock()
+    client.client.request = Mock(return_value=_err(500, "internal", "boom"))
+
+    with pytest.raises(AgentStateError) as exc:
+        client.get_conversation("c1")
+
+    assert exc.value.code == "internal"
+    assert "boom" in str(exc.value)
+
+
+# -------------------------------------------------------------------------
+# Timeout (#268)
+# -------------------------------------------------------------------------
+
+
+@patch("agentstate.client.httpx.Client")
+def test_timeout_passed_to_httpx(mock_httpx):
+    """The timeout parameter flows into httpx.Client."""
+    AgentStateClient(api_key="k", timeout=5.0)
+
+    _, kwargs = mock_httpx.call_args
+    assert kwargs["timeout"] == 5.0
+
+
+def test_default_timeout():
+    """Default timeout is 30 seconds."""
+    client = AgentStateClient(api_key="k")
+    assert client.timeout == 30.0
+
+
+# -------------------------------------------------------------------------
+# Idempotent retries (#272) + Retry-After / jitter (#274)
+# -------------------------------------------------------------------------
+
+
+@patch("agentstate.client.time.sleep")
+def test_post_not_retried_on_server_error(mock_sleep):
+    """A plain POST (no Idempotency-Key) is not retried on 5xx."""
+    client = _make_client()
+    client.client.request = Mock(return_value=_err(500, "internal", "boom"))
+
+    with pytest.raises(AgentStateError):
+        client.create_conversation(messages=[])
+
+    assert client.client.request.call_count == 1
+    mock_sleep.assert_not_called()
+
+
+@patch("agentstate.client.time.sleep")
+def test_get_retried_on_server_error(mock_sleep):
+    """An idempotent GET is retried on 5xx then succeeds."""
+    client = _make_client()
+    client.client.request = Mock(
+        side_effect=[_err(500, "internal", "boom"), _ok({"id": "c1"})]
+    )
+
+    result = client.get_conversation("c1")
+
+    assert result["id"] == "c1"
+    assert client.client.request.call_count == 2
+    assert mock_sleep.call_count == 1
+
+
+@patch("agentstate.client.time.sleep")
+def test_retry_honors_retry_after_header_with_jitter(mock_sleep):
+    """On 429, Retry-After is used as the base delay with added jitter (#274)."""
+    client = _make_client()
+    client.client.request = Mock(
+        side_effect=[_err(429, headers={"Retry-After": "2"}), _ok({"id": "c1"})]
+    )
+
+    result = client.get_conversation("c1")
+
+    assert result["id"] == "c1"
+    assert mock_sleep.call_count == 1
+    delay = mock_sleep.call_args.args[0]
+    # base 2s honored, plus up to 50% jitter
+    assert 2.0 <= delay <= 3.0
+
+
+@patch("agentstate.client.time.sleep")
+def test_post_with_idempotency_key_is_retried(mock_sleep):
+    """A POST carrying an Idempotency-Key is safe to retry on 5xx."""
+    client = _make_client()
+    client.client.request = Mock(
+        side_effect=[_err(500, "internal", "boom"), _ok({"ok": True})]
+    )
+
+    result = client._request(
+        "POST", "/v1/states/query", headers={"Idempotency-Key": "k1"}
+    )
+
+    assert result == {"ok": True}
+    assert client.client.request.call_count == 2
+    assert mock_sleep.call_count == 1

--- a/packages/python-sdk/tests/test_langgraph.py
+++ b/packages/python-sdk/tests/test_langgraph.py
@@ -220,3 +220,141 @@ async def test_async_saver_delegates_to_sync():
     async for item in async_saver.alist({"configurable": {"thread_id": "thread-1"}}):
         rows.append(item)
     assert len(rows) == 2
+
+
+# -------------------------------------------------------------------------
+# In-memory fake client for cursor-following / integration tests
+# -------------------------------------------------------------------------
+
+
+class FakeStateClient:
+    """Minimal in-memory stand-in for AgentStateClient state methods.
+
+    Emulates predicate filtering (by ``$.kind`` / ``$.thread_id`` / …) and
+    cursor pagination so the checkpoint saver can be exercised end to end.
+    """
+
+    def __init__(self):
+        self.records = {}
+        self._seq = 0
+
+    def upsert_state(self, state_key, body, idempotency_key=None):
+        self._seq += 1
+        self.records[state_key] = {
+            "state_key": state_key,
+            "data": body["data"],
+            "metadata": body.get("metadata", {}),
+            "latest_sequence": self._seq,
+        }
+        return self.records[state_key]
+
+    def get_state(self, state_key, **kwargs):
+        rec = self.records.get(state_key)
+        if rec is None:
+            raise NotFoundError("missing")
+        return rec
+
+    def delete_state(self, state_key, **kwargs):
+        self.records.pop(state_key, None)
+        return {"deleted": True}
+
+    def query_states(self, query):
+        preds = query.get("predicates", [])
+
+        def matches(rec):
+            data = rec["data"]
+            return all(data.get(p["path"][2:]) == p["equals"] for p in preds)
+
+        rows = sorted(
+            (r for r in self.records.values() if matches(r)),
+            key=lambda r: r["latest_sequence"],
+            reverse=True,
+        )
+        page_size = query.get("limit") or len(rows) or 1
+        start = int(query.get("cursor") or 0)
+        page = rows[start : start + page_size]
+        next_cursor = str(start + page_size) if start + page_size < len(rows) else None
+        return {"data": page, "pagination": {"next_cursor": next_cursor}}
+
+
+def test_list_follows_cursor_beyond_single_page():
+    """list() must page past the 100-row API cap up to the requested limit (#270)."""
+    client = FakeStateClient()
+    saver = AgentStateCheckpointSaver(client)
+    for i in range(150):
+        saver.put(
+            {"configurable": {"thread_id": "t", "checkpoint_ns": ""}},
+            {"id": f"cp-{i:03d}"},
+            {},
+            {},
+        )
+
+    entries = list(saver.list({"configurable": {"thread_id": "t"}}, limit=150))
+    assert len(entries) == 150
+    checkpoint_ids = {e[0]["configurable"]["checkpoint_id"] for e in entries}
+    assert len(checkpoint_ids) == 150
+
+
+def test_list_unbounded_returns_all_records():
+    """list() with no limit returns every checkpoint, not a clamped page (#270)."""
+    client = FakeStateClient()
+    saver = AgentStateCheckpointSaver(client)
+    for i in range(120):
+        saver.put(
+            {"configurable": {"thread_id": "t", "checkpoint_ns": ""}},
+            {"id": f"cp-{i:03d}"},
+            {},
+            {},
+        )
+
+    entries = list(saver.list({"configurable": {"thread_id": "t"}}))
+    assert len(entries) == 120
+
+
+# -------------------------------------------------------------------------
+# Real LangGraph integration (skipped when langgraph is not installed) — #265
+# -------------------------------------------------------------------------
+
+
+def test_saver_subclasses_real_base_when_langgraph_installed():
+    base = pytest.importorskip("langgraph.checkpoint.base")
+    assert issubclass(AgentStateCheckpointSaver, base.BaseCheckpointSaver)
+    assert issubclass(AsyncAgentStateCheckpointSaver, base.BaseCheckpointSaver)
+    saver = AgentStateCheckpointSaver(FakeStateClient())
+    assert isinstance(saver, base.BaseCheckpointSaver)
+
+
+def test_compiles_and_runs_real_stategraph():
+    """Compile a real StateGraph with the saver and exercise persist + resume."""
+    graph_mod = pytest.importorskip("langgraph.graph")
+    from typing_extensions import TypedDict
+
+    class State(TypedDict):
+        count: int
+
+    def increment(state):
+        return {"count": state["count"] + 1}
+
+    client = FakeStateClient()
+    saver = AgentStateCheckpointSaver(client)
+
+    builder = graph_mod.StateGraph(State)
+    builder.add_node("increment", increment)
+    builder.add_edge(graph_mod.START, "increment")
+    builder.add_edge("increment", graph_mod.END)
+    app = builder.compile(checkpointer=saver)
+
+    config = {"configurable": {"thread_id": "integration-thread"}}
+    first = app.invoke({"count": 0}, config)
+    assert first["count"] == 1
+
+    # Resume: reading back the persisted checkpoint must work (requires a real
+    # CheckpointTuple, not a bare tuple).
+    resumed = app.invoke({"count": 0}, config)
+    assert resumed["count"] == 1
+
+    snapshot = app.get_state(config)
+    assert snapshot.values["count"] == 1
+
+    history = list(app.get_state_history(config))
+    assert len(history) >= 1

--- a/packages/sdk/dist/ai-sdk.d.ts
+++ b/packages/sdk/dist/ai-sdk.d.ts
@@ -1,39 +1,39 @@
 import { JsonObject, AgentState } from './index.js';
 
 type UIMessage = Record<string, unknown> & {
-  id?: string;
-  role?: string;
+    id?: string;
+    role?: string;
 };
 interface ChatStoreOptions {
-  agentId?: string;
-  stateKeyPrefix?: string;
-  generateChatId?: () => string;
+    agentId?: string;
+    stateKeyPrefix?: string;
+    generateChatId?: () => string;
 }
 interface RSCStoreOptions {
-  stateKey: string;
-  agentId?: string;
-  stateKeyPrefix?: string;
-  mapAIStateToUIMessages?: (state: JsonObject | null) => UIMessage[];
+    stateKey: string;
+    agentId?: string;
+    stateKeyPrefix?: string;
+    mapAIStateToUIMessages?: (state: JsonObject | null) => UIMessage[];
 }
 interface AISDKChatStore {
-  createChat: () => Promise<string>;
-  loadChat: (chatId: string) => Promise<UIMessage[]>;
-  saveChat: (input: { chatId: string; messages: UIMessage[] }) => Promise<void>;
-  deleteChat: (chatId: string) => Promise<void>;
+    createChat: () => Promise<string>;
+    loadChat: (chatId: string) => Promise<UIMessage[]>;
+    saveChat: (input: {
+        chatId: string;
+        messages: UIMessage[];
+    }) => Promise<void>;
+    deleteChat: (chatId: string) => Promise<void>;
 }
 interface AISDKRSCStateStore {
-  loadAIState: () => Promise<JsonObject | null>;
-  saveAIState: (state: JsonObject | null) => Promise<void>;
-  onSetAIState: (params: { state: JsonObject | null; done: boolean }) => Promise<void>;
-  onGetUIState: () => Promise<UIMessage[]>;
+    loadAIState: () => Promise<JsonObject | null>;
+    saveAIState: (state: JsonObject | null) => Promise<void>;
+    onSetAIState: (params: {
+        state: JsonObject | null;
+        done: boolean;
+    }) => Promise<void>;
+    onGetUIState: () => Promise<UIMessage[]>;
 }
-declare function createAISDKChatStore(
-  client: AgentState,
-  options?: ChatStoreOptions,
-): AISDKChatStore;
-declare function createAISDKRSCStateStore(
-  client: AgentState,
-  options: RSCStoreOptions,
-): AISDKRSCStateStore;
+declare function createAISDKChatStore(client: AgentState, options?: ChatStoreOptions): AISDKChatStore;
+declare function createAISDKRSCStateStore(client: AgentState, options: RSCStoreOptions): AISDKRSCStateStore;
 
 export { type AISDKChatStore, type AISDKRSCStateStore, createAISDKChatStore, createAISDKRSCStateStore };

--- a/packages/sdk/dist/ai-sdk.mjs
+++ b/packages/sdk/dist/ai-sdk.mjs
@@ -1,6 +1,6 @@
 import {
   AgentStateError
-} from "./chunk-MKYN4MXF.mjs";
+} from "./chunk-6JBLXPTC.mjs";
 
 // src/ai-sdk.ts
 function buildChatKey(prefix, chatId) {

--- a/packages/sdk/dist/index.d.ts
+++ b/packages/sdk/dist/index.d.ts
@@ -1,343 +1,317 @@
 interface AgentStateConfig {
-  apiKey: string;
-  baseUrl?: string;
+    apiKey: string;
+    baseUrl?: string;
+    /** Max retry attempts for transient errors (429, 5xx, network). Default: 3 */
+    maxRetries?: number;
+    /** Base delay in ms for exponential backoff. Default: 1000 */
+    retryDelayMs?: number;
+    /** Request timeout in ms. Default: 30000 */
+    timeout?: number;
 }
 type JsonPrimitive = string | number | boolean | null;
 type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
 interface JsonObject {
-  [key: string]: JsonValue;
+    [key: string]: JsonValue;
 }
 interface Message {
-  id?: string;
-  role: "user" | "assistant" | "system" | "tool";
-  content: string;
-  metadata?: Record<string, unknown>;
-  token_count?: number;
-  created_at?: number;
+    id?: string;
+    role: "user" | "assistant" | "system" | "tool";
+    content: string;
+    metadata?: Record<string, unknown>;
+    token_count?: number;
+    created_at?: number;
 }
 interface Conversation {
-  id: string;
-  project_id: string;
-  external_id: string | null;
-  title: string | null;
-  metadata: Record<string, unknown> | null;
-  message_count: number;
-  token_count: number;
-  created_at: number;
-  updated_at: number;
+    id: string;
+    project_id: string;
+    external_id: string | null;
+    title: string | null;
+    metadata: Record<string, unknown> | null;
+    message_count: number;
+    token_count: number;
+    created_at: number;
+    updated_at: number;
 }
 interface ConversationWithMessages extends Conversation {
-  messages: Message[];
+    messages: Message[];
 }
 interface ListResponse<T> {
-  data: T[];
-  pagination: {
-    limit: number;
-    next_cursor: string | null;
-  };
+    data: T[];
+    pagination: {
+        limit: number;
+        next_cursor: string | null;
+    };
 }
 type StateOrder = "asc" | "desc";
 type StateEventType = "upsert" | "delete";
-type CapabilityTokenScope =
-  | "state:read"
-  | "state:write"
-  | "state:watch"
-  | "lease:write"
-  | "claim:write";
+type CapabilityTokenScope = "state:read" | "state:write" | "state:watch" | "lease:write" | "claim:write";
 type ClaimStatus = "pending" | "verified" | "failed";
 type ClaimEvidenceKind = "state_event" | "text_hash" | "json_value";
 interface StateListResponse<T> {
-  data: T[];
-  pagination: {
-    limit: number;
-    next_cursor: string | null;
-    total?: number;
-  };
+    data: T[];
+    pagination: {
+        limit: number;
+        next_cursor: string | null;
+        total?: number;
+    };
 }
 interface StateRecord {
-  state_key: string;
-  agent_id: string;
-  data: JsonObject;
-  metadata: JsonObject | null;
-  tags: string[];
-  latest_sequence: number;
-  created_at: number;
-  updated_at: number;
-  deleted_at: number | null;
+    state_key: string;
+    agent_id: string;
+    data: JsonObject;
+    metadata: JsonObject | null;
+    tags: string[];
+    latest_sequence: number;
+    created_at: number;
+    updated_at: number;
+    deleted_at: number | null;
 }
 interface UpsertStateRequest {
-  agent_id: string;
-  data: JsonObject;
-  metadata?: JsonObject;
-  tags?: string[];
-  lease_id?: string;
+    agent_id: string;
+    data: JsonObject;
+    metadata?: JsonObject;
+    tags?: string[];
+    lease_id?: string;
 }
 interface StateQueryPredicate {
-  path: string;
-  equals: JsonValue;
+    path: string;
+    equals: JsonValue;
 }
 interface StateQueryRequest {
-  agent_id?: string;
-  tags?: string[];
-  updated_after?: number;
-  updated_before?: number;
-  json_path?: string;
-  json_equals?: JsonValue;
-  predicates?: StateQueryPredicate[];
-  at_sequence?: number;
-  at_time?: number;
-  limit?: number;
-  cursor?: string;
-}
-interface StateEvent {
-  sequence: number;
-  id: string;
-  state_key: string;
-  agent_id: string;
-  event_type: StateEventType;
-  data: JsonObject | null;
-  metadata: JsonObject | null;
-  tags: string[];
-  idempotency_key: string | null;
-  created_at: number;
-}
-interface ListStateEventsParams {
-  after?: number;
-  limit?: number;
-}
-interface DeleteStateRequest {
-  lease_id?: string;
-}
-interface StateMutationResponse {
-  state?: StateRecord;
-  deleted?: true;
-  event: StateEvent;
-}
-interface CreateStateLeaseRequest {
-  holder: string;
-  ttl_ms?: number;
-}
-interface RenewStateLeaseRequest {
-  ttl_ms?: number;
-}
-interface StateLease {
-  id: string;
-  project_id: string;
-  state_key: string;
-  holder: string | null;
-  capability_token_id: string | null;
-  expires_at: number;
-  created_at: number;
-  renewed_at: number | null;
-  released_at: number | null;
-}
-interface CreateCapabilityTokenRequest {
-  name: string;
-  scopes: CapabilityTokenScope[];
-  expires_at?: number;
-}
-interface CapabilityToken {
-  id: string;
-  project_id: string;
-  name: string | null;
-  state_key: string | null;
-  token_prefix: string;
-  scopes: CapabilityTokenScope[];
-  expires_at: number | null;
-  created_at: number;
-  last_used_at: number | null;
-  revoked_at: number | null;
-}
-interface CapabilityTokenCreated extends CapabilityToken {
-  token: string;
-}
-interface CapabilityTokenListResponse {
-  data: CapabilityToken[];
-}
-interface TextHashClaimEvidenceInput {
-  kind: "text_hash";
-  source: string;
-  data: string;
-  hash: string;
-}
-interface JsonValueClaimEvidenceInput {
-  kind: "json_value";
-  source: string;
-  data: JsonValue;
-  json_path: string;
-  expected_value: JsonValue;
-}
-interface StateEventClaimEvidenceInput {
-  kind: "state_event";
-  source: string;
-  hash?: string;
-  json_path?: string;
-  expected_value?: JsonValue;
-}
-type ClaimEvidenceInput =
-  | TextHashClaimEvidenceInput
-  | JsonValueClaimEvidenceInput
-  | StateEventClaimEvidenceInput;
-interface CreateClaimRequest {
-  subject_type: string;
-  subject_id: string;
-  statement: string;
-  evidence: ClaimEvidenceInput[];
-}
-interface ClaimEvidence {
-  id: string;
-  project_id: string;
-  claim_id: string;
-  kind: ClaimEvidenceKind;
-  source: string;
-  data: unknown;
-  hash: string | null;
-  json_path: string | null;
-  expected_value: unknown;
-  created_at: number;
-}
-interface Claim {
-  id: string;
-  project_id: string;
-  subject_type: string;
-  subject_id: string;
-  statement: string;
-  status: ClaimStatus;
-  created_at: number;
-  updated_at: number;
-  evidence?: ClaimEvidence[];
-}
-interface ClaimVerificationEvidenceResult {
-  evidence_id: string;
-  kind: ClaimEvidenceKind;
-  source: string;
-  passed: boolean;
-  message: string;
-}
-interface ClaimVerificationRun {
-  id: string;
-  project_id: string;
-  claim_id: string;
-  status: Exclude<ClaimStatus, "pending">;
-  details: {
-    results: ClaimVerificationEvidenceResult[];
-  };
-  created_at: number;
-}
-interface ListClaimsParams {
-  subject_type?: string;
-  subject_id?: string;
-  cursor?: string;
-  limit?: number;
-  order?: StateOrder;
-}
-declare class AgentState {
-  private apiKey;
-  private baseUrl;
-  constructor(config: AgentStateConfig);
-  private request;
-  private withQuery;
-  createConversation(data: {
-    external_id?: string;
-    title?: string;
-    metadata?: Record<string, unknown>;
-    messages?: Omit<Message, "id" | "created_at">[];
-  }): Promise<ConversationWithMessages>;
-  getConversation(id: string): Promise<ConversationWithMessages>;
-  getConversationByExternalId(externalId: string): Promise<ConversationWithMessages>;
-  listConversations(params?: {
+    agent_id?: string;
+    tags?: string[];
+    updated_after?: number;
+    updated_before?: number;
+    json_path?: string;
+    json_equals?: JsonValue;
+    predicates?: StateQueryPredicate[];
+    at_sequence?: number;
+    at_time?: number;
     limit?: number;
     cursor?: string;
-    order?: "asc" | "desc";
-  }): Promise<ListResponse<Conversation>>;
-  updateConversation(
-    id: string,
-    data: {
-      title?: string;
-      metadata?: Record<string, unknown>;
-    },
-  ): Promise<Conversation>;
-  deleteConversation(id: string): Promise<void>;
-  appendMessages(
-    conversationId: string,
-    messages: Omit<Message, "id" | "created_at">[],
-  ): Promise<{
-    messages: Message[];
-  }>;
-  listMessages(
-    conversationId: string,
-    params?: {
-      limit?: number;
-      after?: string;
-    },
-  ): Promise<ListResponse<Message>>;
-  generateTitle(conversationId: string): Promise<{
-    title: string;
-  }>;
-  generateFollowUps(conversationId: string): Promise<{
-    questions: string[];
-  }>;
-  exportConversations(ids?: string[]): Promise<{
-    data: ConversationWithMessages[];
-    count: number;
-  }>;
-  upsertState(
-    stateKey: string,
-    data: UpsertStateRequest,
-    options?: {
-      idempotencyKey?: string;
-    },
-  ): Promise<StateRecord>;
-  getState(
-    stateKey: string,
-    params?: {
-      at_sequence?: number;
-      at_time?: number;
-    },
-  ): Promise<StateRecord>;
-  queryStates(query?: StateQueryRequest): Promise<StateListResponse<StateRecord>>;
-  deleteState(
-    stateKey: string,
-    params?: DeleteStateRequest & {
-      idempotencyKey?: string;
-    },
-  ): Promise<{
-    deleted: true;
+}
+interface StateEvent {
+    sequence: number;
+    id: string;
+    state_key: string;
+    agent_id: string;
+    event_type: StateEventType;
+    data: JsonObject | null;
+    metadata: JsonObject | null;
+    tags: string[];
+    idempotency_key: string | null;
+    created_at: number;
+}
+interface ListStateEventsParams {
+    after?: number;
+    limit?: number;
+}
+interface DeleteStateRequest {
+    lease_id?: string;
+}
+interface StateMutationResponse {
+    state?: StateRecord;
+    deleted?: true;
     event: StateEvent;
-  }>;
-  listStateEvents(
-    stateKey: string,
-    params?: ListStateEventsParams,
-    options?: {
-      capabilityToken?: string;
-    },
-  ): Promise<StateListResponse<StateEvent>>;
-  createStateLease(stateKey: string, data: CreateStateLeaseRequest): Promise<StateLease>;
-  renewStateLease(
-    id: string,
-    data?: RenewStateLeaseRequest,
-    options?: {
-      capabilityToken?: string;
-    },
-  ): Promise<StateLease>;
-  releaseStateLease(
-    id: string,
-    options?: {
-      capabilityToken?: string;
-    },
-  ): Promise<void>;
-  createCapabilityToken(data: CreateCapabilityTokenRequest): Promise<CapabilityTokenCreated>;
-  listCapabilityTokens(): Promise<CapabilityTokenListResponse>;
-  revokeCapabilityToken(id: string): Promise<void>;
-  createClaim(data: CreateClaimRequest): Promise<Claim>;
-  listClaims(params?: ListClaimsParams): Promise<StateListResponse<Claim>>;
-  getClaim(id: string): Promise<Claim>;
-  verifyClaim(id: string): Promise<ClaimVerificationRun>;
+}
+interface CreateStateLeaseRequest {
+    holder: string;
+    ttl_ms?: number;
+}
+interface RenewStateLeaseRequest {
+    ttl_ms?: number;
+}
+interface StateLease {
+    id: string;
+    project_id: string;
+    state_key: string;
+    holder: string | null;
+    capability_token_id: string | null;
+    expires_at: number;
+    created_at: number;
+    renewed_at: number | null;
+    released_at: number | null;
+}
+interface CreateCapabilityTokenRequest {
+    name: string;
+    scopes: CapabilityTokenScope[];
+    expires_at?: number;
+}
+interface CapabilityToken {
+    id: string;
+    project_id: string;
+    name: string | null;
+    state_key: string | null;
+    token_prefix: string;
+    scopes: CapabilityTokenScope[];
+    expires_at: number | null;
+    created_at: number;
+    last_used_at: number | null;
+    revoked_at: number | null;
+}
+interface CapabilityTokenCreated extends CapabilityToken {
+    token: string;
+}
+interface CapabilityTokenListResponse {
+    data: CapabilityToken[];
+}
+interface TextHashClaimEvidenceInput {
+    kind: "text_hash";
+    source: string;
+    data: string;
+    hash: string;
+}
+interface JsonValueClaimEvidenceInput {
+    kind: "json_value";
+    source: string;
+    data: JsonValue;
+    json_path: string;
+    expected_value: JsonValue;
+}
+interface StateEventClaimEvidenceInput {
+    kind: "state_event";
+    source: string;
+    hash?: string;
+    json_path?: string;
+    expected_value?: JsonValue;
+}
+type ClaimEvidenceInput = TextHashClaimEvidenceInput | JsonValueClaimEvidenceInput | StateEventClaimEvidenceInput;
+interface CreateClaimRequest {
+    subject_type: string;
+    subject_id: string;
+    statement: string;
+    evidence: ClaimEvidenceInput[];
+}
+interface ClaimEvidence {
+    id: string;
+    project_id: string;
+    claim_id: string;
+    kind: ClaimEvidenceKind;
+    source: string;
+    data: unknown;
+    hash: string | null;
+    json_path: string | null;
+    expected_value: unknown;
+    created_at: number;
+}
+interface Claim {
+    id: string;
+    project_id: string;
+    subject_type: string;
+    subject_id: string;
+    statement: string;
+    status: ClaimStatus;
+    created_at: number;
+    updated_at: number;
+    evidence?: ClaimEvidence[];
+}
+interface ClaimVerificationEvidenceResult {
+    evidence_id: string;
+    kind: ClaimEvidenceKind;
+    source: string;
+    passed: boolean;
+    message: string;
+}
+interface ClaimVerificationRun {
+    id: string;
+    project_id: string;
+    claim_id: string;
+    status: Exclude<ClaimStatus, "pending">;
+    details: {
+        results: ClaimVerificationEvidenceResult[];
+    };
+    created_at: number;
+}
+interface ListClaimsParams {
+    subject_type?: string;
+    subject_id?: string;
+    cursor?: string;
+    limit?: number;
+    order?: StateOrder;
+}
+interface ListConversationsParams {
+    limit?: number;
+    cursor?: string;
+    order?: StateOrder;
+    /** Exact-match filter: only return conversations tagged with this exact tag. */
+    tag?: string;
+}
+declare class AgentState {
+    private apiKey;
+    private baseUrl;
+    private maxRetries;
+    private retryDelayMs;
+    private timeoutMs;
+    constructor(config: AgentStateConfig);
+    private request;
+    private withQuery;
+    createConversation(data: {
+        external_id?: string;
+        title?: string;
+        metadata?: Record<string, unknown>;
+        messages?: Omit<Message, "id" | "created_at">[];
+    }): Promise<ConversationWithMessages>;
+    getConversation(id: string): Promise<ConversationWithMessages>;
+    getConversationByExternalId(externalId: string): Promise<ConversationWithMessages>;
+    listConversations(params?: ListConversationsParams): Promise<ListResponse<Conversation>>;
+    updateConversation(id: string, data: {
+        title?: string;
+        metadata?: Record<string, unknown>;
+    }): Promise<Conversation>;
+    deleteConversation(id: string): Promise<void>;
+    appendMessages(conversationId: string, messages: Omit<Message, "id" | "created_at">[]): Promise<{
+        messages: Message[];
+    }>;
+    listMessages(conversationId: string, params?: {
+        limit?: number;
+        after?: string;
+    }): Promise<ListResponse<Message>>;
+    generateTitle(conversationId: string): Promise<{
+        title: string;
+    }>;
+    generateFollowUps(conversationId: string): Promise<{
+        questions: string[];
+    }>;
+    exportConversations(ids?: string[]): Promise<{
+        data: ConversationWithMessages[];
+        count: number;
+    }>;
+    upsertState(stateKey: string, data: UpsertStateRequest, options?: {
+        idempotencyKey?: string;
+    }): Promise<StateRecord>;
+    getState(stateKey: string, params?: {
+        at_sequence?: number;
+        at_time?: number;
+    }): Promise<StateRecord>;
+    queryStates(query?: StateQueryRequest): Promise<StateListResponse<StateRecord>>;
+    deleteState(stateKey: string, params?: DeleteStateRequest & {
+        idempotencyKey?: string;
+    }): Promise<{
+        deleted: true;
+        event: StateEvent;
+    }>;
+    listStateEvents(stateKey: string, params?: ListStateEventsParams, options?: {
+        capabilityToken?: string;
+    }): Promise<StateListResponse<StateEvent>>;
+    createStateLease(stateKey: string, data: CreateStateLeaseRequest): Promise<StateLease>;
+    renewStateLease(id: string, data?: RenewStateLeaseRequest, options?: {
+        capabilityToken?: string;
+    }): Promise<StateLease>;
+    releaseStateLease(id: string, options?: {
+        capabilityToken?: string;
+    }): Promise<void>;
+    createCapabilityToken(data: CreateCapabilityTokenRequest): Promise<CapabilityTokenCreated>;
+    listCapabilityTokens(): Promise<CapabilityTokenListResponse>;
+    revokeCapabilityToken(id: string): Promise<void>;
+    createClaim(data: CreateClaimRequest): Promise<Claim>;
+    listClaims(params?: ListClaimsParams): Promise<StateListResponse<Claim>>;
+    getClaim(id: string): Promise<Claim>;
+    verifyClaim(id: string): Promise<ClaimVerificationRun>;
 }
 declare class AgentStateError extends Error {
-  code: string;
-  status: number;
-  constructor(message: string, code: string, status: number);
+    code: string;
+    status: number;
+    constructor(message: string, code: string, status: number);
 }
 
-export { AgentState, type AgentStateConfig, AgentStateError, type CapabilityToken, type CapabilityTokenCreated, type CapabilityTokenListResponse, type CapabilityTokenScope, type Claim, type ClaimEvidence, type ClaimEvidenceInput, type ClaimEvidenceKind, type ClaimStatus, type ClaimVerificationEvidenceResult, type ClaimVerificationRun, type Conversation, type ConversationWithMessages, type CreateCapabilityTokenRequest, type CreateClaimRequest, type CreateStateLeaseRequest, type DeleteStateRequest, type JsonObject, type JsonPrimitive, type JsonValue, type JsonValueClaimEvidenceInput, type ListClaimsParams, type ListResponse, type ListStateEventsParams, type Message, type RenewStateLeaseRequest, type StateEvent, type StateEventClaimEvidenceInput, type StateEventType, type StateLease, type StateListResponse, type StateMutationResponse, type StateOrder, type StateQueryPredicate, type StateQueryRequest, type StateRecord, type TextHashClaimEvidenceInput, type UpsertStateRequest };
+export { AgentState, type AgentStateConfig, AgentStateError, type CapabilityToken, type CapabilityTokenCreated, type CapabilityTokenListResponse, type CapabilityTokenScope, type Claim, type ClaimEvidence, type ClaimEvidenceInput, type ClaimEvidenceKind, type ClaimStatus, type ClaimVerificationEvidenceResult, type ClaimVerificationRun, type Conversation, type ConversationWithMessages, type CreateCapabilityTokenRequest, type CreateClaimRequest, type CreateStateLeaseRequest, type DeleteStateRequest, type JsonObject, type JsonPrimitive, type JsonValue, type JsonValueClaimEvidenceInput, type ListClaimsParams, type ListConversationsParams, type ListResponse, type ListStateEventsParams, type Message, type RenewStateLeaseRequest, type StateEvent, type StateEventClaimEvidenceInput, type StateEventType, type StateLease, type StateListResponse, type StateMutationResponse, type StateOrder, type StateQueryPredicate, type StateQueryRequest, type StateRecord, type TextHashClaimEvidenceInput, type UpsertStateRequest };

--- a/packages/sdk/dist/index.js
+++ b/packages/sdk/dist/index.js
@@ -24,6 +24,19 @@ __export(index_exports, {
   AgentStateError: () => AgentStateError
 });
 module.exports = __toCommonJS(index_exports);
+var IDEMPOTENT_METHODS = /* @__PURE__ */ new Set(["GET", "HEAD", "PUT", "DELETE", "OPTIONS"]);
+function parseRetryAfter(value) {
+  if (!value) return null;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) {
+    return Math.max(0, Math.round(seconds * 1e3));
+  }
+  const dateMs = Date.parse(value);
+  if (!Number.isNaN(dateMs)) {
+    return Math.max(0, dateMs - Date.now());
+  }
+  return null;
+}
 var AgentState = class {
   apiKey;
   baseUrl;
@@ -44,10 +57,20 @@ var AgentState = class {
       "Content-Type": "application/json",
       ...options?.headers
     };
+    const method = (options?.method ?? "GET").toUpperCase();
+    const hasIdempotencyKey = Object.keys(headers).some(
+      (key) => key.toLowerCase() === "idempotency-key"
+    );
+    const retriable = IDEMPOTENT_METHODS.has(method) || hasIdempotencyKey;
+    const maxRetries = retriable ? this.maxRetries : 0;
     let lastError = null;
-    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+    let nextDelayMs = null;
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
       if (attempt > 0) {
-        const delay = this.retryDelayMs * 2 ** (attempt - 1);
+        const backoff = this.retryDelayMs * 2 ** (attempt - 1);
+        const jittered = backoff + Math.floor(Math.random() * backoff);
+        const delay = nextDelayMs ?? jittered;
+        nextDelayMs = null;
         await new Promise((resolve) => setTimeout(resolve, delay));
       }
       try {
@@ -63,7 +86,10 @@ var AgentState = class {
         } finally {
           clearTimeout(timeoutId);
         }
-        if ((res.status === 429 || res.status >= 500) && attempt < this.maxRetries) {
+        if ((res.status === 429 || res.status >= 500) && attempt < maxRetries) {
+          if (res.status === 429) {
+            nextDelayMs = parseRetryAfter(res.headers.get("Retry-After"));
+          }
           lastError = new AgentStateError(
             `Retriable server error: ${res.status}`,
             "SERVER_ERROR",
@@ -84,7 +110,7 @@ var AgentState = class {
       } catch (error) {
         if (error instanceof AgentStateError) throw error;
         lastError = error;
-        if (attempt === this.maxRetries) throw lastError;
+        if (attempt === maxRetries) throw lastError;
       }
     }
     throw lastError;
@@ -219,7 +245,7 @@ var AgentState = class {
     return this.request("/v1/capability-tokens");
   }
   async revokeCapabilityToken(id) {
-    return this.request(`/v2/capability-tokens/${encodeURIComponent(id)}`, {
+    return this.request(`/v1/capability-tokens/${encodeURIComponent(id)}`, {
       method: "DELETE"
     });
   }

--- a/packages/sdk/dist/index.mjs
+++ b/packages/sdk/dist/index.mjs
@@ -1,7 +1,7 @@
 import {
   AgentState,
   AgentStateError
-} from "./chunk-MKYN4MXF.mjs";
+} from "./chunk-6JBLXPTC.mjs";
 export {
   AgentState,
   AgentStateError

--- a/packages/sdk/dist/langgraph.d.ts
+++ b/packages/sdk/dist/langgraph.d.ts
@@ -3,39 +3,29 @@ import { BaseCheckpointSaver, CheckpointTuple, CheckpointListOptions, Checkpoint
 import { AgentState } from './index.js';
 
 interface AGENTSTATELangGraphOptions {
-  agentId?: string;
-  stateKeyPrefix?: string;
+    agentId?: string;
+    stateKeyPrefix?: string;
 }
 type ListOptions = CheckpointListOptions & {
-  after?: string | RunnableConfig;
+    after?: string | RunnableConfig;
 };
 declare class AgentStateCheckpointSaver extends BaseCheckpointSaver {
-  private readonly client;
-  private readonly agentId;
-  private readonly stateKeyPrefix;
-  constructor(client: AgentState, options?: AGENTSTATELangGraphOptions);
-  private queryRecords;
-  private parseCheckpointState;
-  private parseWriteState;
-  private parseCheckpointTuple;
-  private parsePendingWrites;
-  private getLatestCheckpoint;
-  getTuple(config: RunnableConfig): Promise<CheckpointTuple | undefined>;
-  list(config: RunnableConfig, options?: ListOptions): AsyncGenerator<CheckpointTuple>;
-  put(
-    config: RunnableConfig,
-    checkpoint: Checkpoint | Record<string, unknown>,
-    metadata?: unknown,
-    newVersions?: ChannelVersions,
-  ): Promise<RunnableConfig>;
-  putWrites(
-    config: RunnableConfig,
-    writes: PendingWrite[],
-    taskId: string,
-    taskPath?: string,
-  ): Promise<void>;
-  private deleteRecords;
-  deleteThread(threadId: string): Promise<void>;
+    private readonly client;
+    private readonly agentId;
+    private readonly stateKeyPrefix;
+    constructor(client: AgentState, options?: AGENTSTATELangGraphOptions);
+    private queryRecords;
+    private parseCheckpointState;
+    private parseWriteState;
+    private parseCheckpointTuple;
+    private parsePendingWrites;
+    private getLatestCheckpoint;
+    getTuple(config: RunnableConfig): Promise<CheckpointTuple | undefined>;
+    list(config: RunnableConfig, options?: ListOptions): AsyncGenerator<CheckpointTuple>;
+    put(config: RunnableConfig, checkpoint: Checkpoint | Record<string, unknown>, metadata?: unknown, newVersions?: ChannelVersions): Promise<RunnableConfig>;
+    putWrites(config: RunnableConfig, writes: PendingWrite[], taskId: string, taskPath?: string): Promise<void>;
+    private deleteRecords;
+    deleteThread(threadId: string): Promise<void>;
 }
 
 export { type AGENTSTATELangGraphOptions, AgentStateCheckpointSaver };

--- a/packages/sdk/dist/langgraph.js
+++ b/packages/sdk/dist/langgraph.js
@@ -41,7 +41,6 @@ var AgentStateError = class extends Error {
 var DEFAULT_NAMESPACE = "";
 var DEFAULT_AGENT_ID = "agentstate-sdk";
 var DEFAULT_PREFIX = "agentstate/langgraph";
-var DEFAULT_LIST_LIMIT = 50;
 var PAGE_SIZE = 100;
 var BASE_RUNTIME = "langgraph";
 function checkpointIdFromConfig(value) {
@@ -330,7 +329,7 @@ var AgentStateCheckpointSaver = class extends import_langgraph_checkpoint.BaseCh
   async *list(config, options = {}) {
     const threadId = getThreadId(config);
     const checkpointNs = getStateKeyPrefix(config);
-    const limit = Math.min(options.limit ?? DEFAULT_LIST_LIMIT, PAGE_SIZE);
+    const limit = options.limit;
     const records = await this.queryRecords(threadId, checkpointNs, {
       kind: "checkpoint",
       limit,
@@ -338,7 +337,7 @@ var AgentStateCheckpointSaver = class extends import_langgraph_checkpoint.BaseCh
       before: options.before,
       filter: options.filter
     });
-    const filtered = records.slice(0, limit);
+    const filtered = limit === void 0 ? records : records.slice(0, limit);
     for (const state of filtered) {
       const tuple = this.parseCheckpointTuple(state);
       const pendingWrites = await this.parsePendingWrites(

--- a/packages/sdk/dist/langgraph.mjs
+++ b/packages/sdk/dist/langgraph.mjs
@@ -1,6 +1,6 @@
 import {
   AgentStateError
-} from "./chunk-MKYN4MXF.mjs";
+} from "./chunk-6JBLXPTC.mjs";
 
 // src/langgraph.ts
 import {
@@ -9,7 +9,6 @@ import {
 var DEFAULT_NAMESPACE = "";
 var DEFAULT_AGENT_ID = "agentstate-sdk";
 var DEFAULT_PREFIX = "agentstate/langgraph";
-var DEFAULT_LIST_LIMIT = 50;
 var PAGE_SIZE = 100;
 var BASE_RUNTIME = "langgraph";
 function checkpointIdFromConfig(value) {
@@ -298,7 +297,7 @@ var AgentStateCheckpointSaver = class extends BaseCheckpointSaver {
   async *list(config, options = {}) {
     const threadId = getThreadId(config);
     const checkpointNs = getStateKeyPrefix(config);
-    const limit = Math.min(options.limit ?? DEFAULT_LIST_LIMIT, PAGE_SIZE);
+    const limit = options.limit;
     const records = await this.queryRecords(threadId, checkpointNs, {
       kind: "checkpoint",
       limit,
@@ -306,7 +305,7 @@ var AgentStateCheckpointSaver = class extends BaseCheckpointSaver {
       before: options.before,
       filter: options.filter
     });
-    const filtered = records.slice(0, limit);
+    const filtered = limit === void 0 ? records : records.slice(0, limit);
     for (const state of filtered) {
       const tuple = this.parseCheckpointTuple(state);
       const pendingWrites = await this.parsePendingWrites(

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -28,9 +28,13 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
+    "@langchain/core": "^1.1.49",
     "@langchain/langgraph-checkpoint": "^1.1.1"
   },
   "peerDependenciesMeta": {
+    "@langchain/core": {
+      "optional": true
+    },
     "@langchain/langgraph-checkpoint": {
       "optional": true
     }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -351,7 +351,9 @@ export class AgentState {
         const backoff = this.retryDelayMs * 2 ** (attempt - 1);
         // Full jitter on the exponential backoff to avoid thundering herds.
         const jittered = backoff + Math.floor(Math.random() * backoff);
-        const delay = nextDelayMs ?? jittered;
+        // Clamp to 30s so a misconfigured/huge Retry-After can't hang the client
+        // (Workers execution limits especially).
+        const delay = Math.min(nextDelayMs ?? jittered, 30000);
         nextDelayMs = null;
         await new Promise((resolve) => setTimeout(resolve, delay));
       }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -284,6 +284,30 @@ type QueryParamValue =
   | undefined
   | readonly (string | number | boolean)[];
 
+/** HTTP methods that are safe to retry automatically without side effects. */
+const IDEMPOTENT_METHODS = new Set(["GET", "HEAD", "PUT", "DELETE", "OPTIONS"]);
+
+/**
+ * Parse an HTTP `Retry-After` header into a delay in milliseconds.
+ * Supports both delta-seconds (e.g. `"5"`) and HTTP-date formats.
+ * Returns null when the header is absent or unparseable.
+ */
+function parseRetryAfter(value: string | null): number | null {
+  if (!value) return null;
+
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) {
+    return Math.max(0, Math.round(seconds * 1000));
+  }
+
+  const dateMs = Date.parse(value);
+  if (!Number.isNaN(dateMs)) {
+    return Math.max(0, dateMs - Date.now());
+  }
+
+  return null;
+}
+
 export class AgentState {
   private apiKey: string;
   private baseUrl: string;
@@ -307,11 +331,28 @@ export class AgentState {
       ...(options?.headers as Record<string, string> | undefined),
     };
 
-    let lastError: Error | null = null;
+    // Only retry when it is safe to do so. Idempotent methods can always be
+    // replayed; a non-idempotent POST is only replayed when the caller supplied
+    // an Idempotency-Key, so the server can dedupe the retried request.
+    const method = (options?.method ?? "GET").toUpperCase();
+    const hasIdempotencyKey = Object.keys(headers).some(
+      (key) => key.toLowerCase() === "idempotency-key",
+    );
+    const retriable = IDEMPOTENT_METHODS.has(method) || hasIdempotencyKey;
+    const maxRetries = retriable ? this.maxRetries : 0;
 
-    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+    let lastError: Error | null = null;
+    // Delay to apply before the next attempt. Derived from Retry-After when the
+    // server provides it, otherwise exponential backoff with jitter.
+    let nextDelayMs: number | null = null;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
       if (attempt > 0) {
-        const delay = this.retryDelayMs * 2 ** (attempt - 1);
+        const backoff = this.retryDelayMs * 2 ** (attempt - 1);
+        // Full jitter on the exponential backoff to avoid thundering herds.
+        const jittered = backoff + Math.floor(Math.random() * backoff);
+        const delay = nextDelayMs ?? jittered;
+        nextDelayMs = null;
         await new Promise((resolve) => setTimeout(resolve, delay));
       }
 
@@ -331,7 +372,11 @@ export class AgentState {
         }
 
         // Retry on 429 and 5xx
-        if ((res.status === 429 || res.status >= 500) && attempt < this.maxRetries) {
+        if ((res.status === 429 || res.status >= 500) && attempt < maxRetries) {
+          // Honor Retry-After (seconds or HTTP-date) for the next delay.
+          if (res.status === 429) {
+            nextDelayMs = parseRetryAfter(res.headers.get("Retry-After"));
+          }
           lastError = new AgentStateError(
             `Retriable server error: ${res.status}`,
             "SERVER_ERROR",
@@ -355,7 +400,7 @@ export class AgentState {
         if (error instanceof AgentStateError) throw error;
         // Network errors — retry
         lastError = error as Error;
-        if (attempt === this.maxRetries) throw lastError;
+        if (attempt === maxRetries) throw lastError;
       }
     }
 

--- a/packages/sdk/src/langgraph.ts
+++ b/packages/sdk/src/langgraph.ts
@@ -70,7 +70,6 @@ type ListOptions = CheckpointListOptions & {
 const DEFAULT_NAMESPACE = "";
 const DEFAULT_AGENT_ID = "agentstate-sdk";
 const DEFAULT_PREFIX = "agentstate/langgraph";
-const DEFAULT_LIST_LIMIT = 50;
 const PAGE_SIZE = 100;
 const BASE_RUNTIME = "langgraph";
 
@@ -484,7 +483,10 @@ export class AgentStateCheckpointSaver extends BaseCheckpointSaver {
   async *list(config: RunnableConfig, options: ListOptions = {}): AsyncGenerator<CheckpointTuple> {
     const threadId = getThreadId(config);
     const checkpointNs = getStateKeyPrefix(config);
-    const limit = Math.min(options.limit ?? DEFAULT_LIST_LIMIT, PAGE_SIZE);
+    // Honor the caller's requested limit exactly. `queryRecords` transparently
+    // follows `next_cursor` across pages (PAGE_SIZE per request) until the
+    // requested limit is reached, or fetches all records when no limit is set.
+    const limit = options.limit;
 
     const records = await this.queryRecords(threadId, checkpointNs, {
       kind: "checkpoint",
@@ -494,7 +496,7 @@ export class AgentStateCheckpointSaver extends BaseCheckpointSaver {
       filter: options.filter,
     });
 
-    const filtered = records.slice(0, limit);
+    const filtered = limit === undefined ? records : records.slice(0, limit);
 
     for (const state of filtered) {
       const tuple = this.parseCheckpointTuple(state);

--- a/packages/sdk/tests/langgraph.test.ts
+++ b/packages/sdk/tests/langgraph.test.ts
@@ -83,6 +83,49 @@ describe("AgentState LangGraph saver", () => {
     expect(tuples[0].config.configurable.checkpoint_id).toBe("cp-2");
   });
 
+  it("follows next_cursor across pages beyond a single page for large limits", async () => {
+    const makeState = (id: string, sequence: number) => ({
+      ...CHECKPOINT_STATE,
+      state_key: `agentstate/langgraph/thread-1/default/${id}`,
+      data: { ...CHECKPOINT_STATE.data, checkpoint_id: id },
+      latest_sequence: sequence,
+    });
+
+    // 150 checkpoints split across two pages (100 + 50) — exceeds the 100-record
+    // page size, which previously clamped list() output to 100 with no continuation.
+    const page1 = Array.from({ length: 100 }, (_, i) => makeState(`cp-${i}`, 1000 - i));
+    const page2 = Array.from({ length: 50 }, (_, i) => makeState(`cp-${100 + i}`, 900 - i));
+
+    const queryStates = vi.fn(async (q: { predicates?: Array<{ path: string; equals: unknown }>; cursor?: string }) => {
+      const kind = q.predicates?.find((p) => p.path === "$.kind")?.equals;
+      if (kind === "checkpoint-writes") {
+        return { data: [], pagination: { next_cursor: null } };
+      }
+      if (!q.cursor) {
+        return { data: page1, pagination: { next_cursor: "cursor-2" } };
+      }
+      if (q.cursor === "cursor-2") {
+        return { data: page2, pagination: { next_cursor: null } };
+      }
+      return { data: [], pagination: { next_cursor: null } };
+    });
+
+    const client = { queryStates, getState: vi.fn(), upsertState: vi.fn(), deleteState: vi.fn() };
+    const saver = new AgentStateCheckpointSaver(client as any);
+
+    const tuples = [];
+    for await (const tuple of saver.list({ configurable: { thread_id: "thread-1" } }, { limit: 150 })) {
+      tuples.push(tuple);
+    }
+
+    expect(tuples.length).toBe(150);
+    // Proves continuation: the second page was fetched using the returned cursor.
+    const checkpointCalls = queryStates.mock.calls.filter(
+      ([q]: [any]) => q.predicates?.find((p: any) => p.path === "$.kind")?.equals === "checkpoint",
+    );
+    expect(checkpointCalls.some(([q]: [any]) => q.cursor === "cursor-2")).toBe(true);
+  });
+
   it("supports list filter predicates", async () => {
     const first = { ...CHECKPOINT_STATE, data: { ...CHECKPOINT_STATE.data, runtime: "langgraph" } };
     const second = {

--- a/packages/sdk/tests/retry.test.ts
+++ b/packages/sdk/tests/retry.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AgentState, AgentStateError } from "../src/index";
+
+type MockResponse = {
+  status: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+};
+
+function makeSequencedFetch(responses: MockResponse[]) {
+  let call = 0;
+  return vi.fn(async () => {
+    const spec = responses[Math.min(call, responses.length - 1)]!;
+    call += 1;
+    return new Response(JSON.stringify(spec.body ?? {}), {
+      status: spec.status,
+      headers: { "content-type": "application/json", ...(spec.headers ?? {}) },
+    });
+  });
+}
+
+describe("SDK retry policy", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  it("retries idempotent GET requests on 5xx until success", async () => {
+    const fetchMock = makeSequencedFetch([
+      { status: 500 },
+      { status: 500 },
+      { status: 200, body: { id: "conv_1", messages: [] } },
+    ]);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+
+    const client = new AgentState({ apiKey: "as_live_test", retryDelayMs: 1 });
+    const result = await client.getConversation("conv_1");
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(result).toMatchObject({ id: "conv_1" });
+  });
+
+  it("retries idempotent PUT (upsertState) on 5xx", async () => {
+    const fetchMock = makeSequencedFetch([
+      { status: 500 },
+      { status: 200, body: { state_key: "k", agent_id: "a", data: {} } },
+    ]);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+
+    const client = new AgentState({ apiKey: "as_live_test", retryDelayMs: 1 });
+    await client.upsertState("k", { agent_id: "a", data: {} });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT retry non-idempotent POST without an idempotency key", async () => {
+    const fetchMock = makeSequencedFetch([
+      { status: 500, body: { error: { code: "INTERNAL", message: "boom" } } },
+    ]);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+
+    const client = new AgentState({ apiKey: "as_live_test", retryDelayMs: 1 });
+
+    await expect(client.createConversation({ title: "x" })).rejects.toBeInstanceOf(AgentStateError);
+    // POST is not replayed — a single attempt only.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("honors Retry-After on 429 and eventually succeeds for GET", async () => {
+    const fetchMock = makeSequencedFetch([
+      { status: 429, headers: { "Retry-After": "0" } },
+      { status: 200, body: { id: "conv_1", messages: [] } },
+    ]);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+
+    const client = new AgentState({ apiKey: "as_live_test", retryDelayMs: 1 });
+    const result = await client.getConversation("conv_1");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ id: "conv_1" });
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -120,10 +120,14 @@ export interface TraceDetailResponse extends ConversationResponse {
 
 // API response wrappers
 
+export interface ListPagination {
+  limit: number;
+  next_cursor: string | null;
+}
+
 export interface ListResponse<T> {
   data: T[];
-  has_more: boolean;
-  next_cursor: string | null;
+  pagination: ListPagination;
 }
 
 export interface ErrorResponse {


### PR DESCRIPTION
Fixes the 22 issues filed from the deep codebase analysis. Quality gates green locally: Biome clean, `tsc` clean, **API vitest 353 passed** (+12 new), TS SDK 17 passed, MCP 11 passed, python-sdk 57 passed.

## Security — API
- **Closes #254** (critical, tenancy) — org-less Clerk sessions now derive a per-user org (`personal:${clerkUserId}`) instead of a shared `"default"` sentinel; removed the `?? "default"` fallbacks. Test proves user A cannot see user B's org-less projects and that they map to distinct internal orgs.
- **Closes #255** (SSRF) — new `lib/url-safety.ts` (https-only; blocks loopback/private/link-local/`::1`/`fc00::/7`/localhost), enforced in the Create/Update webhook schemas **and** again before delivery in `webhook.ts`. Parametrized rejection tests added.
- **Closes #257** — `requireScope("analytics:read")` added to the public analytics routes (403 for a `state:read`-only key, 200 with `analytics:read`).
- **Closes #263** — constant-time `client_secret` verification (basic + post) for confidential OAuth clients; public/PKCE and unknown-client paths unchanged.
- **Closes #264** — per-IP rate limit on `POST /oauth/register`. The SSE `?token=` path was verified: the error handler logs `c.req.path` (query-stripped), so no token leaks — no code change needed there.

## Correctness / reliability — API
- **Closes #256** — atomic lease acquisition via a partial unique index `(project_id, state_key) WHERE released_at IS NULL` + guarded conditional insert → `LEASE_CONFLICT` on violation. Migration `0008_amusing_nightshade.sql` regenerated via drizzle-kit.
- **Closes #258** — `ESCAPE '\'` added to search LIKE; dropped the invalid `[` escaping.
- **Closes #261** — composite `(timestamp, id)` cursors + matching `ORDER BY` for search and claims.
- **Closes #260** — `GET /conversations/:id` orders messages by `(created_at, rowid)`, bounded at 1000.
- **Closes #262** — `deleteProject` explicitly deletes every child table and returns capability-token hashes for cache invalidation.
- **Addresses #259** (partial) — confirmed the **default** limiter path is already the atomic D1 fixed-window; documented the KV sliding-window's non-atomicity and kept it opt-in behind `USE_SLIDING_WINDOW`. A full Durable-Object sliding window is left as follow-up, so this issue stays open.

## SDK / MCP / shared / dashboard
- **Closes #265** — root cause confirmed (`AsyncBaseCheckpointSaver` doesn't exist in langgraph-checkpoint 4.x); split imports so a missing symbol no longer discards both base classes. Integration test added.
- **Closes #266** — dashboard `useMessages` no longer keeps stale messages on conversation switch (removed the `loaded` ref, added an `ignore` cleanup flag).
- **Closes #267** — python SDK normalizes 400/403 and wraps all non-2xx in `AgentStateError`, parsing the `{error:{code,message}}` body.
- **Closes #268** — python SDK gains a configurable `timeout` (default ~30s).
- **Closes #269** — unified default base URL across the clients.
- **Closes #270** — LangGraph `list()` paginates across cursors instead of clamping at 100.
- **Closes #271** — MCP `apiRequest` gains an `AbortController` timeout (`AGENTSTATE_TIMEOUT_MS`).
- **Closes #272** — retries restricted to idempotent methods / `Idempotency-Key` on retried POSTs.
- **Closes #273** — `shared` `ListResponse<T>` reconciled to the real `{ data, pagination: { limit, next_cursor } }`.
- **Closes #274** — honor `Retry-After` on 429 + backoff jitter.
- **Closes #275** — `@langchain/core` added as an optional peer dependency.

Commits are grouped by subsystem, each with the repo's dual co-author trailers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8P4aYCrgJKpTu4Ti9zmmk)_