### PR TITLE
feat: enable Cloudflare Workers Cache for public read-only endpoints

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -26,6 +26,7 @@
 | [Environment Variables](environment-variables.md) | Env vars and Cloudflare bindings |
 | [Data Handling & Ownership](data-handling.md) | What data is stored, export, deletion controls, retention, and self-hosting |
 | [Core Memory](knowledge/core-memory.md) | Durable maintenance notes for future agents |
+| [Workers Cache](knowledge/workers-cache.md) | Cloudflare Workers Cache: what's enabled, which public endpoints are cached, why authed routes are not |
 | [Recipe: Leases](recipes/leases.md) | Distributed locking — coordinate N agents with exactly-one-writer semantics |
 | [Recipe: Claims](recipes/claims.md) | Verifiable agent output — attest and audit work with evidence |
 | [Recipe: Capability Tokens](recipes/capability-tokens.md) | Scoped sub-agent delegation — least-privilege tokens for untrusted processes |

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -12,6 +12,7 @@ Durable notes for recurring maintenance. Keep this file small and update it inst
 - In sandboxed maintenance runs, set Bun and Wrangler writable paths when needed: `BUN_TMPDIR=/private/tmp/codex-bun-tmp`, `BUN_INSTALL_CACHE_DIR=/private/tmp/codex-bun-cache`, and `XDG_CONFIG_HOME=/private/tmp/codex-wrangler-config`.
 - Root `bun run deploy` should delegate to `cd packages/api && bun run deploy`, and the API deploy script must prepare `wrangler.deploy.jsonc` first so deploys can omit unavailable Vectorize or cron bindings without editing `wrangler.jsonc`.
 - Validate dashboard changes with `cd packages/dashboard && bun run build`; raw `bunx tsc --noEmit` can fail in fresh checkouts before Next generates route type files.
+- Workers Cache is enabled (`"cache": { "enabled": true }` in `packages/api/wrangler.jsonc`). Only the public static GETs (`/api`, `/llms.txt`, `/agents.md`, `/openapi.json`) set `Cache-Control: public`; every Bearer-authed / per-project route stays uncacheable (and auto-bypasses on the `Authorization` header). Details + the rule: `docs/knowledge/workers-cache.md`.
 
 ## Review Memory
 

--- a/docs/knowledge/workers-cache.md
+++ b/docs/knowledge/workers-cache.md
@@ -1,0 +1,66 @@
+# Workers Cache
+
+Durable note on how AgentState uses Cloudflare **Workers Cache** (launched
+2026-07-06, https://blog.cloudflare.com/workers-cache/).
+
+## What it is
+
+A tiered cache that sits **in front of** the Worker. Enable it per-worker in the
+wrangler config, then control it entirely with standard HTTP response headers.
+Key safety facts:
+
+- Only responses that are **explicitly cacheable** (e.g. `Cache-Control: public,
+  max-age=...`) are stored. Responses with no public cache directive are never
+  cached — so merely enabling the feature is safe by default.
+- Requests carrying an `Authorization` header are **automatically bypassed** and
+  never cached. AgentState's API auth is `Authorization: Bearer as_live_...`, so
+  every authenticated / per-project / per-key route auto-bypasses.
+- On a cache **HIT** the Worker doesn't run (no CPU billing). MISS/BYPASS run
+  normally. `Cache-Control: ..., stale-while-revalidate=<s>` serves stale
+  instantly while refreshing in the background.
+
+## How it's enabled here
+
+`packages/api/wrangler.jsonc` has a top-level:
+
+```jsonc
+"cache": { "enabled": true }
+```
+
+## What is cached (public, read-only, non-user-specific only)
+
+Set in `packages/api/src/index.ts`:
+
+| Endpoint | `Cache-Control` | Why safe |
+|----------|-----------------|----------|
+| `GET /api` (health) | `public, max-age=60, stale-while-revalidate=300` | Static health payload, no auth, no user data |
+| `GET /llms.txt` | `public, max-age=300, stale-while-revalidate=3600` | Static agent-readable content, changes only on deploy |
+| `GET /agents.md` | `public, max-age=300, stale-while-revalidate=3600` | Static agent-readable content |
+| `GET /openapi.json` | `public, max-age=300, stale-while-revalidate=3600` | Static API spec |
+
+## What is intentionally NOT cached
+
+Everything authenticated, per-user, or mutating — no `Cache-Control: public` is
+ever set on these, and the `Authorization: Bearer` header makes Workers Cache
+bypass them anyway:
+
+- `/api/v1/conversations`, `/api/v1/projects`, `/api/v1/states`, `/api/v1/leases`,
+  `/api/v1/capability-tokens`, `/api/v1/claims`, `/api/v1/organizations`,
+  `/api/v1/keys`, `/api/v1/tags`, `/api/v1/webhooks`, the MCP server, OAuth
+  endpoints — all Bearer-authed and/or per-project.
+- `/api/v1/analytics/*` (`routes/analytics-public.ts`) — despite the "public"
+  name it runs `apiKeyAuth` + a required read scope and returns **per-project**
+  aggregates. Never cache it publicly.
+- All POST/PATCH/DELETE routes.
+
+## Rule
+
+Only add `Cache-Control: public, ...` to genuinely public, unauthenticated,
+non-user-specific GET responses. When in doubt, leave it uncacheable — the
+default (no directive) is not cached.
+
+## Purging
+
+From inside the owning entrypoint: `await ctx.cache.purge({ tags: [...] })` /
+`{ prefix: "/x" }` / `{ purgeEverything: true }`. Not currently wired up; the
+short TTLs above make the cached set self-heal on deploy without manual purges.

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -94,6 +94,10 @@ app.use("/api/v1/organizations/*", clerkDashboardAuth);
 // ---------------------------------------------------------------------------
 
 app.get("/api", (c) => {
+  // Public, unauthenticated health check — safe to cache briefly. Workers Cache
+  // stores this on a HIT (no Authorization header); SWR serves stale instantly
+  // while revalidating. See docs/knowledge/workers-cache.md.
+  c.header("Cache-Control", "public, max-age=60, stale-while-revalidate=300");
   return c.json({ name: "agentstate", version: "0.1.0", status: "ok" });
 });
 
@@ -101,9 +105,23 @@ app.get("/api", (c) => {
 // Agent-readable endpoints
 // ---------------------------------------------------------------------------
 
-app.get("/llms.txt", (c) => c.text(LLMS_TXT));
-app.get("/agents.md", (c) => c.text(AGENTS_MD));
-app.get("/openapi.json", (c) => c.json(JSON.parse(OPENAPI_SPEC)));
+// Static, public agent-readable content — changes only on deploy, so cache it
+// for longer with SWR. These carry no user-specific data. See
+// docs/knowledge/workers-cache.md.
+const STATIC_CACHE_CONTROL = "public, max-age=300, stale-while-revalidate=3600";
+
+app.get("/llms.txt", (c) => {
+  c.header("Cache-Control", STATIC_CACHE_CONTROL);
+  return c.text(LLMS_TXT);
+});
+app.get("/agents.md", (c) => {
+  c.header("Cache-Control", STATIC_CACHE_CONTROL);
+  return c.text(AGENTS_MD);
+});
+app.get("/openapi.json", (c) => {
+  c.header("Cache-Control", STATIC_CACHE_CONTROL);
+  return c.json(JSON.parse(OPENAPI_SPEC));
+});
 
 // ---------------------------------------------------------------------------
 // Remote MCP server (Streamable HTTP) at /api/mcp

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -110,6 +110,10 @@ app.get("/api", (c) => {
 // docs/knowledge/workers-cache.md.
 const STATIC_CACHE_CONTROL = "public, max-age=300, stale-while-revalidate=3600";
 
+// The OpenAPI spec is static — parse it once at module load (Worker startup)
+// instead of on every request, so cache misses/bypasses pay no re-parse cost.
+const PARSED_OPENAPI_SPEC = JSON.parse(OPENAPI_SPEC);
+
 app.get("/llms.txt", (c) => {
   c.header("Cache-Control", STATIC_CACHE_CONTROL);
   return c.text(LLMS_TXT);
@@ -120,7 +124,7 @@ app.get("/agents.md", (c) => {
 });
 app.get("/openapi.json", (c) => {
   c.header("Cache-Control", STATIC_CACHE_CONTROL);
-  return c.json(JSON.parse(OPENAPI_SPEC));
+  return c.json(PARSED_OPENAPI_SPEC);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -15,6 +15,15 @@
     "enabled": true
   },
 
+  // Workers Cache — tiered cache in front of the Worker. Only responses with
+  // explicit public cache directives (Cache-Control: public, ...) are stored;
+  // Authorization-bearing requests (our Bearer as_live_ API auth) are always
+  // bypassed. So enabling this is safe: authed/per-user routes are never cached.
+  // See docs/knowledge/workers-cache.md.
+  "cache": {
+    "enabled": true
+  },
+
   "d1_databases": [
     {
       "binding": "DB",


### PR DESCRIPTION
## What

Enables **Cloudflare Workers Cache** ([blog](https://blog.cloudflare.com/workers-cache/), launched 2026-07-06) on the AgentState API Worker and marks the genuinely public, unauthenticated GETs as cacheable.

- `packages/api/wrangler.jsonc` — add top-level `"cache": { "enabled": true }`.
- `packages/api/src/index.ts` — set `Cache-Control: public` on the static public GETs only:
  - `GET /api` (health) → `public, max-age=60, stale-while-revalidate=300`
  - `GET /llms.txt`, `GET /agents.md`, `GET /openapi.json` → `public, max-age=300, stale-while-revalidate=3600`

## Why

When the Worker is the origin, every request re-runs the app even when the response is identical. Workers Cache serves a HIT without invoking the Worker (0 CPU) and `stale-while-revalidate` refreshes in the background so no user waits.

## Safety

- Enabling the flag is a no-op until a response sets a **public** `Cache-Control` — nothing else is cached implicitly.
- All Bearer-authed / per-project / mutating routes (`/api/v1/conversations`, `/projects`, `/states`, `/leases`, `/keys`, MCP, OAuth, and all POST/PATCH/DELETE) set **no** public directive and additionally **auto-bypass** on the `Authorization: Bearer as_live_…` header, so they can never be cached.
- `/api/v1/analytics/*` (`routes/analytics-public.ts`) is *not* cached despite its name — it runs `apiKeyAuth` + a read scope and returns per-project aggregates. Verified and documented.
- No changes to `compatibility_date`, bindings, ids, or secrets.

## Docs

`docs/knowledge/workers-cache.md` (new) + pointer in `docs/knowledge/core-memory.md` and `docs/INDEX.md`.

## Verification

- `bunx biome check packages/api/src/index.ts` → exit 0
- `bunx tsc --noEmit -p packages/api/tsconfig.json` → exit 0

> Note: requires a Wrangler version with Workers Cache support (the `cache` config key) at deploy time.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fmi52VxTzLjDqZqj4f9QKd)_