### PR TITLE
feat(dashboard): shadcn/ui redesign — landing page, dashboard spacing, chat components

### DIFF
--- a/packages/dashboard/src/components/analytics/area-chart.tsx
+++ b/packages/dashboard/src/components/analytics/area-chart.tsx
@@ -173,7 +173,7 @@ export function AreaChartCard({
   }, []);
 
   return (
-    <Card className="flex flex-col gap-4 p-5">
+    <Card className="flex flex-col gap-4 p-6">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="flex flex-col gap-1">
           <p className="font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4">{title}</p>

--- a/packages/dashboard/src/components/analytics/summary-cards.tsx
+++ b/packages/dashboard/src/components/analytics/summary-cards.tsx
@@ -83,7 +83,7 @@ export function SummaryCards({
       {stats.map((s) => {
         const IconComp = s.icon;
         return (
-          <Card key={s.label} className="flex flex-col gap-4 p-5">
+          <Card key={s.label} className="flex flex-col gap-4 p-6">
             <div className="flex items-start justify-between gap-2">
               <div className="flex flex-col gap-1.5">
                 <p className="font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4">

--- a/packages/dashboard/src/components/dashboard/analytics/_metric-card.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_metric-card.tsx
@@ -23,7 +23,7 @@ export function MetricCard({
   iconColor = "text-accent",
 }: MetricCardProps) {
   return (
-    <Card className="flex h-full flex-col gap-4 p-5">
+    <Card className="flex h-full flex-col gap-4 p-6">
       <div className="flex items-start justify-between gap-2">
         <div className="flex flex-col gap-1">
           <h3 className="text-[14px] font-medium text-fg">{title}</h3>

--- a/packages/dashboard/src/components/dashboard/analytics/_top-conversations.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/_top-conversations.tsx
@@ -36,7 +36,7 @@ export function TopConversations({ conversations, limit = 5 }: TopConversationsP
   }
 
   return (
-    <Card className="h-full p-5">
+    <Card className="h-full p-6">
       <div className="flex flex-col gap-1">
         <h3 className="text-[14px] font-medium text-fg">Top Conversations</h3>
         <p className="font-mono text-[11px] uppercase tracking-[0.1em] text-fg-4">

--- a/packages/dashboard/src/components/dashboard/analytics/analytics-page-content.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/analytics-page-content.tsx
@@ -36,7 +36,7 @@ export function AnalyticsPageContent() {
   const loading = loadingProjects || loadingAnalytics;
 
   return (
-    <div className="flex flex-col gap-6 px-4 lg:px-6">
+    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
       <AnalyticsHeader range={range} onRangeChange={setRange} />
 
       {loading && <AnalyticsLoading hasData={!!data} />}

--- a/packages/dashboard/src/components/dashboard/conversations/conversations-page.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/conversations-page.tsx
@@ -17,8 +17,8 @@ function PageHeader({
   return (
     <header className="mb-[22px] flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
       <div className="flex max-w-2xl flex-col gap-1.5">
-        <h1 className="text-[26px] tracking-tight text-fg">{title}</h1>
-        <p className="text-[14.5px] leading-6 text-fg-3">{description}</p>
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">{title}</h1>
+        <p className="text-sm text-muted-foreground">{description}</p>
       </div>
       {actions && <div className="flex flex-wrap items-center gap-2 sm:justify-end">{actions}</div>}
     </header>
@@ -53,7 +53,7 @@ function ConversationsContent() {
   const showLoadMore = hasMore && conversations.length > 0;
 
   return (
-    <div className="px-5 sm:px-7">
+    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
       <PageHeader
         title="Conversations"
         description={

--- a/packages/dashboard/src/components/dashboard/domains/domains-content.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/domains-content.tsx
@@ -41,7 +41,7 @@ export function DomainsContent() {
     <Suspense
       fallback={<div className="h-32 animate-pulse rounded-[var(--radius-lg)] bg-panel2" />}
     >
-      <div className="flex flex-col gap-component px-4 py-7 lg:px-6">
+      <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
         <PageHeader
           title="Custom Domains"
           description="Add a custom domain to serve your project from your own domain with SSL."

--- a/packages/dashboard/src/components/dashboard/integrate/integrate-content.tsx
+++ b/packages/dashboard/src/components/dashboard/integrate/integrate-content.tsx
@@ -135,7 +135,7 @@ export default function IntegrateContent() {
   const isCurl = fw === "rest";
 
   return (
-    <div className="flex flex-col gap-5 px-4 lg:px-6">
+    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
       <PageHeader
         title="Integrate"
         description="Pick your framework — copy the adapter and you're persisting state."

--- a/packages/dashboard/src/components/dashboard/keys/keys-page.tsx
+++ b/packages/dashboard/src/components/dashboard/keys/keys-page.tsx
@@ -82,7 +82,7 @@ function KeysContent() {
   };
 
   return (
-    <div className="flex flex-col space-y-section page-padding section-padding">
+    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
       <PageHeader
         title="API Keys"
         description="Project-scoped keys your agents use to authenticate against the API. Keep them secret."
@@ -100,7 +100,7 @@ function KeysContent() {
       />
 
       {/* Active project selector — shares ProjectScope with the sidebar */}
-      <Card className="flex flex-col gap-2 p-4 sm:flex-row sm:items-center sm:justify-between">
+      <Card className="flex flex-col gap-2 p-6 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-2.5">
           <span className="as-label-sm text-fg-4">Project</span>
           {loadingProjects ? (

--- a/packages/dashboard/src/components/dashboard/organizations/create/_create-org-loading.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/_create-org-loading.tsx
@@ -3,7 +3,7 @@ import { Card } from "@/components/ui/card";
 
 export function CreateOrgLoading() {
   return (
-    <div className="page-padding flex flex-col gap-section py-7">
+    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
       <div className="flex items-start gap-3">
         <span className="mt-0.5 grid size-8 shrink-0 place-items-center rounded-[var(--radius)] text-fg-4">
           <ArrowLeftIcon className="size-4" aria-hidden="true" />

--- a/packages/dashboard/src/components/dashboard/organizations/create/create-org-content.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/create-org-content.tsx
@@ -31,7 +31,7 @@ export function CreateOrgContent() {
   const existingOrgDomain = advisory?.meta?.organization_domain;
 
   return (
-    <div className="page-padding flex flex-col gap-section py-7">
+    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
       <CreateOrgHeader />
       <CreateOrgForm
         organizationName={organizationName}

--- a/packages/dashboard/src/components/dashboard/organizations/list/organizations-list-content.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/list/organizations-list-content.tsx
@@ -28,7 +28,7 @@ export function OrganizationsListContent() {
 
   if (!isUserLoaded || !isOrgListLoaded) {
     return (
-      <div className="page-padding flex flex-col gap-section py-7">
+      <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
         <PageHeader title="Organizations" description="Manage your organizations and members" />
         <OrgListSkeleton />
       </div>
@@ -40,7 +40,7 @@ export function OrganizationsListContent() {
   }
 
   return (
-    <div className="page-padding flex flex-col gap-section py-7">
+    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
       <PageHeader
         title="Organizations"
         description="Manage your organizations and members"

--- a/packages/dashboard/src/components/dashboard/organizations/members/members-content.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/members-content.tsx
@@ -65,7 +65,7 @@ export function MembersContent() {
   // Loading state
   if (!isUserLoaded || !isOrgListLoaded || !isOrgLoaded) {
     return (
-      <div className="page-padding flex flex-col gap-section py-7">
+      <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
         <_PageHeader isLoading />
         <_MembersSkeleton />
       </div>
@@ -75,7 +75,7 @@ export function MembersContent() {
   // Not signed in or no organization
   if (!isSignedIn || !organization) {
     return (
-      <div className="page-padding flex flex-col gap-section py-7">
+      <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
         <_PageHeader />
         <Card className="card-padding flex flex-col gap-tight">
           <h2 className="text-[16px] font-semibold text-fg">No organization selected</h2>
@@ -88,7 +88,7 @@ export function MembersContent() {
   }
 
   return (
-    <div className="page-padding flex flex-col gap-section py-7">
+    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
       <_PageHeader organizationName={organization.name} />
       <InviteMemberForm isInviting={isInviting} onInvite={inviteMember} />
       <MembersList

--- a/packages/dashboard/src/components/dashboard/page-header.tsx
+++ b/packages/dashboard/src/components/dashboard/page-header.tsx
@@ -51,8 +51,8 @@ export function PageHeader({ title, description, actions }: PageHeaderProps) {
   return (
     <header className="mb-[22px] flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
       <div className="flex max-w-2xl flex-col gap-1.5">
-        <h1 className="text-[26px] tracking-tight text-fg">{title}</h1>
-        {description && <p className="text-[14.5px] leading-6 text-fg-3">{description}</p>}
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">{title}</h1>
+        {description && <p className="text-sm text-muted-foreground">{description}</p>}
       </div>
       {actions && <div className="flex flex-wrap items-center gap-2 sm:justify-end">{actions}</div>}
     </header>

--- a/packages/dashboard/src/components/dashboard/project/_api-keys-table.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_api-keys-table.tsx
@@ -72,7 +72,9 @@ export function ApiKeysTable({ keys, onRevoke }: ApiKeysTableProps) {
             <TableHead>Key</TableHead>
             <TableHead className="hidden md:table-cell">Permissions</TableHead>
             <TableHead className="hidden sm:table-cell">Last used</TableHead>
-            <TableHead className="w-10" />
+            <TableHead className="w-10">
+              <span className="sr-only">Actions</span>
+            </TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/packages/dashboard/src/components/dashboard/project/_conversation-message.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_conversation-message.tsx
@@ -2,6 +2,7 @@
 
 import type { MessageResponse } from "@agentstate/shared";
 import { Markdown } from "@/components/ui/markdown";
+import { Bubble, Message as MessageRow } from "@/components/ui/message";
 import { formatDateTime } from "./_utils";
 
 type Message = MessageResponse;
@@ -14,7 +15,7 @@ interface ConversationMessageProps {
 function MessageMeta({ message, align }: { message: Message; align: "left" | "right" }) {
   return (
     <p
-      className={`num mt-1 font-mono text-[11px] text-fg-4 ${align === "right" ? "text-right" : ""}`}
+      className={`num mt-1 font-mono text-[11px] text-muted-foreground ${align === "right" ? "text-right" : ""}`}
     >
       {formatDateTime(message.created_at)}
       {message.token_count > 0 && ` · ${message.token_count} tokens`}
@@ -23,10 +24,12 @@ function MessageMeta({ message, align }: { message: Message; align: "left" | "ri
 }
 
 /**
- * ConversationMessage — chat-style message rendering (assistant-ui inspired):
- * - user: right-aligned bubble
- * - assistant: left-aligned, full width, markdown body
- * - other roles (system / tool / …): left-aligned with a small role label
+ * ConversationMessage — chat-style message rendering (assistant-ui inspired),
+ * built on the shared Message/Bubble primitives (@/components/ui/message):
+ * - user: end-aligned Bubble (filled muted surface, rounded-br-sm tail)
+ * - assistant: start-aligned, full-width markdown, no bubble surface
+ * - other roles (system / tool / …): start-aligned with a small role label
+ *   header and content in a bordered muted surface
  *
  * Content is rendered as GitHub-flavored markdown via the shared Markdown
  * component so headings, lists, bold, links, and code render properly.
@@ -34,28 +37,38 @@ function MessageMeta({ message, align }: { message: Message; align: "left" | "ri
 export function ConversationMessage({ message }: ConversationMessageProps) {
   const role = message.role;
 
-  // User → right-aligned bubble.
+  // User → end-aligned bubble.
   if (role === "user") {
     return (
-      <div className="flex flex-col items-end">
-        <div className="max-w-[85%] rounded-[var(--radius-xl)] rounded-br-[var(--radius-sm)] border border-edge bg-panel px-3.5 py-2.5">
+      <MessageRow align="end" footer={<MessageMeta message={message} align="right" />}>
+        <Bubble variant="default" align="end">
           <Markdown content={message.content} />
-        </div>
-        <MessageMeta message={message} align="right" />
-      </div>
+        </Bubble>
+      </MessageRow>
     );
   }
 
-  const isAssistant = role === "assistant";
+  // Assistant → full-width markdown, no bubble surface.
+  if (role === "assistant") {
+    return (
+      <MessageRow align="start" footer={<MessageMeta message={message} align="left" />}>
+        <div className="min-w-0 max-w-[95%]">
+          <Markdown content={message.content} />
+        </div>
+      </MessageRow>
+    );
+  }
 
-  // Assistant → full-width markdown. Other roles → labeled left block.
+  // Other roles (system / tool / …) → labeled, bordered muted surface.
   return (
-    <div className="flex flex-col items-start">
-      {!isAssistant && <span className="as-label-xs mb-1 text-fg-4">{role}</span>}
-      <div className="min-w-0 max-w-[95%]">
+    <MessageRow
+      align="start"
+      header={<span className="mb-1 text-xs uppercase text-muted-foreground">{role}</span>}
+      footer={<MessageMeta message={message} align="left" />}
+    >
+      <div className="min-w-0 max-w-[95%] rounded-lg border border-border bg-muted/40 px-3 py-2">
         <Markdown content={message.content} />
       </div>
-      <MessageMeta message={message} align="left" />
-    </div>
+    </MessageRow>
   );
 }

--- a/packages/dashboard/src/components/dashboard/project/_conversation-row.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_conversation-row.tsx
@@ -61,7 +61,7 @@ export function ConversationRow({
               {isLoading ? (
                 <MessageListSkeleton lines={2} />
               ) : messages?.length ? (
-                <div className="flex max-h-[500px] flex-col gap-component overflow-y-auto">
+                <div className="flex max-h-[500px] flex-col gap-6 overflow-y-auto">
                   {messages.map((msg) => (
                     <ConversationMessage key={msg.id} message={msg} />
                   ))}

--- a/packages/dashboard/src/components/dashboard/project/_loading-state.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_loading-state.tsx
@@ -2,7 +2,7 @@ import { PageHeaderSkeleton, StatsCardsSkeleton } from "@/components/dashboard/l
 
 export function _ProjectLoadingState() {
   return (
-    <div className="flex flex-col space-y-section page-padding section-padding">
+    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
       <PageHeaderSkeleton />
       <StatsCardsSkeleton count={4} />
       <div className="flex flex-col gap-component">

--- a/packages/dashboard/src/components/dashboard/project/_page-header.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_page-header.tsx
@@ -26,7 +26,9 @@ export function _PageHeader({ name, slug }: PageHeaderProps) {
               <Badge>Project</Badge>
               <span className="num font-mono text-xs text-fg-4">{slug}</span>
             </div>
-            <h1 className="truncate text-[26px] text-fg">{name}</h1>
+            <h1 className="truncate text-2xl font-semibold tracking-tight text-foreground">
+              {name}
+            </h1>
           </div>
         </div>
         <div className="grid gap-tight text-xs text-fg-3 sm:min-w-64">

--- a/packages/dashboard/src/components/dashboard/project/project-content.tsx
+++ b/packages/dashboard/src/components/dashboard/project/project-content.tsx
@@ -112,7 +112,7 @@ function ProjectContent() {
   ];
 
   return (
-    <div className="flex flex-col space-y-section page-padding section-padding">
+    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
       <_PageHeader name={project.name} slug={project.slug} />
 
       {createdKey && <_CreatedKeyDisplay apiKey={createdKey} copied={copied} onCopy={copy} />}

--- a/packages/dashboard/src/components/dashboard/projects/projects-page.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/projects-page.tsx
@@ -35,7 +35,7 @@ function ProjectsContent() {
   } = useCreateProject(projects);
 
   return (
-    <div className="flex flex-col space-y-section page-padding section-padding">
+    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
       <PageHeader
         title="Projects"
         description="Manage your API projects and keys."

--- a/packages/dashboard/src/components/dashboard/traces/traces-page.tsx
+++ b/packages/dashboard/src/components/dashboard/traces/traces-page.tsx
@@ -41,7 +41,7 @@ function TracesContent() {
   );
 
   return (
-    <div className="px-5 sm:px-7">
+    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
       <PageHeader title="Traces" description="LLM execution traces and observability." />
 
       {loadingProjects && (

--- a/packages/dashboard/src/components/home/code-tabs.astro
+++ b/packages/dashboard/src/components/home/code-tabs.astro
@@ -34,12 +34,12 @@ const highlight = (line: string): string => {
 // biome-ignore lint/correctness/noUnusedVariables: used in the template below
 const uid = Math.random().toString(36).slice(2, 8);
 ---
-<div class={`codetabs overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-panel ${cls}`}>
-  <div class="ct-bar flex items-center gap-1 border-b border-edge-soft bg-panel2 px-2 py-1.5">
+<div class={`codetabs overflow-hidden rounded-xl border border-border bg-card ${cls}`}>
+  <div class="ct-bar flex items-center gap-1 border-b border-border bg-muted px-2 py-1.5">
     {tabs.map((t, i) => (
       <label for={`ct-${uid}-${i}`} class="ct-tab cursor-pointer select-none rounded-[var(--radius-sm)] px-3 py-1 font-mono text-[11.5px] transition-colors">{t.label}</label>
     ))}
-    <span class="ml-auto font-mono text-[11px] text-fg-4">{tabs[0].lang}</span>
+    <span class="ml-auto font-mono text-[11px] text-muted-foreground">{tabs[0].lang}</span>
   </div>
   {tabs.map((t, i) => {
     const lines = t.code.replace(/\n$/, "").split("\n");

--- a/packages/dashboard/src/components/ui/card.tsx
+++ b/packages/dashboard/src/components/ui/card.tsx
@@ -1,9 +1,5 @@
 import type { ReactNode } from "react";
 
 export function Card({ className = "", children }: { className?: string; children?: ReactNode }) {
-  return (
-    <div className={`rounded-[var(--radius-lg)] border border-edge bg-panel ${className}`}>
-      {children}
-    </div>
-  );
+  return <div className={`rounded-xl border border-border bg-card ${className}`}>{children}</div>;
 }

--- a/packages/dashboard/src/components/ui/message.tsx
+++ b/packages/dashboard/src/components/ui/message.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Message — row wrapper for a single chat message. Handles start/end
+ * alignment and optional header/footer slots (role label, meta line) around
+ * the message content (typically a Bubble or full-width Markdown block).
+ */
+export function Message({
+  align,
+  header,
+  footer,
+  className,
+  children,
+}: {
+  align: "start" | "end";
+  header?: ReactNode;
+  footer?: ReactNode;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className={cn("flex flex-col", align === "end" ? "items-end" : "items-start", className)}>
+      {header}
+      {children}
+      {footer}
+    </div>
+  );
+}
+
+/**
+ * Bubble — surface for a single message's content. `variant="default"` is a
+ * filled muted surface (user messages); `variant="outline"` is a bordered
+ * transparent surface. `align` controls which corner gets the small radius,
+ * matching the chat-bubble "tail" convention (end: bottom-right, start:
+ * bottom-left).
+ */
+export function Bubble({
+  variant = "default",
+  align,
+  className,
+  children,
+}: {
+  variant?: "default" | "outline";
+  align: "start" | "end";
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "max-w-[85%] px-4 py-2.5",
+        align === "end" ? "rounded-2xl rounded-br-sm" : "rounded-2xl rounded-bl-sm",
+        variant === "outline" ? "border border-border bg-transparent" : "bg-muted",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/dashboard/src/layouts/MarketingLayout.astro
+++ b/packages/dashboard/src/layouts/MarketingLayout.astro
@@ -53,22 +53,22 @@ const canonicalUrl = new URL(canonical ?? Astro.url.pathname, SITE).href;
     <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png" />
     <ThemeScript />
   </head>
-  <body class="min-h-screen bg-base text-fg-2">
+  <body class="min-h-screen bg-background text-foreground">
     <!-- top nav -->
-    <header class="sticky top-0 z-40 border-b border-edge-soft bg-base/85 backdrop-blur">
-      <div class="mx-auto flex h-14 max-w-[1040px] items-center gap-2.5 px-5">
-        <a href="/" class="flex items-center gap-2 text-fg"><Logo size={20} /><span class="text-[15px] font-semibold tracking-tight">AgentState</span></a>
-        <nav class="ml-8 hidden items-center gap-6 text-[13.5px] text-fg-3 sm:flex">
-          <a href="/docs" class="hover:text-fg">Docs</a>
-          <a href="/dashboard" class="hover:text-fg">Dashboard</a>
-          <a href="https://github.com/duyet/agentstate" class="hover:text-fg">GitHub</a>
+    <header class="sticky top-0 z-40 border-b border-border bg-background/85 backdrop-blur">
+      <div class="mx-auto flex h-16 w-full max-w-6xl items-center gap-2.5 px-6">
+        <a href="/" class="flex items-center gap-2 text-foreground"><Logo size={20} /><span class="text-[15px] font-semibold tracking-tight">AgentState</span></a>
+        <nav class="ml-8 hidden items-center gap-6 text-[13.5px] text-muted-foreground sm:flex">
+          <a href="/docs" class="hover:text-foreground">Docs</a>
+          <a href="/#pricing" class="hover:text-foreground">Pricing</a>
+          <a href="https://github.com/duyet/agentstate" class="hover:text-foreground">GitHub</a>
         </nav>
         <div class="ml-auto flex items-center gap-2">
           <button
             type="button"
             data-theme-toggle
             aria-label="Toggle color theme"
-            class="grid size-8 place-items-center rounded-[var(--radius)] border border-edge text-fg-3 transition-[background-color,color] hover:bg-panel2 hover:text-fg"
+            class="grid size-8 place-items-center rounded-[var(--radius)] border border-border text-muted-foreground transition-[background-color,color] hover:bg-muted hover:text-foreground"
           >
             <span class="icon-moon"
               ><svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path
@@ -82,15 +82,45 @@ const canonicalUrl = new URL(canonical ?? Astro.url.pathname, SITE).href;
                   d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" /></svg></span
             >
           </button>
-          <a href="/dashboard" class="rounded-[var(--radius)] bg-fg px-3.5 py-1.5 text-[13px] font-medium text-[var(--color-base)] hover:opacity-90">Open dashboard</a>
+          <a href="/dashboard" class="hidden rounded-[var(--radius)] border border-border px-3.5 py-1.5 text-[13px] font-medium text-foreground transition-colors hover:bg-muted sm:inline-flex">Sign in</a>
+          <a href="/dashboard" class="rounded-[var(--radius)] bg-primary px-3.5 py-1.5 text-[13px] font-medium text-primary-foreground transition-opacity hover:opacity-90">Start for free</a>
         </div>
       </div>
     </header>
     <slot />
-    <footer class="border-t border-edge-soft">
-      <div class="mx-auto flex max-w-[1040px] flex-col items-center gap-2 px-5 py-8 text-center font-mono text-[11px] text-fg-4">
-        <a href="/" class="flex items-center gap-1.5 text-fg-3"><Logo size={14} /> AgentState</a>
-        <span>© 2026 AgentState · MIT · built on Cloudflare D1</span>
+    <footer class="border-t border-border">
+      <div class="mx-auto w-full max-w-6xl px-6 py-16">
+        <div class="grid grid-cols-2 gap-8 sm:grid-cols-4">
+          <div class="col-span-2 sm:col-span-1">
+            <a href="/" class="flex items-center gap-1.5 text-foreground"><Logo size={16} /><span class="text-[14px] font-semibold tracking-tight">AgentState</span></a>
+            <p class="mt-3 max-w-[220px] text-[13px] leading-relaxed text-muted-foreground">Conversation history &amp; coordination database for AI agent fleets.</p>
+          </div>
+          <div>
+            <div class="text-[12px] font-medium text-foreground">Product</div>
+            <ul class="mt-3 flex flex-col gap-2 text-[13px] text-muted-foreground">
+              <li><a href="/docs" class="hover:text-foreground">Docs</a></li>
+              <li><a href="/#pricing" class="hover:text-foreground">Pricing</a></li>
+              <li><a href="/dashboard" class="hover:text-foreground">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <div class="text-[12px] font-medium text-foreground">Company</div>
+            <ul class="mt-3 flex flex-col gap-2 text-[13px] text-muted-foreground">
+              <li><a href="https://github.com/duyet/agentstate" class="hover:text-foreground">GitHub</a></li>
+              <li><a href="https://github.com/duyet/agentstate/blob/main/LICENSE" class="hover:text-foreground">License (MIT)</a></li>
+            </ul>
+          </div>
+          <div>
+            <div class="text-[12px] font-medium text-foreground">Resources</div>
+            <ul class="mt-3 flex flex-col gap-2 text-[13px] text-muted-foreground">
+              <li><a href="/llms.txt" class="hover:text-foreground">/llms.txt</a></li>
+              <li><a href="/openapi.json" class="hover:text-foreground">/openapi.json</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="mt-12 flex flex-col items-center justify-between gap-3 border-t border-border pt-6 text-[12px] text-muted-foreground sm:flex-row">
+          <span>© 2026 AgentState · MIT · built on Cloudflare D1</span>
+        </div>
       </div>
     </footer>
     <RevealScript />

--- a/packages/dashboard/src/pages/index.astro
+++ b/packages/dashboard/src/pages/index.astro
@@ -2,223 +2,108 @@
 // biome-ignore lint/correctness/noUnusedImports: Astro component imports are used in the template below
 import CodeTabs from "../components/home/code-tabs.astro";
 // biome-ignore lint/correctness/noUnusedImports: Astro component imports are used in the template below
-import HubDiagram from "../components/home/hub-diagram.astro";
-// biome-ignore lint/correctness/noUnusedImports: Astro component imports are used in the template below
 import PrimitiveIcon from "../components/home/primitive-icon.astro";
-// biome-ignore lint/correctness/noUnusedImports: Astro component imports are used in the template below
-import Card from "../components/ui/card.astro";
 // biome-ignore lint/correctness/noUnusedImports: Astro component imports are used in the template below
 import MarketingLayout from "../layouts/MarketingLayout.astro";
 
 // biome-ignore lint/correctness/noUnusedVariables: used in the template below
-const primitives = [
+const workflow = [
   {
-    name: "state",
-    eyebrow: "States",
-    title: "Versioned key/value state",
-    body: "Append-only event log; query across all agents in a fleet. Any shape, typed.",
+    n: "01",
+    title: "Send conversations",
+    body: "One API call from any SDK or REST client appends messages, metadata, and tags — no schema to design, no infra to run.",
   },
   {
-    name: "lease",
-    eyebrow: "Leases",
-    title: "Distributed locks",
-    body: "Exactly-one-writer coordination across N concurrent agents — no double-writes.",
+    n: "02",
+    title: "Query & search",
+    body: "Full-text search across messages, filter by tag or external ID, and paginate with stable cursors — never offsets.",
   },
   {
-    name: "claim",
-    eyebrow: "Claims",
-    title: "Verifiable assertions",
-    body: "Attach evidence to decisions so you can audit them later. Built-in provenance.",
-  },
-  {
-    name: "token",
-    eyebrow: "Capability Tokens",
-    title: "Scoped delegation",
-    body: "Sub-agents get only the access they need — revocable, time-bounded, auditable.",
-  },
-  {
-    name: "conversation",
-    eyebrow: "Conversations",
-    title: "Full message history",
-    body: "CRUD, search, tags, bulk export, and AI-generated titles — for agents and humans.",
+    n: "03",
+    title: "Analyze",
+    body: "Usage summaries, time-series, and per-tag breakdowns across your whole fleet, plus webhooks for real-time events.",
   },
 ] as const;
 
-// Supporting capabilities — grouped into feature categories for the showcase grid.
 // biome-ignore lint/correctness/noUnusedVariables: used in the template below
-const featureGroups = [
+const features = [
   {
-    label: "Access & trust",
-    features: [
-      {
-        icon: "auth",
-        title: "API key auth",
-        body: "SHA-256-hashed bearer keys, project-scoped with scoped-key management.",
-        href: "/dashboard/keys",
-      },
-      {
-        icon: "token",
-        title: "Capability tokens",
-        body: "Revocable, time-bounded delegation — sub-agents get least privilege.",
-      },
-      {
-        icon: "claim",
-        title: "Verifiable claims",
-        body: "Attach evidence to decisions; run verify passes and audit later.",
-      },
-      {
-        icon: "orgs",
-        title: "Organizations",
-        body: "Multi-tenant orgs (Clerk-scoped) for projects, keys, and domains.",
-      },
-    ],
+    icon: "docs",
+    title: "REST API",
+    body: "Cursor-paginated, snake_case JSON, bearer-token auth. Small enough to keep in an agent's context window.",
   },
   {
-    label: "Intelligence",
-    features: [
-      {
-        icon: "ai",
-        title: "AI enrichment",
-        body: "Workers AI auto-generates conversation titles and follow-up questions.",
-      },
-      {
-        icon: "conversation",
-        title: "Searchable history",
-        body: "Full-text search across messages with snippets; organize by tags.",
-      },
-      {
-        icon: "bulk",
-        title: "Bulk operations",
-        body: "Export or delete thousands of conversations in a single call.",
-      },
-      {
-        icon: "tags",
-        title: "Tags & external IDs",
-        body: "Filter conversations by tag and map your own IDs to ours.",
-      },
-    ],
+    icon: "adapters",
+    title: "SDKs for TS & Python",
+    body: "First-class clients plus adapters for Vercel AI SDK, LangGraph, and Cloudflare Workers AI.",
   },
   {
-    label: "Observability",
-    features: [
-      {
-        icon: "analytics",
-        title: "Usage analytics",
-        body: "Summaries, time-series, and per-tag breakdowns across fleets.",
-      },
-      {
-        icon: "tracing",
-        title: "LLM tracing",
-        body: "Per-project conversation traces with a detailed step view.",
-      },
-      {
-        icon: "webhooks",
-        title: "Webhooks",
-        body: "Receive event notifications on create/update/delete — no polling.",
-      },
-      {
-        icon: "pagination",
-        title: "Cursor pagination",
-        body: "Stable, offset-free pagination on every list endpoint.",
-      },
-    ],
+    icon: "mcp",
+    title: "MCP server",
+    body: "Remote streamable-HTTP MCP endpoint at /api/mcp — works with Claude, Cursor, and Windsurf out of the box.",
   },
   {
-    label: "Integrations",
-    features: [
-      {
-        icon: "adapters",
-        title: "Framework adapters",
-        body: "First-class SDKs: Vercel AI, LangGraph, Cloudflare Workers AI, Python.",
-      },
-      {
-        icon: "mcp",
-        title: "Remote MCP server",
-        body: "Streamable-HTTP MCP at /api/mcp for Cursor, Claude, Windsurf.",
-      },
-      {
-        icon: "oauth",
-        title: "OAuth 2.1 server",
-        body: "PKCE + consent for MCP clients; dynamic registration & discovery.",
-      },
-      {
-        icon: "domains",
-        title: "Custom domains",
-        body: "Attach and verify your own domain to any project.",
-      },
-    ],
+    icon: "conversation",
+    title: "Full-text search",
+    body: "Search across every message in a project, with match snippets and tag/external-ID filters.",
   },
-] as const;
-
-// Agent-readable surfaces — every coding agent can self-integrate.
-// biome-ignore lint/correctness/noUnusedVariables: used in the template below
-const developerSurfaces = [
-  { icon: "docs", title: "/llms.txt", body: "Compact index of the product for coding agents." },
-  { icon: "docs", title: "/agents.md", body: "Copy-pasteable system prompt with the full guide." },
-  { icon: "docs", title: "/openapi.json", body: "Machine-readable spec for any client generator." },
+  {
+    icon: "analytics",
+    title: "Usage analytics",
+    body: "Summaries and time-series across agents and tags, so you can see what your fleet is actually doing.",
+  },
+  {
+    icon: "auth",
+    title: "Scoped API keys",
+    body: "SHA-256-hashed bearer keys with subset delegation — issue a key that can only do what a sub-agent needs.",
+  },
 ] as const;
 ---
 <MarketingLayout
-  title="AgentState — State & coordination layer for AI agent fleets"
-  description="Stop reinventing distributed state. AgentState gives your agent fleet five primitives — state, leases, claims, tokens, and conversations — behind one API."
+  title="AgentState — Conversation history database for AI agent fleets"
+  description="Stop reinventing conversation storage. AgentState is a database-as-a-service for AI agent conversation history — REST API, SDKs, MCP server, full-text search, and analytics behind one call."
   canonical="/"
 >
   <main>
     <!-- hero -->
-    <section class="relative overflow-hidden border-b border-edge-soft dot-grid">
-      <div class="relative mx-auto grid max-w-[1040px] gap-10 px-5 py-24 sm:pt-32 lg:grid-cols-[1fr_360px] lg:items-center lg:gap-6">
-        <div data-reveal class="max-w-[640px]">
-          <span class="inline-flex items-center gap-2 rounded-full border border-edge bg-base px-3 py-1 text-[12.5px] text-fg-3"><span class="size-1.5 rounded-full bg-accent"></span>open source · MIT · free to start</span>
-          <h1 class="mt-7 text-[44px] font-semibold leading-[0.98] tracking-[-0.04em] text-fg sm:text-[64px]">
-            State &amp; coordination<br />for agent <span class="text-accent">fleets</span>.
+    <section class="border-b border-border">
+      <div class="mx-auto grid w-full max-w-6xl gap-12 px-6 py-24 md:grid-cols-2 md:items-center md:py-32">
+        <div data-reveal>
+          <span class="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 text-[12.5px] text-muted-foreground"><span class="size-1.5 rounded-full bg-accent"></span>open source · MIT · free to start</span>
+          <h1 class="mt-6 text-4xl font-semibold leading-[1.05] tracking-tight text-foreground lg:text-6xl">
+            Conversation history for <span class="text-accent">AI agent fleets</span>.
           </h1>
-          <p class="mt-7 max-w-[540px] text-[17px] leading-[1.55] text-fg-3 sm:text-[19px]">
-            You're building AI agents — not a distributed systems backend. Stop reinventing state management, locking, delegation, and history storage. AgentState gives your fleet five primitives and a single API call.
+          <p class="mt-6 max-w-[520px] text-lg leading-relaxed text-muted-foreground">
+            You're building AI agents — not a database backend. AgentState stores, searches, and analyzes every conversation your fleet has, behind one simple API.
           </p>
-          <div class="mt-9 flex flex-wrap items-center gap-3">
-            <a href="/dashboard" class="inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-accent px-5 py-2.5 text-[14px] font-medium text-accent-fg transition-[opacity,transform] duration-150 hover:opacity-90 active:scale-[0.96]">Get a free key →</a>
-            <a href="/docs" class="inline-flex items-center gap-1.5 rounded-[var(--radius)] border border-edge px-5 py-2.5 text-[14px] text-fg transition-[background-color,transform] duration-150 hover:bg-panel2 active:scale-[0.96]">Read the docs</a>
+          <div class="mt-8 flex flex-wrap items-center gap-3">
+            <a href="/dashboard" class="inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-[opacity,transform] duration-150 hover:opacity-90 active:scale-[0.96]">Start for free →</a>
+            <a href="/docs" class="inline-flex items-center gap-1.5 rounded-[var(--radius)] border border-border px-5 py-2.5 text-sm font-medium text-foreground transition-[background-color,transform] duration-150 hover:bg-muted active:scale-[0.96]">View docs</a>
           </div>
-          <p class="mt-5 text-[12.5px] text-fg-4">Open source · free to start · no credit card</p>
+          <p class="mt-5 text-[12.5px] text-muted-foreground">Open source · free to start · no credit card</p>
         </div>
-        <div data-reveal style="--reveal-delay:120ms" class="hidden lg:block">
-          <HubDiagram />
-        </div>
-      </div>
-    </section>
-
-    <!-- code -->
-    <section data-reveal class="mx-auto max-w-[1040px] px-5 pb-24">
-      <CodeTabs
-        tabs={[
-          {
-            label: "TypeScript",
-            lang: "sdk",
-            code: `import { AgentState } from "@agentstate/sdk";
+        <div data-reveal style="--reveal-delay:120ms">
+          <CodeTabs
+            tabs={[
+              {
+                label: "TypeScript",
+                lang: "sdk",
+                code: `import { AgentState } from "@agentstate/sdk";
 
 const client = new AgentState({ apiKey: process.env.AS_KEY });
 
-// Acquire a distributed lease before writing
-const lease = await client.createStateLease("job:42", {
-  holder: "worker-1",
-  ttl_ms: 30_000,
-});
-
-// Store typed state under any key
-await client.upsertState("job:42:result", {
-  agent_id: "worker-1",
-  data: { status: "done", tokens: 1240 },
-});
-
-// Append a conversation turn
 const conv = await client.createConversation({
   messages: [{ role: "user", content: "Summarize findings" }],
+});
+
+const { data } = await client.searchConversations({
+  query: "summarize",
 });`,
-          },
-          {
-            label: "Vercel AI",
-            lang: "ts",
-            code: `import { AgentState } from "@agentstate/sdk";
+              },
+              {
+                label: "Vercel AI",
+                lang: "ts",
+                code: `import { AgentState } from "@agentstate/sdk";
 import { createAISDKChatStore } from "@agentstate/sdk/ai-sdk";
 
 const client = new AgentState({ apiKey: process.env.AS_KEY });
@@ -227,43 +112,22 @@ const store = createAISDKChatStore(client);
 const chatId = await store.createChat();
 await store.saveChat({ chatId, messages });
 const messages = await store.loadChat(chatId);`,
-          },
-          {
-            label: "LangGraph",
-            lang: "ts",
-            code: `import { AgentState } from "@agentstate/sdk";
+              },
+              {
+                label: "LangGraph",
+                lang: "ts",
+                code: `import { AgentState } from "@agentstate/sdk";
 import { AgentStateCheckpointSaver } from "@agentstate/sdk/langgraph";
 
 const client = new AgentState({ apiKey: process.env.AS_KEY });
 const saver = new AgentStateCheckpointSaver(client);
 
 const graph = workflow.compile({ checkpointer: saver });`,
-          },
-          {
-            label: "Workers AI",
-            lang: "ts",
-            code: `import { Agent } from "agents";
-import { AgentState } from "@agentstate/sdk";
-
-export class ChatAgent extends Agent<Env> {
-  state = new AgentState({ apiKey: this.env.AS_KEY });
-
-  async onMessage(conn, message) {
-    const conv = await this.state.getConversation(this.id);
-    const out = await this.env.AI.run("@cf/meta/llama-3.1-8b-instruct", {
-      messages: conv.messages,
-    });
-    await this.state.appendMessages(this.id, [
-      { role: "user", content: message },
-      { role: "assistant", content: out.response },
-    ]);
-  }
-}`,
-          },
-          {
-            label: "Python",
-            lang: "py",
-            code: `from agentstate import AgentStateClient
+              },
+              {
+                label: "Python",
+                lang: "py",
+                code: `from agentstate import AgentStateClient
 
 client = AgentStateClient(api_key="as_live_...")
 
@@ -271,203 +135,68 @@ conv = client.create_conversation(
     messages=[{"role": "user", "content": "Hello!"}]
 )
 messages = client.get_conversation(conv.id).messages`,
-          },
-          {
-            label: "REST",
-            lang: "bash",
-            code: `curl -X POST https://agentstate.app/api/v1/conversations \\
+              },
+              {
+                label: "REST",
+                lang: "bash",
+                code: `curl -X POST https://agentstate.app/api/v1/conversations \\
   -H "Authorization: Bearer as_live_..." \\
   -H "Content-Type: application/json" \\
   -d '{"messages":[{"role":"user","content":"Hi"}]}'`,
-          },
-        ]}
-      />
-    </section>
-
-    <!-- five primitives -->
-    <section data-reveal class="border-t border-edge-soft">
-      <div class="mx-auto max-w-[1040px] px-5 py-24">
-        <div class="mb-3 font-mono text-[11px] uppercase tracking-[0.15em] text-fg-4">Five primitives</div>
-        <h2 class="max-w-[620px] text-[34px] font-semibold leading-[1.05] tracking-[-0.03em] text-fg sm:text-[40px]">
-          Everything a coordinated fleet needs, nothing it doesn't.
-        </h2>
-        <div class="mt-10 grid grid-cols-1 gap-px overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-edge-soft sm:grid-cols-2 lg:grid-cols-3">
-          {primitives.map((p) => (
-            <div class="group bg-panel p-6 transition-colors hover:bg-panel2">
-              <div class="grid size-9 place-items-center rounded-[var(--radius)] border border-edge text-fg-3 transition-colors group-hover:border-accent/40 group-hover:text-accent">
-                <PrimitiveIcon name={p.name} class="size-[18px]" />
-              </div>
-              <div class="mt-4 font-mono text-[11px] uppercase tracking-wider text-fg-4">{p.eyebrow}</div>
-              <div class="mt-1.5 text-[16px] font-medium text-fg">{p.title}</div>
-              <p class="mt-1.5 text-[13.5px] leading-relaxed text-fg-3">{p.body}</p>
-            </div>
-          ))}
-          <div class="flex flex-col justify-center bg-panel p-6">
-            <div class="text-[15px] font-medium text-fg">One API, five primitives.</div>
-            <p class="mt-1.5 text-[13.5px] leading-relaxed text-fg-3">No separate services to glue together — every primitive shares auth, projects, and analytics.</p>
-            <a href="/docs" class="mt-3 inline-flex items-center gap-1 text-[13px] font-medium text-accent hover:opacity-80">See the API surface →</a>
-          </div>
+              },
+            ]}
+          />
         </div>
       </div>
     </section>
 
-    <!-- features -->
-    <section data-reveal class="border-t border-edge-soft">
-      <div class="mx-auto max-w-[1040px] px-5 py-24">
-        <div class="mb-3 font-mono text-[11px] uppercase tracking-[0.15em] text-fg-4">Everything in the box</div>
-        <h2 class="max-w-[640px] text-[34px] font-semibold leading-[1.05] tracking-[-0.03em] text-fg sm:text-[40px]">
-          One API, the coordination layer your agents actually need.
+    <!-- numbered workflow -->
+    <section data-reveal class="border-b border-border">
+      <div class="mx-auto w-full max-w-6xl px-6 py-24 md:py-32">
+        <h2 class="max-w-xl text-3xl font-semibold leading-tight tracking-tight text-foreground md:text-4xl">
+          Three steps, one API.
         </h2>
-        <p class="mt-4 max-w-[600px] text-[15px] leading-relaxed text-fg-3">Beyond the five primitives, AgentState ships auth, observability, integrations, and agent-readable docs — so you ship the agent, not the backend.</p>
-
-        <div class="mt-12 flex flex-col gap-10">
-          {featureGroups.map((group) => (
-            <div>
-              <div class="mb-4 font-mono text-[11px] uppercase tracking-[0.12em] text-fg-4">{group.label}</div>
-              <div class="grid grid-cols-1 gap-px overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-edge-soft sm:grid-cols-2 lg:grid-cols-4">
-                {group.features.map((f) => (
-                  <div class="group flex flex-col bg-panel p-5 transition-colors hover:bg-panel2">
-                    <div class="grid size-9 place-items-center rounded-[var(--radius)] border border-edge text-fg-3 transition-colors group-hover:border-accent/40 group-hover:text-accent">
-                      <PrimitiveIcon name={f.icon} class="size-[18px]" />
-                    </div>
-                    <div class="mt-3.5 text-[14.5px] font-medium text-fg">{f.title}</div>
-                    <p class="mt-1 text-[13px] leading-relaxed text-fg-3">{f.body}</p>
-                    {f.href && (
-                      <a href={f.href} class="mt-3 inline-flex items-center gap-1 text-[12.5px] font-medium text-accent transition-opacity hover:opacity-80">Manage →</a>
-                    )}
-                  </div>
-                ))}
+        <div class="mt-12">
+          {workflow.map((step) => (
+            <div class="grid grid-cols-1 gap-3 border-b border-border py-8 first:pt-0 last:border-0 last:pb-0 md:grid-cols-2 md:gap-10">
+              <div class="flex items-baseline gap-4">
+                <span class="font-mono text-sm text-muted-foreground">{step.n}</span>
+                <span class="text-xl font-medium text-foreground">{step.title}</span>
               </div>
+              <p class="text-[15px] leading-relaxed text-muted-foreground">{step.body}</p>
             </div>
           ))}
         </div>
+      </div>
+    </section>
 
-        <!-- agent-readable surfaces -->
-        <div class="mt-10 rounded-[var(--radius-lg)] border border-edge bg-panel p-5 sm:p-6">
-          <div class="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
-            <div class="max-w-[480px]">
-              <div class="font-mono text-[11px] uppercase tracking-[0.12em] text-fg-4">Agent-readable by design</div>
-              <p class="mt-1.5 text-[14px] leading-relaxed text-fg-3">Every coding agent can self-integrate — no human in the loop. Point your agent at the spec and it wires up persistence on its own.</p>
+    <!-- feature grid -->
+    <section data-reveal class="border-b border-border">
+      <div class="mx-auto w-full max-w-6xl px-6 py-24 md:py-32">
+        <h2 class="max-w-xl text-3xl font-semibold leading-tight tracking-tight text-foreground md:text-4xl">
+          Everything a fleet needs to remember.
+        </h2>
+        <p class="mt-4 max-w-lg text-[15px] leading-relaxed text-muted-foreground">Beyond storage, AgentState ships auth, search, observability, and integrations — so you ship the agent, not the backend.</p>
+        <div class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {features.map((f) => (
+            <div class="rounded-xl border border-border bg-card p-6">
+              <div class="grid size-9 place-items-center rounded-[var(--radius)] border border-border text-muted-foreground">
+                <PrimitiveIcon name={f.icon} class="size-[18px]" />
+              </div>
+              <div class="mt-4 text-[15px] font-medium text-foreground">{f.title}</div>
+              <p class="mt-1.5 text-[13.5px] leading-relaxed text-muted-foreground">{f.body}</p>
             </div>
-            <div class="flex flex-wrap gap-2.5">
-              {developerSurfaces.map((s) => (
-                <span class="inline-flex items-center gap-2 rounded-[var(--radius)] border border-edge bg-base px-3 py-2 font-mono text-[12.5px] text-fg-2">
-                  <PrimitiveIcon name={s.icon} class="size-4 text-fg-4" />
-                  {s.title}
-                </span>
-              ))}
-            </div>
-          </div>
+          ))}
         </div>
       </div>
     </section>
 
-    <!-- comparison -->
-    <section data-reveal class="border-t border-edge-soft">
-      <div class="mx-auto max-w-[1040px] px-5 py-24">
-        <div class="mb-3 font-mono text-[11px] uppercase tracking-[0.15em] text-fg-4">Why AgentState</div>
-        <h2 class="max-w-[620px] text-[34px] font-semibold leading-[1.05] tracking-[-0.03em] text-fg sm:text-[40px]">
-          More than memory — coordination included.
-        </h2>
-        <p class="mt-4 max-w-[580px] text-[15px] leading-relaxed text-fg-3">Memory and history tools store what happened. AgentState also coordinates what happens next — distributed locks, scoped delegation, and verifiable evidence baked in.</p>
-        <Card class="mt-10 overflow-hidden p-0">
-          <table class="w-full text-left text-[13.5px]">
-            <thead>
-              <tr class="border-b border-edge-soft font-mono text-[11px] uppercase text-fg-4">
-                <th class="px-5 py-3 font-medium">Capability</th>
-                <th class="px-5 py-3 font-medium">Memory-only / roll your own</th>
-                <th class="px-5 py-3 font-medium">AgentState</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr class="border-b border-edge-soft hover:bg-panel2">
-                <td class="px-5 py-3.5 text-fg">Conversation history</td>
-                <td class="px-5 py-3.5 text-fg-3">Yes — most tools cover this</td>
-                <td class="px-5 py-3.5 text-pos">Yes — CRUD, search, tags, bulk export</td>
-              </tr>
-              <tr class="border-b border-edge-soft hover:bg-panel2">
-                <td class="px-5 py-3.5 text-fg">Versioned key/value state</td>
-                <td class="px-5 py-3.5 text-fg-3">DIY — wire up your own store</td>
-                <td class="px-5 py-3.5 text-pos">Built in — append-only event log, fleet-queryable</td>
-              </tr>
-              <tr class="border-b border-edge-soft hover:bg-panel2">
-                <td class="px-5 py-3.5 text-fg">Distributed leases</td>
-                <td class="px-5 py-3.5 text-fg-3">DIY — Redis, DynamoDB, or hope for the best</td>
-                <td class="px-5 py-3.5 text-pos">Built in — exactly-one-writer across N agents</td>
-              </tr>
-              <tr class="border-b border-edge-soft hover:bg-panel2">
-                <td class="px-5 py-3.5 text-fg">Scoped capability tokens</td>
-                <td class="px-5 py-3.5 text-fg-3">Not typically available</td>
-                <td class="px-5 py-3.5 text-pos">Built in — revocable, time-bounded, auditable</td>
-              </tr>
-              <tr class="border-b border-edge-soft hover:bg-panel2">
-                <td class="px-5 py-3.5 text-fg">Verifiable claims / evidence</td>
-                <td class="px-5 py-3.5 text-fg-3">Not typically available</td>
-                <td class="px-5 py-3.5 text-pos">Built in — attach evidence to decisions, audit later</td>
-              </tr>
-              <tr class="border-b border-edge-soft last:border-0 hover:bg-panel2">
-                <td class="px-5 py-3.5 text-fg">Pricing / hosting</td>
-                <td class="px-5 py-3.5 text-fg-3">Varies — often proprietary or self-managed infra</td>
-                <td class="px-5 py-3.5 text-pos">Free to start · open source (MIT) · self-host anytime</td>
-              </tr>
-            </tbody>
-          </table>
-        </Card>
-      </div>
-    </section>
-
-    <!-- API -->
-    <section data-reveal class="border-t border-edge-soft">
-      <div class="mx-auto max-w-[1040px] px-5 py-24">
-        <div class="mb-3 font-mono text-[11px] uppercase tracking-wider text-fg-4">API surface</div>
-        <h2 class="max-w-[620px] text-[34px] font-semibold leading-[1.05] tracking-[-0.03em] text-fg sm:text-[40px]">
-          Small enough for agents and humans to keep in context.
-        </h2>
-        <Card class="mt-10 overflow-hidden p-0">
-          <table class="w-full text-left text-[13.5px]">
-            <thead>
-              <tr class="border-b border-edge-soft font-mono text-[11px] uppercase text-fg-4">
-                <th class="w-24 px-5 py-3 font-medium">Method</th>
-                <th class="px-5 py-3 font-medium">Endpoint</th>
-                <th class="px-5 py-3 font-medium">Description</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr class="border-b border-edge-soft hover:bg-panel2">
-                <td class="px-5 py-3.5 font-mono text-pos">PUT</td>
-                <td class="px-5 py-3.5 font-mono text-fg">/states/:key</td>
-                <td class="px-5 py-3.5 text-fg-3">Create or replace versioned state</td>
-              </tr>
-              <tr class="border-b border-edge-soft hover:bg-panel2">
-                <td class="px-5 py-3.5 font-mono text-accent">POST</td>
-                <td class="px-5 py-3.5 font-mono text-fg">/states/:key/lease</td>
-                <td class="px-5 py-3.5 text-fg-3">Acquire distributed lock</td>
-              </tr>
-              <tr class="border-b border-edge-soft hover:bg-panel2">
-                <td class="px-5 py-3.5 font-mono text-pos">POST</td>
-                <td class="px-5 py-3.5 font-mono text-fg">/conversations</td>
-                <td class="px-5 py-3.5 text-fg-3">Create a conversation with messages</td>
-              </tr>
-              <tr class="border-b border-edge-soft last:border-0 hover:bg-panel2">
-                <td class="px-5 py-3.5 font-mono text-accent">GET</td>
-                <td class="px-5 py-3.5 font-mono text-fg">/analytics/summary</td>
-                <td class="px-5 py-3.5 text-fg-3">Usage summary across all agents</td>
-              </tr>
-            </tbody>
-          </table>
-          <div class="border-t border-edge-soft px-5 py-3 font-mono text-[12px] text-fg-4">
-            base <span class="text-fg-3">https://agentstate.app/api/v1</span> · bearer auth · cursor pagination
-          </div>
-        </Card>
-      </div>
-    </section>
-
-    <!-- CTA -->
-    <section data-reveal class="border-t border-edge-soft py-24 text-center dot-grid">
-      <div class="mx-auto max-w-[680px] px-5">
-        <h2 class="text-[30px] font-semibold tracking-[-0.03em] text-fg sm:text-[36px]">Ship the agent,<br />not the backend.</h2>
-        <p class="mx-auto mt-4 max-w-[460px] text-fg-3">Spin up a project, grab a key, and persist your first session in two minutes. No credit card required.</p>
-        <a href="/dashboard" class="mt-8 inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-accent px-5 py-2.5 text-[14px] font-medium text-accent-fg transition-[opacity,transform] duration-150 hover:opacity-90 active:scale-[0.96]">Get a free key →</a>
+    <!-- CTA band -->
+    <section data-reveal class="py-24 text-center md:py-32">
+      <div class="mx-auto w-full max-w-2xl px-6">
+        <h2 class="text-3xl font-semibold tracking-tight text-foreground md:text-4xl">Ship the agent,<br />not the backend.</h2>
+        <p class="mx-auto mt-4 max-w-md text-muted-foreground">Spin up a project, grab a key, and persist your first conversation in two minutes. No credit card required.</p>
+        <a href="/dashboard" class="mt-8 inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-[opacity,transform] duration-150 hover:opacity-90 active:scale-[0.96]">Start for free →</a>
       </div>
     </section>
   </main>

--- a/packages/dashboard/src/styles/tokens.css
+++ b/packages/dashboard/src/styles/tokens.css
@@ -45,6 +45,34 @@
 }
 
 /*
+ * shadcn/ui semantic aliases — map shadcn token names onto the design-system
+ * tokens above so registry components (message, bubble, sidebar, …) and
+ * shadcn-style utility classes (bg-background, border-border, bg-card,
+ * text-muted-foreground, bg-primary) resolve without a parallel palette.
+ * NOTE: --color-accent stays the vermilion brand accent (NOT shadcn's
+ * hover-muted accent) — use `muted` for hover surfaces.
+ */
+@theme inline {
+  --color-background: var(--color-base);
+  --color-foreground: var(--color-fg);
+  --color-card: var(--color-panel);
+  --color-card-foreground: var(--color-fg-2);
+  --color-popover: var(--color-panel);
+  --color-popover-foreground: var(--color-fg-2);
+  --color-muted: var(--color-panel2);
+  --color-muted-foreground: var(--color-fg-3);
+  --color-border: var(--color-edge);
+  --color-input: var(--color-edge);
+  --color-ring: var(--color-fg-4);
+  --color-primary: var(--color-fg);
+  --color-primary-foreground: var(--color-base);
+  --color-secondary: var(--color-panel2);
+  --color-secondary-foreground: var(--color-fg);
+  --color-destructive: var(--color-neg);
+  --color-destructive-foreground: #ffffff;
+}
+
+/*
  * Light theme — flips the tokens. `.dark` is the ONE mechanism that drives
  * every layout: theme-script.astro toggles the class on <html> before paint
  * (no FOUC) and next-themes (attribute="class") keeps it in sync post-hydration.


### PR DESCRIPTION
## Summary

Full visual redesign moving the dashboard to a clean shadcn/ui design language and removing the Anthropic-brand experiment.

- **Design tokens**: shadcn semantic aliases (`bg-background`, `bg-card`, `bg-muted`, `text-muted-foreground`, `border-border`, `bg-primary`, …) mapped onto the existing token system via `@theme inline`, so light/dark theming keeps working and registry components drop in cleanly.
- **Landing page**: rebuilt with shadcn-style blocks (inspired by shadcnblocks landing-page11) — split hero + live code demo, numbered workflow (01/02/03), feature grid, CTA band, rich footer. One consistent `max-w-6xl px-6` container; Anthropic brand CSS/fonts (Poppins/Lora) removed.
- **Conversation rendering**: new `Message`/`Bubble` primitives following the shadcn June 2026 chat-components API; user messages as end-aligned bubbles, assistant as full-width markdown, system/tool as labeled markers.
- **Dashboard spacing**: normalized page shells (`px-6 py-6 gap-6`), `bg-card border-border rounded-xl` cards, consistent page headers across all routes.

## Verification
- `bunx astro check`: 0 errors
- Dashboard production build: 15 pages built ✓
- Biome pre-commit hook: pass

## Related
Filed 24 audit issues ([dashboard]/[sdk]/[docs] prefixes) as follow-up backlog; API audit issues to follow.

https://claude.ai/code/session_017PYqoyRqbiJDp6rbABqshW