### PR TITLE
fix: batch of triaged correctness bugs and small dashboard/SDK fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ npx wrangler deploy -c wrangler.deploy.jsonc
 - `packages/api/src/middleware/auth.ts` — API key auth (critical security path)
 - `packages/api/src/routes/conversations/` — Core CRUD operations
 - `packages/api/src/routes/projects.ts` — Project and key management routes
-- `packages/api/drizzle/` — Generated SQL migrations (committed to git)
+- `packages/api/drizzle/` — Generated SQL migrations (committed to git). If you hand-write a `.sql` migration (bypassing `bunx drizzle-kit generate`), you MUST also add its entry to `drizzle/meta/_journal.json` in the same PR (in wrangler apply order, i.e. filename order) — otherwise the next `drizzle-kit generate` diffs against a stale baseline and emits broken migrations (see #292).
 
 ## Testing
 

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -54,15 +54,36 @@
     {
       "idx": 7,
       "version": "6",
-      "when": 1781779218292,
-      "tag": "0007_whole_meggan",
+      "when": 1781743830000,
+      "tag": "0006_retention_days",
       "breakpoints": true
     },
     {
       "idx": 8,
       "version": "6",
+      "when": 1781743830001,
+      "tag": "0007_state_platform",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1781779218292,
+      "tag": "0007_whole_meggan",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
       "when": 1782995518760,
       "tag": "0008_amusing_nightshade",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1784250132977,
+      "tag": "0011_overrated_cerebro",
       "breakpoints": true
     }
   ]

--- a/packages/api/src/lib/constants.ts
+++ b/packages/api/src/lib/constants.ts
@@ -1,5 +1,0 @@
-/**
- * Default Clerk organization ID used when no organization is specified.
- * This serves as the fallback for projects and users not assigned to a specific organization.
- */
-export const DEFAULT_CLERK_ORG_ID = "default";

--- a/packages/api/src/lib/db-errors.ts
+++ b/packages/api/src/lib/db-errors.ts
@@ -1,0 +1,21 @@
+/**
+ * db-errors.ts — Classification helpers for D1/SQLite driver errors.
+ */
+
+/**
+ * True if a DB error is a SQLite/D1 UNIQUE constraint violation.
+ *
+ * Drizzle (and the raw D1 driver) wrap the underlying SQLite error in a
+ * generic `Failed query: …` / `D1_ERROR` Error and attach the original (whose
+ * message carries "UNIQUE constraint failed") as `.cause`, so the whole cause
+ * chain is inspected.
+ */
+export function isUniqueViolation(err: unknown): boolean {
+  let current: unknown = err;
+  for (let depth = 0; current != null && depth < 5; depth++) {
+    const message = current instanceof Error ? current.message : String(current);
+    if (/unique constraint failed/i.test(message)) return true;
+    current = current instanceof Error ? current.cause : undefined;
+  }
+  return false;
+}

--- a/packages/api/src/lib/env.ts
+++ b/packages/api/src/lib/env.ts
@@ -1,0 +1,21 @@
+/**
+ * env.ts — Parsing helpers for operator-supplied environment variables.
+ */
+
+/**
+ * Parse an env var that must be a positive integer, falling back to the
+ * documented default when it is unset, blank, non-numeric, zero, negative,
+ * or fractional.
+ *
+ * WHY the strictness: `Number("") === 0` and `Number.isFinite(0)` is true, so
+ * a naive `Number.isFinite` guard silently turns an accidentally-blank
+ * override (e.g. an empty `RATE_LIMIT_MAX` in a wrangler vars template) into
+ * a limit of ZERO — blocking every request on that deployment (#291).
+ * Misconfiguration must fail open to the default, never closed to a
+ * self-inflicted denial of service.
+ */
+export function parsePositiveIntEnv(raw: string | undefined, fallback: number): number {
+  if (raw === undefined) return fallback;
+  const value = Number(raw.trim());
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}

--- a/packages/api/src/middleware/project-creation-rate-limit.ts
+++ b/packages/api/src/middleware/project-creation-rate-limit.ts
@@ -14,6 +14,7 @@
 // ---------------------------------------------------------------------------
 
 import { createMiddleware } from "hono/factory";
+import { parsePositiveIntEnv } from "../lib/env";
 import {
   checkProjectCreationRateLimit,
   hashIdentifier,
@@ -46,12 +47,12 @@ export const projectCreationRateLimit = createMiddleware<{
     identifier = `ip:${await hashIdentifier(ip)}`;
   }
 
-  const configuredRateLimit = Number(
+  // A blank/invalid override falls back to the default instead of becoming a
+  // zero limit that blocks every request (#291).
+  const rateLimit = parsePositiveIntEnv(
     (c.env as { PROJECT_CREATION_RATE_LIMIT_MAX?: string }).PROJECT_CREATION_RATE_LIMIT_MAX,
+    PROJECT_CREATION_RATE_LIMIT,
   );
-  const rateLimit = Number.isFinite(configuredRateLimit)
-    ? configuredRateLimit
-    : PROJECT_CREATION_RATE_LIMIT;
   const result = await checkProjectCreationRateLimit(db, identifier, rateLimit);
 
   // Attach project-creation-specific rate limit headers

--- a/packages/api/src/middleware/rate-limit.ts
+++ b/packages/api/src/middleware/rate-limit.ts
@@ -3,6 +3,7 @@ import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
 import { nanoid } from "nanoid";
 import { rateLimits } from "../db/schema";
+import { parsePositiveIntEnv } from "../lib/env";
 import type { Bindings, Variables } from "../types";
 
 // ---------------------------------------------------------------------------
@@ -194,8 +195,12 @@ export const rateLimitMiddleware = createMiddleware<{
   const apiKeyHash = c.get("apiKeyHash");
 
   const now = Date.now();
-  const configuredRateLimit = Number((c.env as { RATE_LIMIT_MAX?: string }).RATE_LIMIT_MAX);
-  const rateLimit = Number.isFinite(configuredRateLimit) ? configuredRateLimit : RATE_LIMIT;
+  // A blank/invalid override falls back to the default instead of becoming a
+  // zero limit that blocks every request (#291).
+  const rateLimit = parsePositiveIntEnv(
+    (c.env as { RATE_LIMIT_MAX?: string }).RATE_LIMIT_MAX,
+    RATE_LIMIT,
+  );
   // Feature flag: set USE_SLIDING_WINDOW environment variable to "true" to enable
   const useSlidingWindow = (c.env as { USE_SLIDING_WINDOW?: string }).USE_SLIDING_WINDOW === "true";
 

--- a/packages/api/src/routes/projects.ts
+++ b/packages/api/src/routes/projects.ts
@@ -82,10 +82,14 @@ app.post("/", projectCreationRateLimit, async (c) => {
   }
 
   // org_id is taken from the verified Clerk session, NOT the request body.
-  // The auth middleware always sets a non-empty per-org (or per-user) value.
+  // The auth middleware always sets a non-empty per-org (or per-user) value;
+  // if it somehow didn't, refuse rather than fall back to a shared org (#277).
   const name = parsed.data.name;
   const slug = parsed.data.slug;
   const sessionOrgId = c.get("orgId");
+  if (!sessionOrgId) {
+    return errorResponse(c, "UNAUTHORIZED", "Missing organization context", 401);
+  }
 
   try {
     const result = await createProject(db, name, slug, sessionOrgId);
@@ -105,7 +109,11 @@ app.post("/", projectCreationRateLimit, async (c) => {
 app.get("/", async (c) => {
   const db = c.get("db");
   // org_id is taken from the verified Clerk session, NOT the query string.
+  // Refuse rather than fall back to a shared org when it is missing (#277).
   const sessionOrgId = c.get("orgId");
+  if (!sessionOrgId) {
+    return errorResponse(c, "UNAUTHORIZED", "Missing organization context", 401);
+  }
 
   const data = await listProjects(db, sessionOrgId);
   return c.json({ data });

--- a/packages/api/src/routes/states/index.ts
+++ b/packages/api/src/routes/states/index.ts
@@ -194,9 +194,13 @@ router.put("/:state_key", scopedAuth({ scope: "state:write" }), async (c) => {
     stateKey,
     data,
     idempotencyKey,
+    requestHash,
   );
   if (result.error)
     return errorResponse(c, result.error.code, result.error.message, result.error.status);
+  // A concurrent duplicate carried the same Idempotency-Key: this request's
+  // mutation was rolled back atomically; serve the winner's stored response.
+  if (result.replay) return result.replay;
   if (!result.result) return errorResponse(c, "INTERNAL_ERROR", "State write failed", 500);
 
   await storeIdempotency(
@@ -252,9 +256,19 @@ router.delete("/:state_key", scopedAuth({ scope: "state:write" }), async (c) => 
     return errorResponse(c, cached.error.code, cached.error.message, cached.error.status);
   if (cached.replay) return cached.replay;
 
-  const result = await deleteState(c.get("d1Db"), c.get("projectId"), stateKey, leaseId);
+  const result = await deleteState(
+    c.get("d1Db"),
+    c.get("projectId"),
+    stateKey,
+    leaseId,
+    idempotencyKey,
+    requestHash,
+  );
   if (result.error)
     return errorResponse(c, result.error.code, result.error.message, result.error.status);
+  // A concurrent duplicate carried the same Idempotency-Key: this request's
+  // mutation was rolled back atomically; serve the winner's stored response.
+  if (result.replay) return result.replay;
   if (!result.result) return errorResponse(c, "INTERNAL_ERROR", "State delete failed", 500);
 
   await storeIdempotency(

--- a/packages/api/src/services/leases.ts
+++ b/packages/api/src/services/leases.ts
@@ -2,25 +2,10 @@ import { and, desc, eq, isNull, lte } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { stateLeases } from "../db/schema";
 import { LEASE_DEFAULT_TTL_MS } from "../lib/config";
+// isUniqueViolation turns the atomic active-lease uniqueness collision into a
+// clean LEASE_CONFLICT.
+import { isUniqueViolation } from "../lib/db-errors";
 import { generateId } from "../lib/id";
-
-/**
- * True if a DB error is a SQLite/D1 UNIQUE constraint violation. Used to turn
- * the atomic active-lease uniqueness collision into a clean LEASE_CONFLICT.
- *
- * Drizzle wraps driver errors in a generic `Failed query: …` Error and attaches
- * the original (whose message carries "UNIQUE constraint failed") as `.cause`,
- * so the whole cause chain is inspected.
- */
-function isUniqueViolation(err: unknown): boolean {
-  let current: unknown = err;
-  for (let depth = 0; current != null && depth < 5; depth++) {
-    const message = current instanceof Error ? current.message : String(current);
-    if (/unique constraint failed/i.test(message)) return true;
-    current = current instanceof Error ? current.cause : undefined;
-  }
-  return false;
-}
 
 export interface LeaseResponse {
   id: string;

--- a/packages/api/src/services/oauth.ts
+++ b/packages/api/src/services/oauth.ts
@@ -116,6 +116,14 @@ function timingSafeEqualHex(a: string, b: string): boolean {
 }
 
 /**
+ * Fixed decoy hash compared against when the client_id is unknown, so the
+ * unknown-client path performs the same hash + constant-time comparison work
+ * as the wrong-secret path. 64 hex chars, same length as a real SHA-256 hex
+ * digest; no secret hashes to it.
+ */
+const DECOY_CLIENT_SECRET_HASH = "0000000000000000000000000000000000000000000000000000000000000000";
+
+/**
  * Authenticate the client at the token endpoint (client_secret verification).
  *
  * Public clients (`token_endpoint_auth_method: "none"`, no stored secret) rely
@@ -124,10 +132,13 @@ function timingSafeEqualHex(a: string, b: string): boolean {
  * is compared, in constant time, against the stored hash; a missing/incorrect
  * secret throws `OAuthError("invalid_client", …, 401)`.
  *
- * An UNKNOWN client_id is intentionally not rejected here: the grant handlers
- * bind the client to the code/refresh-token and surface an `invalid_grant`, so
- * this function leaves that path unchanged and only adds secret enforcement for
- * confidential clients that actually exist.
+ * An UNKNOWN client_id fails exactly like a confidential client with bad
+ * credentials — same error code/status, same point in the control flow, and
+ * (when a secret was presented) the same hash + constant-time comparison work
+ * against a decoy hash. Previously an unknown client fell through to a later
+ * `400 invalid_grant`, letting an attacker fingerprint which client_ids exist
+ * as confidential clients via the response shape/timing (#278). RFC 6749 §5.2
+ * explicitly lists "unknown client" under `invalid_client`.
  */
 export async function authenticateClient(
   db: DrizzleD1Database,
@@ -135,8 +146,14 @@ export async function authenticateClient(
   providedSecret: string | undefined,
 ): Promise<void> {
   const client = await getClient(db, clientId);
+
   if (!client) {
-    return;
+    if (!providedSecret) {
+      throw new OAuthError("invalid_client", "client authentication required", 401);
+    }
+    const providedHash = await hashApiKey(providedSecret);
+    timingSafeEqualHex(providedHash, DECOY_CLIENT_SECRET_HASH);
+    throw new OAuthError("invalid_client", "invalid client credentials", 401);
   }
 
   const isConfidential =

--- a/packages/api/src/services/projects.ts
+++ b/packages/api/src/services/projects.ts
@@ -28,7 +28,6 @@ import {
   webhooks,
 } from "../db/schema";
 import { buildApiKey } from "../lib/api-key";
-import { DEFAULT_CLERK_ORG_ID } from "../lib/constants";
 import { generateId } from "../lib/id";
 import { parseScopesJson } from "../lib/scopes";
 import { deserializeMetadata } from "../lib/serialization";
@@ -130,7 +129,7 @@ export async function getOrCreateOrg(
 
   const orgId = generateId();
   const now = Date.now();
-  const orgName = clerkOrgId === DEFAULT_CLERK_ORG_ID ? "Default Organization" : clerkOrgId;
+  const orgName = clerkOrgId;
 
   await db.insert(organizations).values({
     id: orgId,
@@ -161,14 +160,21 @@ export async function getOrgByClerkId(
 
 /**
  * Create a new project with a default API key.
+ *
+ * `clerkOrgId` is required at the type level: callers MUST pass the org id
+ * resolved from the verified Clerk session (see `verifyDashboardSession`,
+ * which derives `personal:<userId>` for org-less sessions). A silent
+ * fallback to a shared "default" org previously let any caller that omitted
+ * the org id resurrect the #254 cross-tenant leak — omitting it is now a
+ * compile-time error (#277).
  */
 export async function createProject(
   db: DrizzleD1Database,
   name: string,
   slug: string,
-  clerkOrgId?: string,
+  clerkOrgId: string,
 ): Promise<CreateProjectResult> {
-  const org = await getOrCreateOrg(db, clerkOrgId ?? DEFAULT_CLERK_ORG_ID);
+  const org = await getOrCreateOrg(db, clerkOrgId);
   const now = Date.now();
 
   // Check slug uniqueness within the org
@@ -217,12 +223,14 @@ export async function createProject(
 
 /**
  * List projects for an organization with active key counts.
+ *
+ * `clerkOrgId` is required at the type level — see `createProject` (#277).
  */
 export async function listProjects(
   db: DrizzleD1Database,
-  clerkOrgId?: string,
+  clerkOrgId: string,
 ): Promise<ProjectListItem[]> {
-  const org = await getOrgByClerkId(db, clerkOrgId ?? DEFAULT_CLERK_ORG_ID);
+  const org = await getOrgByClerkId(db, clerkOrgId);
 
   if (!org) {
     return [];

--- a/packages/api/src/services/states.ts
+++ b/packages/api/src/services/states.ts
@@ -1,3 +1,4 @@
+import { isUniqueViolation } from "../lib/db-errors";
 import { generateId } from "../lib/id";
 import {
   decodeJson,
@@ -9,6 +10,57 @@ import {
 import type { QueryStatesInput, UpsertStateInput } from "../lib/validation";
 
 const MAX_QUERY_SCAN_PAGES = 10;
+
+/**
+ * Sentinel `response_status` for an idempotency-key *reservation* row: the key
+ * has been claimed atomically with the state mutation, but the final response
+ * has not been recorded yet (`storeIdempotency` fills it in post-mutation).
+ * 0 is never a real HTTP status, so it can't collide with a cached response.
+ */
+const IDEMPOTENCY_PENDING_STATUS = 0;
+
+/**
+ * A reservation row older than this is considered orphaned (the reserving
+ * request died between its mutation batch and `storeIdempotency`) and is
+ * dropped so a retry isn't locked out forever. The trade-off: a retry after
+ * such a crash re-applies the mutation (at-least-once) instead of failing
+ * every replay permanently.
+ */
+const IDEMPOTENCY_RESERVATION_STALE_MS = 60_000;
+
+/**
+ * Lease guard evaluated *inside* the mutation batch itself (#289): the write
+ * proceeds only when no blocking lease exists at execution time. A blocking
+ * lease is an active (unreleased, unexpired) lease whose id differs from the
+ * presented `lease_id`. Because D1 batches run as a single transaction, this
+ * closes the TOCTOU window a separate check-then-write had: a lease that
+ * expires or is handed off to a new holder after a pre-check can no longer
+ * let the stale writer's batch land.
+ *
+ * Bind order: projectId, stateKey, now, presented lease id (or "" for none).
+ */
+const LEASE_GUARD_SQL = `NOT EXISTS (
+  SELECT 1 FROM state_leases
+  WHERE project_id = ? AND state_key = ? AND released_at IS NULL AND expires_at > ? AND id <> ?
+)`;
+
+const LEASE_GUARD_FAILED: StateServiceError = {
+  code: "LEASE_CONFLICT",
+  message: "lease_id does not match active lease",
+  status: 409,
+};
+
+const IDEMPOTENCY_IN_PROGRESS: StateServiceError = {
+  code: "IDEMPOTENCY_IN_PROGRESS",
+  message: "A request with this Idempotency-Key is currently being processed; retry shortly",
+  status: 409,
+};
+
+const IDEMPOTENCY_CONFLICT: StateServiceError = {
+  code: "IDEMPOTENCY_CONFLICT",
+  message: "Idempotency-Key was already used for a different request",
+  status: 409,
+};
 
 export interface StateResponse {
   state_key: string;
@@ -76,6 +128,7 @@ type IdempotencyRow = {
   request_hash: string;
   response_status: number;
   response_body: string;
+  created_at: number;
 };
 
 function normalizeTags(tags: string[] | undefined): string[] {
@@ -115,6 +168,13 @@ export async function buildIdempotencyHash(method: string, stateKey: string, bod
   return sha256Hex(`${method}:${stateKey}:${encodeJson(body)}`);
 }
 
+function buildReplayResponse(status: number, body: string): Response {
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "application/json", "Idempotency-Replayed": "true" },
+  });
+}
+
 export async function readIdempotency(
   d1: D1Database,
   projectId: string,
@@ -125,7 +185,7 @@ export async function readIdempotency(
 
   const row = await d1
     .prepare(
-      "SELECT request_hash, response_status, response_body FROM idempotency_keys WHERE project_id = ? AND key = ? LIMIT 1",
+      "SELECT request_hash, response_status, response_body, created_at FROM idempotency_keys WHERE project_id = ? AND key = ? LIMIT 1",
     )
     .bind(projectId, key)
     .first<IdempotencyRow>();
@@ -133,23 +193,34 @@ export async function readIdempotency(
   if (!row) return {};
 
   if (row.request_hash !== requestHash) {
-    return {
-      error: {
-        code: "IDEMPOTENCY_CONFLICT",
-        message: "Idempotency-Key was already used for a different request",
-        status: 409,
-      },
-    };
+    return { error: IDEMPOTENCY_CONFLICT };
   }
 
-  return {
-    replay: new Response(row.response_body, {
-      status: row.response_status,
-      headers: { "Content-Type": "application/json", "Idempotency-Replayed": "true" },
-    }),
-  };
+  if (row.response_status === IDEMPOTENCY_PENDING_STATUS) {
+    if (row.created_at <= Date.now() - IDEMPOTENCY_RESERVATION_STALE_MS) {
+      // Orphaned reservation (the reserving request never recorded its
+      // response). Drop it so this retry can claim the key and proceed.
+      await d1
+        .prepare(
+          "DELETE FROM idempotency_keys WHERE project_id = ? AND key = ? AND response_status = ?",
+        )
+        .bind(projectId, key, IDEMPOTENCY_PENDING_STATUS)
+        .run();
+      return {};
+    }
+    return { error: IDEMPOTENCY_IN_PROGRESS };
+  }
+
+  return { replay: buildReplayResponse(row.response_status, row.response_body) };
 }
 
+/**
+ * Record the final response for an idempotency key claimed by the mutation
+ * batch (see the reservation statement in `upsertState`/`deleteState`). This
+ * is an UPDATE of the reservation row, not an insert: the *claim* of the key
+ * happens atomically with the mutation itself (#290), and this merely fills
+ * in the response for future replays.
+ */
 export async function storeIdempotency(
   d1: D1Database,
   projectId: string,
@@ -162,10 +233,40 @@ export async function storeIdempotency(
 
   await d1
     .prepare(
-      "INSERT OR IGNORE INTO idempotency_keys (id, project_id, key, request_hash, response_status, response_body, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      "UPDATE idempotency_keys SET response_status = ?, response_body = ? WHERE project_id = ? AND key = ? AND request_hash = ? AND response_status = ?",
     )
-    .bind(generateId(), projectId, key, requestHash, status, encodeJson(body), Date.now())
+    .bind(status, encodeJson(body), projectId, key, requestHash, IDEMPOTENCY_PENDING_STATUS)
     .run();
+}
+
+/**
+ * After the mutation batch failed on the idempotency-key unique index, decide
+ * what the caller should see: a replay of the winner's stored response, an
+ * IDEMPOTENCY_CONFLICT for a different request reusing the key, or
+ * IDEMPOTENCY_IN_PROGRESS while the winner is still executing. In every case
+ * the loser's mutation was rolled back with the batch — nothing was applied.
+ */
+async function resolveIdempotencyRace(
+  d1: D1Database,
+  projectId: string,
+  key: string,
+  requestHash: string,
+): Promise<{ replay?: Response; error?: StateServiceError }> {
+  const row = await d1
+    .prepare(
+      "SELECT request_hash, response_status, response_body, created_at FROM idempotency_keys WHERE project_id = ? AND key = ? LIMIT 1",
+    )
+    .bind(projectId, key)
+    .first<IdempotencyRow>();
+
+  if (row) {
+    if (row.request_hash !== requestHash) return { error: IDEMPOTENCY_CONFLICT };
+    if (row.response_status !== IDEMPOTENCY_PENDING_STATUS) {
+      return { replay: buildReplayResponse(row.response_status, row.response_body) };
+    }
+  }
+
+  return { error: IDEMPOTENCY_IN_PROGRESS };
 }
 
 export async function getLatestState(
@@ -249,6 +350,13 @@ export async function listStateEvents(
   return (result.results ?? []).map(mapStateEventRow);
 }
 
+/**
+ * Best-effort, read-only classification of why a write was (or would be)
+ * rejected by the active lease. NOT the enforcement mechanism: the actual
+ * gate is `LEASE_GUARD_SQL`, evaluated atomically inside the mutation batch
+ * (#289). This runs only after the guard rejected a write, to pick the most
+ * helpful error code (LEASE_REQUIRED vs LEASE_CONFLICT).
+ */
 async function enforceLease(
   d1: D1Database,
   projectId: string,
@@ -296,10 +404,8 @@ export async function upsertState(
   stateKey: string,
   input: UpsertStateInput,
   idempotencyKey?: string,
-): Promise<{ result?: StateMutationResult; error?: StateServiceError }> {
-  const leaseError = await enforceLease(d1, projectId, stateKey, input.lease_id);
-  if (leaseError) return { error: leaseError };
-
+  requestHash?: string,
+): Promise<{ result?: StateMutationResult; replay?: Response; error?: StateServiceError }> {
   const now = Date.now();
   const eventId = generateId();
   const stateId = generateId();
@@ -308,12 +414,45 @@ export async function upsertState(
   const data = encodeJson(input.data);
   const metadata = input.metadata === undefined ? null : encodeJson(input.metadata);
   const tagsJson = encodeJson(tags);
+  const leaseGuardParams = [projectId, stateKey, now, input.lease_id ?? ""];
 
-  const statements = [
+  const statements: D1PreparedStatement[] = [];
+
+  // Idempotency-key claim (#290): a plain (non-IGNORE) guarded INSERT inside
+  // the same transaction as the mutation. When two requests race with the
+  // same key, the loser's whole batch fails on the unique index and rolls
+  // back — its mutation never applies. The lease guard keeps a lease-rejected
+  // request from burning the key.
+  if (idempotencyKey && requestHash) {
+    statements.push(
+      d1
+        .prepare(
+          `INSERT INTO idempotency_keys (id, project_id, key, request_hash, response_status, response_body, created_at)
+           SELECT ?, ?, ?, ?, ?, '', ?
+           WHERE ${LEASE_GUARD_SQL}`,
+        )
+        .bind(
+          generateId(),
+          projectId,
+          idempotencyKey,
+          requestHash,
+          IDEMPOTENCY_PENDING_STATUS,
+          now,
+          ...leaseGuardParams,
+        ),
+    );
+  }
+
+  // Every mutation statement is conditional: the event INSERT on the lease
+  // guard (#289), the rest on the event row having been written — so a lost
+  // lease means the batch writes exactly nothing.
+  const eventStatementIndex = statements.length;
+  statements.push(
     d1
       .prepare(
         `INSERT INTO state_events (id, project_id, state_key, agent_id, event_type, data, metadata, tags, idempotency_key, created_at)
-         VALUES (?, ?, ?, ?, 'upsert', ?, ?, ?, ?, ?)`,
+         SELECT ?, ?, ?, ?, 'upsert', ?, ?, ?, ?, ?
+         WHERE ${LEASE_GUARD_SQL}`,
       )
       .bind(
         eventId,
@@ -325,11 +464,13 @@ export async function upsertState(
         tagsJson,
         idempotencyKey ?? null,
         now,
+        ...leaseGuardParams,
       ),
     d1
       .prepare(
         `INSERT INTO agent_states (id, project_id, state_key, agent_id, data, metadata, tags, latest_sequence, deleted_at, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, (SELECT sequence FROM state_events WHERE id = ?), NULL, ?, ?)
+         SELECT ?, ?, ?, ?, ?, ?, ?, e.sequence, NULL, ?, ?
+         FROM state_events e WHERE e.id = ?
          ON CONFLICT(project_id, state_key) DO UPDATE SET
            agent_id = excluded.agent_id,
            data = excluded.data,
@@ -347,29 +488,50 @@ export async function upsertState(
         data,
         metadata,
         tagsJson,
+        now,
+        now,
         eventId,
-        now,
-        now,
       ),
     d1
-      .prepare("DELETE FROM state_tags WHERE project_id = ? AND state_key = ?")
-      .bind(projectId, stateKey),
+      .prepare(
+        "DELETE FROM state_tags WHERE project_id = ? AND state_key = ? AND EXISTS (SELECT 1 FROM state_events WHERE id = ?)",
+      )
+      .bind(projectId, stateKey, eventId),
     ...tags.map((tag) =>
       d1
         .prepare(
-          "INSERT INTO state_tags (id, project_id, state_key, tag, created_at) VALUES (?, ?, ?, ?, ?)",
+          `INSERT INTO state_tags (id, project_id, state_key, tag, created_at)
+           SELECT ?, ?, ?, ?, ?
+           WHERE EXISTS (SELECT 1 FROM state_events WHERE id = ?)`,
         )
-        .bind(generateId(), projectId, stateKey, tag, now),
+        .bind(generateId(), projectId, stateKey, tag, now, eventId),
     ),
     d1
       .prepare(
         `INSERT INTO state_snapshots (id, project_id, state_key, sequence, data, metadata, tags, deleted_at, created_at)
-         VALUES (?, ?, ?, (SELECT sequence FROM state_events WHERE id = ?), ?, ?, ?, NULL, ?)`,
+         SELECT ?, ?, ?, e.sequence, ?, ?, ?, NULL, ?
+         FROM state_events e WHERE e.id = ?`,
       )
-      .bind(snapshotId, projectId, stateKey, eventId, data, metadata, tagsJson, now),
-  ];
+      .bind(snapshotId, projectId, stateKey, data, metadata, tagsJson, now, eventId),
+  );
 
-  await d1.batch(statements);
+  let results: D1Result[];
+  try {
+    results = await d1.batch(statements);
+  } catch (err) {
+    if (idempotencyKey && requestHash && isUniqueViolation(err)) {
+      return resolveIdempotencyRace(d1, projectId, idempotencyKey, requestHash);
+    }
+    throw err;
+  }
+
+  if ((results[eventStatementIndex]?.meta.changes ?? 0) === 0) {
+    // The in-batch guard rejected the write. Re-derive a precise error code
+    // (LEASE_REQUIRED vs LEASE_CONFLICT/expired hand-off) for the caller.
+    const leaseError = await enforceLease(d1, projectId, stateKey, input.lease_id);
+    return { error: leaseError ?? LEASE_GUARD_FAILED };
+  }
+
   const event = await loadEventById(d1, eventId);
   const state = await getLatestState(d1, projectId, stateKey);
   if (!state) throw new Error("State was not written");
@@ -381,7 +543,9 @@ export async function deleteState(
   projectId: string,
   stateKey: string,
   leaseId?: string,
-): Promise<{ result?: StateMutationResult; error?: StateServiceError }> {
+  idempotencyKey?: string,
+  requestHash?: string,
+): Promise<{ result?: StateMutationResult; replay?: Response; error?: StateServiceError }> {
   const existing = await d1
     .prepare(
       "SELECT state_key, agent_id, data, metadata, tags, latest_sequence, created_at, updated_at, deleted_at FROM agent_states WHERE project_id = ? AND state_key = ? AND deleted_at IS NULL LIMIT 1",
@@ -393,35 +557,88 @@ export async function deleteState(
     return { error: { code: "NOT_FOUND", message: "State not found", status: 404 } };
   }
 
-  const leaseError = await enforceLease(d1, projectId, stateKey, leaseId);
-  if (leaseError) return { error: leaseError };
-
   const now = Date.now();
   const eventId = generateId();
-  await d1.batch([
+  const leaseGuardParams = [projectId, stateKey, now, leaseId ?? ""];
+
+  const statements: D1PreparedStatement[] = [];
+
+  // Same atomic idempotency-key claim as upsertState (#290).
+  if (idempotencyKey && requestHash) {
+    statements.push(
+      d1
+        .prepare(
+          `INSERT INTO idempotency_keys (id, project_id, key, request_hash, response_status, response_body, created_at)
+           SELECT ?, ?, ?, ?, ?, '', ?
+           WHERE ${LEASE_GUARD_SQL}`,
+        )
+        .bind(
+          generateId(),
+          projectId,
+          idempotencyKey,
+          requestHash,
+          IDEMPOTENCY_PENDING_STATUS,
+          now,
+          ...leaseGuardParams,
+        ),
+    );
+  }
+
+  // Same atomic lease gating as upsertState (#289): the tombstone event is
+  // lease-guarded, and the remaining statements apply only if it was written.
+  const eventStatementIndex = statements.length;
+  statements.push(
     d1
       .prepare(
         `INSERT INTO state_events (id, project_id, state_key, agent_id, event_type, data, metadata, tags, idempotency_key, created_at)
-         VALUES (?, ?, ?, ?, 'delete', NULL, ?, ?, NULL, ?)`,
+         SELECT ?, ?, ?, ?, 'delete', NULL, ?, ?, NULL, ?
+         WHERE ${LEASE_GUARD_SQL}`,
       )
-      .bind(eventId, projectId, stateKey, existing.agent_id, existing.metadata, existing.tags, now),
+      .bind(
+        eventId,
+        projectId,
+        stateKey,
+        existing.agent_id,
+        existing.metadata,
+        existing.tags,
+        now,
+        ...leaseGuardParams,
+      ),
     d1
       .prepare(
         `UPDATE agent_states
          SET latest_sequence = (SELECT sequence FROM state_events WHERE id = ?), deleted_at = ?, updated_at = ?
-         WHERE project_id = ? AND state_key = ?`,
+         WHERE project_id = ? AND state_key = ? AND EXISTS (SELECT 1 FROM state_events WHERE id = ?)`,
       )
-      .bind(eventId, now, now, projectId, stateKey),
+      .bind(eventId, now, now, projectId, stateKey, eventId),
     d1
-      .prepare("DELETE FROM state_tags WHERE project_id = ? AND state_key = ?")
-      .bind(projectId, stateKey),
+      .prepare(
+        "DELETE FROM state_tags WHERE project_id = ? AND state_key = ? AND EXISTS (SELECT 1 FROM state_events WHERE id = ?)",
+      )
+      .bind(projectId, stateKey, eventId),
     d1
       .prepare(
         `INSERT INTO state_snapshots (id, project_id, state_key, sequence, data, metadata, tags, deleted_at, created_at)
-         VALUES (?, ?, ?, (SELECT sequence FROM state_events WHERE id = ?), NULL, ?, ?, ?, ?)`,
+         SELECT ?, ?, ?, e.sequence, NULL, ?, ?, ?, ?
+         FROM state_events e WHERE e.id = ?`,
       )
-      .bind(generateId(), projectId, stateKey, eventId, existing.metadata, existing.tags, now, now),
-  ]);
+      .bind(generateId(), projectId, stateKey, existing.metadata, existing.tags, now, now, eventId),
+  );
+
+  let results: D1Result[];
+  try {
+    results = await d1.batch(statements);
+  } catch (err) {
+    if (idempotencyKey && requestHash && isUniqueViolation(err)) {
+      return resolveIdempotencyRace(d1, projectId, idempotencyKey, requestHash);
+    }
+    throw err;
+  }
+
+  if ((results[eventStatementIndex]?.meta.changes ?? 0) === 0) {
+    const leaseError = await enforceLease(d1, projectId, stateKey, leaseId);
+    return { error: leaseError ?? LEASE_GUARD_FAILED };
+  }
 
   const event = await loadEventById(d1, eventId);
   return { result: { status: 200, body: { deleted: true, event }, event } };

--- a/packages/api/test/oauth.test.ts
+++ b/packages/api/test/oauth.test.ts
@@ -683,6 +683,9 @@ describe("OAuth 2.1 server", () => {
     });
 
     it("rejects an unknown refresh token", async () => {
+      // The client must exist: an unknown client_id fails earlier with
+      // invalid_client (#278); this test targets the token-lookup path.
+      await insertClient({ id: "client_rt", redirectUris: [REDIRECT] });
       const res = await SELF.fetch("http://localhost/api/oauth/token", {
         method: "POST",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -712,7 +715,9 @@ describe("OAuth 2.1 server", () => {
       expect(body.error).toBe("invalid_request");
     });
 
-    it("rejects a refresh token redeemed with the wrong client_id", async () => {
+    it("rejects a refresh token redeemed with the wrong (unregistered) client_id", async () => {
+      // An unknown client_id now fails client authentication uniformly (#278)
+      // instead of leaking through to a later invalid_grant.
       const initial = await mintInitialTokens();
       const res = await SELF.fetch("http://localhost/api/oauth/token", {
         method: "POST",
@@ -721,6 +726,25 @@ describe("OAuth 2.1 server", () => {
           grant_type: "refresh_token",
           refresh_token: initial.refresh_token,
           client_id: "some_other_client",
+        }).toString(),
+      });
+      expect(res.status).toBe(401);
+      const body = await res.json<{ error: string }>();
+      expect(body.error).toBe("invalid_client");
+    });
+
+    it("rejects a refresh token redeemed by a different registered client with invalid_grant", async () => {
+      // Client-binding enforcement (distinct from client authentication): a
+      // real, registered client presenting someone else's refresh token.
+      const initial = await mintInitialTokens();
+      await insertClient({ id: "client_rt_other", redirectUris: [REDIRECT] });
+      const res = await SELF.fetch("http://localhost/api/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          refresh_token: initial.refresh_token,
+          client_id: "client_rt_other",
         }).toString(),
       });
       expect(res.status).toBe(400);
@@ -784,5 +808,65 @@ describe("OAuth 2.1 server", () => {
       });
       expect(res.status).toBe(400);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Client-existence oracle (#278)
+// ---------------------------------------------------------------------------
+
+describe("POST /api/oauth/token — client-existence oracle (#278)", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+  });
+
+  it("returns an identical response for an unknown client_id and a confidential client with a wrong secret", async () => {
+    // WHY: pre-#278, an unknown client_id fell through to a later 400
+    // invalid_grant while a known confidential client with a wrong secret got
+    // an immediate 401 invalid_client — a response-shape oracle revealing
+    // which client_ids exist as confidential clients.
+    await env.DB.prepare(
+      `INSERT INTO oauth_clients (id, client_secret_hash, client_name, redirect_uris, grant_types, token_endpoint_auth_method, created_at)
+       VALUES (?, ?, 'OracleConf', ?, '["authorization_code","refresh_token"]', 'client_secret_post', ?)`,
+    )
+      .bind(
+        "client_oracle_conf",
+        await hashApiKey("real-secret-for-oracle-test"),
+        JSON.stringify(["http://localhost:8788/cb"]),
+        Date.now(),
+      )
+      .run();
+
+    const probe = (clientId: string, withSecret: boolean) =>
+      SELF.fetch("http://localhost/api/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code: "garbage-code",
+          code_verifier: "garbage-verifier-garbage-verifier-garbage-ok",
+          client_id: clientId,
+          redirect_uri: "http://localhost:8788/cb",
+          ...(withSecret ? { client_secret: "wrong-secret" } : {}),
+        }).toString(),
+      });
+
+    // With a (wrong) secret presented.
+    const [unknownWithSecret, confWrongSecret] = [
+      await probe("client_does_not_exist", true),
+      await probe("client_oracle_conf", true),
+    ];
+    expect(unknownWithSecret.status).toBe(confWrongSecret.status);
+    expect(unknownWithSecret.status).toBe(401);
+    expect(await unknownWithSecret.json()).toEqual(await confWrongSecret.json());
+
+    // With no secret presented.
+    const [unknownNoSecret, confNoSecret] = [
+      await probe("client_does_not_exist", false),
+      await probe("client_oracle_conf", false),
+    ];
+    expect(unknownNoSecret.status).toBe(confNoSecret.status);
+    expect(unknownNoSecret.status).toBe(401);
+    expect(await unknownNoSecret.json()).toEqual(await confNoSecret.json());
   });
 });

--- a/packages/api/test/rate-limit.test.ts
+++ b/packages/api/test/rate-limit.test.ts
@@ -118,3 +118,29 @@ async function computeSHA256Hex(input: string): Promise<string> {
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
 }
+
+// ---------------------------------------------------------------------------
+// Env override parsing (#291)
+// ---------------------------------------------------------------------------
+
+describe("parsePositiveIntEnv", () => {
+  it("falls back to the default for blank/invalid overrides instead of a zero limit", async () => {
+    // WHY: Number("") === 0 is finite, so a naive guard turns an accidentally
+    // blank RATE_LIMIT_MAX into rateLimit = 0 — a self-inflicted full DoS.
+    const { parsePositiveIntEnv } = await import("../src/lib/env");
+
+    // Misconfigurations → documented default.
+    expect(parsePositiveIntEnv(undefined, 100)).toBe(100);
+    expect(parsePositiveIntEnv("", 100)).toBe(100);
+    expect(parsePositiveIntEnv("   ", 100)).toBe(100);
+    expect(parsePositiveIntEnv("0", 100)).toBe(100);
+    expect(parsePositiveIntEnv("-5", 100)).toBe(100);
+    expect(parsePositiveIntEnv("abc", 100)).toBe(100);
+    expect(parsePositiveIntEnv("1.5", 100)).toBe(100);
+    expect(parsePositiveIntEnv("Infinity", 100)).toBe(100);
+
+    // Valid overrides win.
+    expect(parsePositiveIntEnv("250", 100)).toBe(250);
+    expect(parsePositiveIntEnv("1", 100)).toBe(1);
+  });
+});

--- a/packages/api/test/state-platform.test.ts
+++ b/packages/api/test/state-platform.test.ts
@@ -324,3 +324,104 @@ describe("State platform", () => {
     expect((await failedVerify.json<any>()).status).toBe("failed");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Idempotency-Key atomicity (#290)
+// ---------------------------------------------------------------------------
+
+describe("Idempotency-Key atomicity", () => {
+  it("applies exactly one mutation when duplicate requests race with the same Idempotency-Key", async () => {
+    // WHY: The classic idempotency scenario is a client retry after a timed-out
+    // response — two identical requests in flight at once. The key claim happens
+    // in the same atomic batch as the mutation, so the loser's mutation rolls
+    // back entirely; the event log must show exactly ONE apply.
+    const { env } = await import("cloudflare:test");
+    const body = { agent_id: "agent-a", data: { attempt: 1 } };
+    const headers = { "Idempotency-Key": "race-key-1" };
+
+    const [first, second] = await Promise.all([
+      putState("idem-race", body, headers),
+      putState("idem-race", body, headers),
+    ]);
+
+    // At least one caller sees the applied write; a racer may get the stored
+    // replay (200) or a retriable 409 while the winner is mid-flight.
+    const statuses = [first.status, second.status];
+    expect(statuses).toContain(200);
+    for (const status of statuses) expect([200, 409]).toContain(status);
+
+    for (const table of ["state_events", "state_snapshots"]) {
+      const row = await env.DB.prepare(`SELECT COUNT(*) AS n FROM ${table} WHERE state_key = ?`)
+        .bind("idem-race")
+        .first<{ n: number }>();
+      expect(row?.n, table).toBe(1);
+    }
+  });
+
+  it("rejects a duplicate with 409 IDEMPOTENCY_IN_PROGRESS while the original is still executing, without applying it", async () => {
+    // Simulate the winner having claimed the key atomically (reservation row,
+    // response_status = 0) but not yet recorded its response.
+    const { env } = await import("cloudflare:test");
+    const { buildIdempotencyHash } = await import("../src/services/states");
+    const { TEST_PROJECT_ID } = await import("./setup");
+    const body = { agent_id: "agent-a", data: { attempt: 2 } };
+    const hash = await buildIdempotencyHash("PUT", "idem-pending", body);
+
+    await env.DB.prepare(
+      "INSERT INTO idempotency_keys (id, project_id, key, request_hash, response_status, response_body, created_at) VALUES (?, ?, ?, ?, 0, '', ?)",
+    )
+      .bind("idem_reservation_1", TEST_PROJECT_ID, "pending-key-1", hash, Date.now())
+      .run();
+
+    const res = await putState("idem-pending", body, { "Idempotency-Key": "pending-key-1" });
+    expect(res.status).toBe(409);
+    const resBody = await res.json<{ error: { code: string } }>();
+    expect(resBody.error.code).toBe("IDEMPOTENCY_IN_PROGRESS");
+
+    const events = await env.DB.prepare(
+      "SELECT COUNT(*) AS n FROM state_events WHERE state_key = ?",
+    )
+      .bind("idem-pending")
+      .first<{ n: number }>();
+    expect(events?.n).toBe(0);
+  });
+
+  it("recovers from an orphaned reservation (reserving request died before storing its response)", async () => {
+    const { env } = await import("cloudflare:test");
+    const { buildIdempotencyHash } = await import("../src/services/states");
+    const { TEST_PROJECT_ID } = await import("./setup");
+    const body = { agent_id: "agent-a", data: { attempt: 3 } };
+    const hash = await buildIdempotencyHash("PUT", "idem-orphan", body);
+
+    // Stale reservation, older than the 60s recovery window.
+    await env.DB.prepare(
+      "INSERT INTO idempotency_keys (id, project_id, key, request_hash, response_status, response_body, created_at) VALUES (?, ?, ?, ?, 0, '', ?)",
+    )
+      .bind("idem_reservation_2", TEST_PROJECT_ID, "orphan-key-1", hash, Date.now() - 120_000)
+      .run();
+
+    const res = await putState("idem-orphan", body, { "Idempotency-Key": "orphan-key-1" });
+    expect(res.status).toBe(200);
+
+    // The retry re-claimed the key and recorded its real response.
+    const row = await env.DB.prepare(
+      "SELECT response_status FROM idempotency_keys WHERE project_id = ? AND key = ?",
+    )
+      .bind(TEST_PROJECT_ID, "orphan-key-1")
+      .first<{ response_status: number }>();
+    expect(row?.response_status).toBe(200);
+  });
+
+  it("still replays the stored response for a completed request with the same key", async () => {
+    const body = { agent_id: "agent-a", data: { attempt: 4 } };
+    const headers = { "Idempotency-Key": "replay-key-1" };
+
+    const first = await putState("idem-replay", body, headers);
+    expect(first.status).toBe(200);
+
+    const second = await putState("idem-replay", body, headers);
+    expect(second.status).toBe(200);
+    expect(second.headers.get("Idempotency-Replayed")).toBe("true");
+    expect(await second.json()).toEqual(await first.json());
+  });
+});

--- a/packages/api/test/v2-leases-contention.test.ts
+++ b/packages/api/test/v2-leases-contention.test.ts
@@ -407,3 +407,98 @@ describe("Capability token revocation", () => {
     expect(body.error.code).toBe("UNAUTHORIZED");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Lease-gated writes: atomic guard (#289)
+// ---------------------------------------------------------------------------
+
+describe("Lease-gated state writes (atomic guard, #289)", () => {
+  it("rejects a delayed write presenting a stale lease id after an expiry hand-off (TOCTOU regression)", async () => {
+    // WHY: The exactly-one-writer guarantee must hold AT WRITE TIME, not just at
+    // an earlier check time. Scenario: worker-1 holds L1, L1 expires, worker-2
+    // acquires L2 (higher fencing token). Worker-1's delayed write replays with
+    // the stale L1 id — it must be rejected by the guard evaluated inside the
+    // same transaction as the write, and must leave zero rows behind.
+    const { env } = await import("cloudflare:test");
+    const token = await mintCapabilityToken(["lease:write"], "stale-writer");
+    const stateKey = "state:stale-write";
+
+    const l1Res = await acquireLease(stateKey, token.token, { holder: "worker-1", ttl_ms: 1000 });
+    expect(l1Res.status).toBe(201);
+    const l1 = await l1Res.json<LeaseResponse>();
+
+    // Let L1 expire, then hand the key off to worker-2.
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    const l2Res = await acquireLease(stateKey, token.token, { holder: "worker-2" });
+    expect(l2Res.status).toBe(201);
+    const l2 = await l2Res.json<LeaseResponse>();
+    expect(l2.fencing_token).toBeGreaterThan(l1.fencing_token);
+
+    // Worker-1's delayed write with the stale (expired, superseded) lease id.
+    const staleWrite = await SELF.fetch(`http://localhost/api/v1/states/${stateKey}`, {
+      method: "PUT",
+      headers: authHeaders(),
+      body: JSON.stringify({ agent_id: "worker-1", data: { winner: "worker-1" }, lease_id: l1.id }),
+    });
+    expect(staleWrite.status).toBe(409);
+    const staleBody = await staleWrite.json<{ error: { code: string } }>();
+    expect(staleBody.error.code).toBe("LEASE_CONFLICT");
+
+    // The rejected write left nothing behind — no event, no state, no snapshot.
+    for (const table of ["state_events", "agent_states", "state_snapshots"]) {
+      const row = await env.DB.prepare(`SELECT COUNT(*) AS n FROM ${table} WHERE state_key = ?`)
+        .bind(stateKey)
+        .first<{ n: number }>();
+      expect(row?.n, table).toBe(0);
+    }
+
+    // The current holder's write goes through.
+    const freshWrite = await SELF.fetch(`http://localhost/api/v1/states/${stateKey}`, {
+      method: "PUT",
+      headers: authHeaders(),
+      body: JSON.stringify({ agent_id: "worker-2", data: { winner: "worker-2" }, lease_id: l2.id }),
+    });
+    expect(freshWrite.status).toBe(200);
+    const freshBody = await freshWrite.json<{ data: { winner: string } }>();
+    expect(freshBody.data.winner).toBe("worker-2");
+  });
+
+  it("rejects a lease-gated DELETE presenting a stale lease id", async () => {
+    // WHY: deleteState shares the same guard; a stale holder must not be able
+    // to tombstone state owned by the new lease holder.
+    const { env } = await import("cloudflare:test");
+    const token = await mintCapabilityToken(["lease:write"], "stale-deleter");
+    const stateKey = "state:stale-delete";
+
+    // Seed state (no lease yet), then set up an L1 → L2 hand-off.
+    const seed = await SELF.fetch(`http://localhost/api/v1/states/${stateKey}`, {
+      method: "PUT",
+      headers: authHeaders(),
+      body: JSON.stringify({ agent_id: "worker-1", data: { keep: true } }),
+    });
+    expect(seed.status).toBe(200);
+
+    const l1Res = await acquireLease(stateKey, token.token, { holder: "worker-1", ttl_ms: 1000 });
+    expect(l1Res.status).toBe(201);
+    const l1 = await l1Res.json<LeaseResponse>();
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    const l2Res = await acquireLease(stateKey, token.token, { holder: "worker-2" });
+    expect(l2Res.status).toBe(201);
+
+    const staleDelete = await SELF.fetch(
+      `http://localhost/api/v1/states/${stateKey}?lease_id=${l1.id}`,
+      { method: "DELETE", headers: authHeaders() },
+    );
+    expect(staleDelete.status).toBe(409);
+    const body = await staleDelete.json<{ error: { code: string } }>();
+    expect(body.error.code).toBe("LEASE_CONFLICT");
+
+    // State is still live — no tombstone landed.
+    const row = await env.DB.prepare(
+      "SELECT deleted_at FROM agent_states WHERE state_key = ? LIMIT 1",
+    )
+      .bind(stateKey)
+      .first<{ deleted_at: number | null }>();
+    expect(row?.deleted_at).toBeNull();
+  });
+});

--- a/packages/dashboard/src/components/app-shell.tsx
+++ b/packages/dashboard/src/components/app-shell.tsx
@@ -190,6 +190,9 @@ function SecondaryLinks({ onNavigate }: { onNavigate?: () => void }) {
             >
               <Icon size={15} weight="regular" />
               <span>{it.title}</span>
+              {/* The ArrowUpRight affordance is aria-hidden, so give screen
+                  readers an equivalent cue that this link leaves the app (#324). */}
+              <span className="sr-only">(leaves dashboard)</span>
               <ArrowUpRight
                 size={12}
                 weight="bold"

--- a/packages/dashboard/src/components/dashboard/analytics/analytics-page-content.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/analytics-page-content.tsx
@@ -20,17 +20,33 @@ export function AnalyticsPageContent() {
   const [data, setData] = useState<AnalyticsResponse | null>(null);
   const [loadingAnalytics, setLoadingAnalytics] = useState(false);
 
-  // Fetch analytics when the active project or range changes
+  // Fetch analytics when the active project or range changes. The `active`
+  // flag (same pattern as _use-traces-data.ts) prevents a slower stale
+  // response from overwriting fresher data on rapid range/project switches
+  // (#317); clearing data up front avoids skeleton + stale chart rendering
+  // simultaneously (#323).
   useEffect(() => {
     if (!selectedProjectId) return;
+    let active = true;
     setLoadingAnalytics(true);
+    setData(null);
     api<AnalyticsResponse>(`/v1/projects/${selectedProjectId}/analytics?range=${range}`)
-      .then(setData)
+      .then((res) => {
+        if (!active) return;
+        setData(res);
+      })
       .catch((e) => {
+        if (!active) return;
         setData(null);
         toast.error(e instanceof Error ? e.message : "Failed to load analytics");
       })
-      .finally(() => setLoadingAnalytics(false));
+      .finally(() => {
+        if (!active) return;
+        setLoadingAnalytics(false);
+      });
+    return () => {
+      active = false;
+    };
   }, [selectedProjectId, range]);
 
   const loading = loadingProjects || loadingAnalytics;

--- a/packages/dashboard/src/components/dashboard/analytics/analytics-page-content.tsx
+++ b/packages/dashboard/src/components/dashboard/analytics/analytics-page-content.tsx
@@ -36,7 +36,7 @@ export function AnalyticsPageContent() {
   const loading = loadingProjects || loadingAnalytics;
 
   return (
-    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
+    <div className="page-wrap">
       <AnalyticsHeader range={range} onRangeChange={setRange} />
 
       {loading && <AnalyticsLoading hasData={!!data} />}

--- a/packages/dashboard/src/components/dashboard/conversations/_use-conversations-data.ts
+++ b/packages/dashboard/src/components/dashboard/conversations/_use-conversations-data.ts
@@ -29,19 +29,33 @@ export function useConversationsData(): UseConversationsDataResult {
   const [loadingConversations, setLoadingConversations] = useState(false);
   const [hasMore, setHasMore] = useState(true);
 
-  // Fetch conversations when the active project changes
+  // Fetch conversations when the active project changes. The `active` flag
+  // (same pattern as _use-traces-data.ts) keeps a slower stale response from
+  // a previous project overwriting the current one on rapid sidebar
+  // switching, and avoids setState after unmount (#318).
   useEffect(() => {
     if (!selectedProjectId) return;
+    let active = true;
     setLoadingConversations(true);
     setConversations([]);
     setHasMore(true);
     api<{ data: Conversation[] }>(`/v1/projects/${selectedProjectId}/conversations?limit=50`)
       .then((res) => {
+        if (!active) return;
         setConversations(res.data);
         setHasMore(res.data.length >= 50);
       })
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load data"))
-      .finally(() => setLoadingConversations(false));
+      .catch((e) => {
+        if (!active) return;
+        toast.error(e instanceof Error ? e.message : "Failed to load data");
+      })
+      .finally(() => {
+        if (!active) return;
+        setLoadingConversations(false);
+      });
+    return () => {
+      active = false;
+    };
   }, [selectedProjectId]);
 
   const appendConversations = (newConversations: Conversation[]) => {

--- a/packages/dashboard/src/components/dashboard/conversations/conversations-page.tsx
+++ b/packages/dashboard/src/components/dashboard/conversations/conversations-page.tsx
@@ -53,7 +53,7 @@ function ConversationsContent() {
   const showLoadMore = hasMore && conversations.length > 0;
 
   return (
-    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
+    <div className="page-wrap">
       <PageHeader
         title="Conversations"
         description={

--- a/packages/dashboard/src/components/dashboard/domains/_use-domains-list.ts
+++ b/packages/dashboard/src/components/dashboard/domains/_use-domains-list.ts
@@ -1,5 +1,5 @@
 import type { CustomDomainResponse } from "@agentstate/shared";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { loadDomains } from "./_domains-service";
 
@@ -7,15 +7,33 @@ export function useDomainsList(projectId: string | null) {
   const [domains, setDomains] = useState<CustomDomainResponse[]>([]);
   const [loading, setLoading] = useState(true);
 
+  // Guards against setState after unmount and against a slower stale response
+  // from a previous project overwriting the current one (#319). `mountedRef`
+  // covers unmount; `projectIdRef` covers project switches mid-flight.
+  const mountedRef = useRef(true);
+  const projectIdRef = useRef(projectId);
+  projectIdRef.current = projectId;
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   const loadDomainsData = useCallback(async () => {
     if (!projectId) return;
     try {
       const data = await loadDomains(projectId);
+      if (!mountedRef.current || projectIdRef.current !== projectId) return;
       setDomains(data);
     } catch (e) {
+      if (!mountedRef.current || projectIdRef.current !== projectId) return;
       toast.error(e instanceof Error ? e.message : "Failed to load domains");
     } finally {
-      setLoading(false);
+      if (mountedRef.current && projectIdRef.current === projectId) {
+        setLoading(false);
+      }
     }
   }, [projectId]);
 

--- a/packages/dashboard/src/components/dashboard/domains/domains-content.tsx
+++ b/packages/dashboard/src/components/dashboard/domains/domains-content.tsx
@@ -41,7 +41,7 @@ export function DomainsContent() {
     <Suspense
       fallback={<div className="h-32 animate-pulse rounded-[var(--radius-lg)] bg-panel2" />}
     >
-      <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
+      <div className="page-wrap">
         <PageHeader
           title="Custom Domains"
           description="Add a custom domain to serve your project from your own domain with SSL."

--- a/packages/dashboard/src/components/dashboard/integrate/integrate-content.tsx
+++ b/packages/dashboard/src/components/dashboard/integrate/integrate-content.tsx
@@ -136,7 +136,7 @@ export default function IntegrateContent() {
   const isCurl = fw === "rest";
 
   return (
-    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
+    <div className="page-wrap">
       <PageHeader
         title="Integrate"
         description="Pick your framework — copy the adapter and you're persisting state."

--- a/packages/dashboard/src/components/dashboard/integrate/integrate-content.tsx
+++ b/packages/dashboard/src/components/dashboard/integrate/integrate-content.tsx
@@ -8,6 +8,7 @@ import { PageHeader } from "@/components/dashboard/page-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { AGENTS_MD_URL, API_BASE_URL, MCP_URL } from "@/lib/site";
 import { cn } from "@/lib/utils";
 
 // Per-framework adapter snippets — copy one of these and you're persisting state.
@@ -86,24 +87,24 @@ const res = await ai.chat.completions.create({
 });
 await state.appendMessages(id, [res.choices[0].message]);`,
   rest: `# create a conversation
-curl -X POST https://agentstate.app/api/v1/conversations \\
+curl -X POST ${API_BASE_URL}/v1/conversations \\
   -H "Authorization: Bearer as_live_..." \\
   -H "Content-Type: application/json" \\
   -d '{"messages":[{"role":"user","content":"Hi"}]}'
 
 # retrieve it later
-curl https://agentstate.app/api/v1/conversations/:id \\
+curl ${API_BASE_URL}/v1/conversations/:id \\
   -H "Authorization: Bearer as_live_..."`,
 };
 
-const MCP_REMOTE_URL = "https://agentstate.app/api/mcp";
+const MCP_REMOTE_URL = MCP_URL;
 
 // Token mode — paste an API key (or capability token); no browser sign-in needed.
 const MCP_TOKEN_CONFIG = `{
   "mcpServers": {
     "agentstate": {
       "type": "http",
-      "url": "https://agentstate.app/api/mcp",
+      "url": "${MCP_URL}",
       "headers": { "Authorization": "Bearer as_live_..." }
     }
   }
@@ -114,7 +115,7 @@ const MCP_OAUTH_CONFIG = `{
   "mcpServers": {
     "agentstate": {
       "type": "http",
-      "url": "https://agentstate.app/api/mcp"
+      "url": "${MCP_URL}"
     }
   }
 }`;
@@ -122,9 +123,9 @@ const MCP_OAUTH_CONFIG = `{
 const INTEGRATION_PROMPT = `Integrate AgentState into this project for persistent conversation storage.
 
 Read the full integration guide and implement it:
-https://agentstate.app/agents.md
+${AGENTS_MD_URL}
 
-API Base: https://agentstate.app/api
+API Base: ${API_BASE_URL}
 Auth: Bearer token in Authorization header (key starts with as_live_)
 
 After reading agents.md, store all conversation turns via the API so history persists across sessions.`;
@@ -193,7 +194,7 @@ export default function IntegrateContent() {
 
           <div className="flex items-center justify-between rounded-[var(--radius)] border border-edge bg-panel2 px-4 py-3.5">
             <span className="text-[13px] text-fg-3">Need the full guide for {active.name}?</span>
-            <a href="https://agentstate.app/agents.md" target="_blank" rel="noreferrer">
+            <a href={AGENTS_MD_URL} target="_blank" rel="noreferrer">
               <Button variant="ghost" className="min-h-0 px-2.5 py-1 text-fg-3">
                 agents.md
                 <ArrowUpRightIcon aria-hidden="true" />
@@ -263,7 +264,7 @@ export default function IntegrateContent() {
             API reference
           </Link>
           <Link
-            href="https://agentstate.app/agents.md"
+            href={AGENTS_MD_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="transition-colors hover:text-fg"

--- a/packages/dashboard/src/components/dashboard/keys/keys-page.tsx
+++ b/packages/dashboard/src/components/dashboard/keys/keys-page.tsx
@@ -82,7 +82,7 @@ function KeysContent() {
   };
 
   return (
-    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
+    <div className="page-wrap">
       <PageHeader
         title="API Keys"
         description="Project-scoped keys your agents use to authenticate against the API. Keep them secret."

--- a/packages/dashboard/src/components/dashboard/organizations/create/_create-org-loading.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/_create-org-loading.tsx
@@ -3,7 +3,7 @@ import { Card } from "@/components/ui/card";
 
 export function CreateOrgLoading() {
   return (
-    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
+    <div className="page-wrap">
       <div className="flex items-start gap-3">
         <span className="mt-0.5 grid size-8 shrink-0 place-items-center rounded-[var(--radius)] text-fg-4">
           <ArrowLeftIcon className="size-4" aria-hidden="true" />

--- a/packages/dashboard/src/components/dashboard/organizations/create/create-org-content.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/create-org-content.tsx
@@ -31,7 +31,7 @@ export function CreateOrgContent() {
   const existingOrgDomain = advisory?.meta?.organization_domain;
 
   return (
-    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
+    <div className="page-wrap">
       <CreateOrgHeader />
       <CreateOrgForm
         organizationName={organizationName}

--- a/packages/dashboard/src/components/dashboard/organizations/create/create-org-content.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/create-org-content.tsx
@@ -1,4 +1,4 @@
-import { useOrganizationCreationDefaults, useOrganizationList, useUser } from "@clerk/react";
+import { SignIn, useOrganizationCreationDefaults, useOrganizationList, useUser } from "@clerk/react";
 import * as React from "react";
 import { CreateOrgForm } from "./_create-org-form";
 import { CreateOrgHeader } from "./_create-org-header";
@@ -11,8 +11,17 @@ export function CreateOrgContent() {
   const [organizationName, setOrganizationName] = React.useState("");
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 
+  // Seed the name from Clerk's suggested defaults, but never after the user
+  // has started typing — a defaults refetch completing mid-edit must not
+  // stomp their input (#322).
+  const hasUserEditedRef = React.useRef(false);
+  const handleNameChange = React.useCallback((name: string) => {
+    hasUserEditedRef.current = true;
+    setOrganizationName(name);
+  }, []);
+
   React.useEffect(() => {
-    if (defaults?.form.name) {
+    if (defaults?.form.name && !hasUserEditedRef.current) {
       setOrganizationName(defaults.form.name);
     }
   }, [defaults?.form.name]);
@@ -21,8 +30,15 @@ export function CreateOrgContent() {
     return <CreateOrgLoading />;
   }
 
+  // Normally unreachable — AppShell's Gate already blocks signed-out users —
+  // but if this component is ever mounted outside the Gate, show the same
+  // sign-in prompt instead of a blank page (#321).
   if (!isSignedIn) {
-    return null;
+    return (
+      <div className="flex min-h-[50dvh] items-center justify-center px-4">
+        <SignIn routing="hash" />
+      </div>
+    );
   }
 
   const advisory = defaults?.advisory;
@@ -35,7 +51,7 @@ export function CreateOrgContent() {
       <CreateOrgHeader />
       <CreateOrgForm
         organizationName={organizationName}
-        setOrganizationName={setOrganizationName}
+        setOrganizationName={handleNameChange}
         isSubmitting={isSubmitting}
         setIsSubmitting={setIsSubmitting}
         createOrganization={createOrganization}

--- a/packages/dashboard/src/components/dashboard/organizations/list/organizations-list-content.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/list/organizations-list-content.tsx
@@ -28,7 +28,7 @@ export function OrganizationsListContent() {
 
   if (!isUserLoaded || !isOrgListLoaded) {
     return (
-      <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
+      <div className="page-wrap">
         <PageHeader title="Organizations" description="Manage your organizations and members" />
         <OrgListSkeleton />
       </div>
@@ -40,7 +40,7 @@ export function OrganizationsListContent() {
   }
 
   return (
-    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
+    <div className="page-wrap">
       <PageHeader
         title="Organizations"
         description="Manage your organizations and members"

--- a/packages/dashboard/src/components/dashboard/organizations/members/members-content.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/members/members-content.tsx
@@ -65,7 +65,7 @@ export function MembersContent() {
   // Loading state
   if (!isUserLoaded || !isOrgListLoaded || !isOrgLoaded) {
     return (
-      <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
+      <div className="page-wrap">
         <_PageHeader isLoading />
         <_MembersSkeleton />
       </div>
@@ -75,7 +75,7 @@ export function MembersContent() {
   // Not signed in or no organization
   if (!isSignedIn || !organization) {
     return (
-      <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
+      <div className="page-wrap">
         <_PageHeader />
         <Card className="card-padding flex flex-col gap-tight">
           <h2 className="text-[16px] font-semibold text-fg">No organization selected</h2>
@@ -88,7 +88,7 @@ export function MembersContent() {
   }
 
   return (
-    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
+    <div className="page-wrap">
       <_PageHeader organizationName={organization.name} />
       <InviteMemberForm isInviting={isInviting} onInvite={inviteMember} />
       <MembersList

--- a/packages/dashboard/src/components/dashboard/project/_loading-state.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_loading-state.tsx
@@ -2,7 +2,7 @@ import { PageHeaderSkeleton, StatsCardsSkeleton } from "@/components/dashboard/l
 
 export function _ProjectLoadingState() {
   return (
-    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
+    <div className="page-wrap">
       <PageHeaderSkeleton />
       <StatsCardsSkeleton count={4} />
       <div className="flex flex-col gap-component">

--- a/packages/dashboard/src/components/dashboard/project/_page-header.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_page-header.tsx
@@ -3,6 +3,7 @@
 import { ArrowLeft, Database, Globe } from "@phosphor-icons/react";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
+import { API_BASE_URL } from "@/lib/site";
 
 interface PageHeaderProps {
   name: string;
@@ -38,7 +39,7 @@ export function _PageHeader({ name, slug }: PageHeaderProps) {
           </div>
           <div className="flex items-center gap-2 rounded-[var(--radius)] border border-edge bg-panel2 px-2.5 py-2">
             <Globe className="size-3.5" aria-hidden />
-            <span className="num truncate font-mono">https://agentstate.app/api</span>
+            <span className="num truncate font-mono">{API_BASE_URL}</span>
           </div>
         </div>
       </div>

--- a/packages/dashboard/src/components/dashboard/project/_project-details.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_project-details.tsx
@@ -2,6 +2,7 @@
 
 import type { ProjectDetailResponse } from "@agentstate/shared";
 import { Card } from "@/components/ui/card";
+import { API_BASE_URL } from "@/lib/site";
 
 interface ProjectDetailsProps {
   project: ProjectDetailResponse;
@@ -17,7 +18,7 @@ export function _ProjectDetails({ project }: ProjectDetailsProps) {
         </p>
         <p suppressHydrationWarning>Created: {new Date(project.created_at).toLocaleString()}</p>
         <p>
-          Base URL: <code className="num font-mono text-fg-2">https://agentstate.app/api</code>
+          Base URL: <code className="num font-mono text-fg-2">{API_BASE_URL}</code>
         </p>
       </div>
     </Card>

--- a/packages/dashboard/src/components/dashboard/project/_quick-start-code.tsx
+++ b/packages/dashboard/src/components/dashboard/project/_quick-start-code.tsx
@@ -1,6 +1,7 @@
 import { CodeBlock } from "@/components/brand/code-block";
+import { API_BASE_URL } from "@/lib/site";
 
-const QUICK_START_SNIPPET = `curl -X POST https://agentstate.app/api/v1/conversations \\
+const QUICK_START_SNIPPET = `curl -X POST ${API_BASE_URL}/v1/conversations \\
   -H "Authorization: Bearer <your-key>" \\
   -H "Content-Type: application/json" \\
   -d '{"messages": [{"role": "user", "content": "Hello"}]}'`;

--- a/packages/dashboard/src/components/dashboard/project/_use-project-data.ts
+++ b/packages/dashboard/src/components/dashboard/project/_use-project-data.ts
@@ -28,20 +28,35 @@ export function useProjectData(slug: string | null): UseProjectDataResult {
     setProject(p);
   };
 
+  // The `active` flag (same pattern as _use-traces-data.ts) keeps a slower
+  // stale response from a previous slug overwriting the current project's
+  // data on rapid navigation, and avoids setState after unmount (#318).
   useEffect(() => {
     if (!slug) return;
+    let active = true;
     api<ProjectDetail>(`/v1/projects/by-slug/${slug}`)
       .then((p) => {
+        if (!active) return null;
         setProject(p);
         setConvsLoading(true);
         return api<{ data: Conversation[] }>(`/v1/projects/${p.id}/conversations?limit=100`);
       })
-      .then((res) => setConversations(res.data))
-      .catch((e) => toast.error(e instanceof Error ? e.message : "Failed to load data"))
+      .then((res) => {
+        if (!active || !res) return;
+        setConversations(res.data);
+      })
+      .catch((e) => {
+        if (!active) return;
+        toast.error(e instanceof Error ? e.message : "Failed to load data");
+      })
       .finally(() => {
+        if (!active) return;
         setLoading(false);
         setConvsLoading(false);
       });
+    return () => {
+      active = false;
+    };
   }, [slug]);
 
   return {

--- a/packages/dashboard/src/components/dashboard/project/project-content.tsx
+++ b/packages/dashboard/src/components/dashboard/project/project-content.tsx
@@ -112,7 +112,7 @@ function ProjectContent() {
   ];
 
   return (
-    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
+    <div className="page-wrap">
       <_PageHeader name={project.name} slug={project.slug} />
 
       {createdKey && <_CreatedKeyDisplay apiKey={createdKey} copied={copied} onCopy={copy} />}

--- a/packages/dashboard/src/components/dashboard/projects/projects-page.tsx
+++ b/packages/dashboard/src/components/dashboard/projects/projects-page.tsx
@@ -35,7 +35,7 @@ function ProjectsContent() {
   } = useCreateProject(projects);
 
   return (
-    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
+    <div className="page-wrap">
       <PageHeader
         title="Projects"
         description="Manage your API projects and keys."

--- a/packages/dashboard/src/components/dashboard/traces/traces-page.tsx
+++ b/packages/dashboard/src/components/dashboard/traces/traces-page.tsx
@@ -41,7 +41,7 @@ function TracesContent() {
   );
 
   return (
-    <div className="flex flex-col gap-6 px-6 py-6 lg:px-8">
+    <div className="page-wrap">
       <PageHeader title="Traces" description="LLM execution traces and observability." />
 
       {loadingProjects && (

--- a/packages/dashboard/src/components/docs/docs-data.ts
+++ b/packages/dashboard/src/components/docs/docs-data.ts
@@ -1,3 +1,5 @@
+import { API_BASE_URL, MCP_URL } from "@/lib/site";
+
 export type DocNavGroup = {
   group: string;
   items: [id: string, label: string][];
@@ -55,7 +57,7 @@ const conv = await state.createConversation({
 });`;
 
 export const AUTH_CODE = `# every request carries a bearer key (starts with as_live_)
-curl https://agentstate.app/api/v1/conversations \\
+curl ${API_BASE_URL}/v1/conversations \\
   -H "Authorization: Bearer as_live_your_key"`;
 
 export const ADAPTER_CODE = `import { AgentState } from "@agentstate/sdk";
@@ -85,7 +87,7 @@ export const MCP_CONFIG = `{
   "mcpServers": {
     "agentstate": {
       "type": "http",
-      "url": "https://agentstate.app/api/mcp",
+      "url": "${MCP_URL}",
       "headers": { "Authorization": "Bearer as_live_your_key" }
     }
   }

--- a/packages/dashboard/src/layouts/MarketingLayout.astro
+++ b/packages/dashboard/src/layouts/MarketingLayout.astro
@@ -6,8 +6,9 @@ import "../styles/global.css";
 import Logo from "../components/logo.astro";
 import RevealScript from "../components/reveal-script.astro";
 import ThemeScript from "../components/theme-script.astro";
+import { SITE_URL } from "../lib/site";
 
-const SITE = "https://agentstate.app";
+const SITE = SITE_URL;
 const DEFAULT_OG_IMAGE = `${SITE}/brand/agentstate-logo.png`;
 
 interface Props {

--- a/packages/dashboard/src/lib/site.ts
+++ b/packages/dashboard/src/lib/site.ts
@@ -1,0 +1,31 @@
+/**
+ * site.ts — Single source of truth for the public site origin (#316).
+ *
+ * Every place that previously hardcoded `https://agentstate.app` (docs
+ * snippets, MCP configs, marketing layout canonical/OG URLs, quick-start
+ * code) imports from here, so staging/preview deployments and the
+ * custom-domain feature can rebrand the origin with one env var:
+ *
+ *   PUBLIC_SITE_URL=https://staging.agentstate.app
+ *
+ * (Astro inlines `PUBLIC_*`-prefixed env vars into client code at build.)
+ */
+
+function normalizeOrigin(raw: string | undefined): string | undefined {
+  const trimmed = raw?.trim().replace(/\/+$/, "");
+  return trimmed ? trimmed : undefined;
+}
+
+/** Public site origin, no trailing slash (e.g. "https://agentstate.app"). */
+export const SITE_URL =
+  normalizeOrigin(import.meta.env.PUBLIC_SITE_URL as string | undefined) ??
+  "https://agentstate.app";
+
+/** REST API base, no trailing slash (e.g. "https://agentstate.app/api"). */
+export const API_BASE_URL = `${SITE_URL}/api`;
+
+/** Remote MCP endpoint. */
+export const MCP_URL = `${SITE_URL}/api/mcp`;
+
+/** Machine-readable integration guide. */
+export const AGENTS_MD_URL = `${SITE_URL}/agents.md`;

--- a/packages/dashboard/src/pages/brand.astro
+++ b/packages/dashboard/src/pages/brand.astro
@@ -140,7 +140,7 @@ const iconAssets = [
         {logoAssets.map((a) => (
           <div class="overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-panel">
             <div
-              class={`flex h-32 items-center justify-center ${a.surface === "light" ? "bg-zinc-100" : "bg-[#09090b]"}`}
+              class={`flex h-32 items-center justify-center ${a.surface === "light" ? "bg-swatch-light" : "bg-swatch-dark"}`}
               style={`color-scheme:${a.surface === "light" ? "light" : "dark"}`}
             >
               <img
@@ -181,7 +181,7 @@ const iconAssets = [
       <div class="grid grid-cols-2 gap-3 lg:grid-cols-4">
         {iconAssets.map((a) => (
           <div class="overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-panel">
-            <div class={`flex h-28 items-center justify-center ${a.surface === "light" ? "bg-zinc-100" : "bg-[#0f0f11]"}`}>
+            <div class={`flex h-28 items-center justify-center ${a.surface === "light" ? "bg-swatch-light" : "bg-swatch-dark2"}`}>
               <img
                 src={`/brand/${a.file}`}
                 alt={a.label}
@@ -223,7 +223,7 @@ const iconAssets = [
           <div class="border-t border-edge-soft px-4 py-2.5 font-mono text-[10.5px] uppercase tracking-wider text-fg-4">Mark · dark</div>
         </div>
         <div class="flex flex-col bg-panel">
-          <div class="flex h-40 items-center justify-center bg-zinc-100 text-zinc-900"><Logo size={64} /></div>
+          <div class="flex h-40 items-center justify-center bg-swatch-light text-swatch-light-fg"><Logo size={64} /></div>
           <div class="border-t border-edge-soft px-4 py-2.5 font-mono text-[10.5px] uppercase tracking-wider text-fg-4">Mark · light</div>
         </div>
         <div class="flex flex-col bg-panel">

--- a/packages/dashboard/src/pages/brand.astro
+++ b/packages/dashboard/src/pages/brand.astro
@@ -4,6 +4,7 @@ import Logo from "../components/logo.astro";
 import Badge from "../components/ui/badge.astro";
 import Card from "../components/ui/card.astro";
 import MarketingLayout from "../layouts/MarketingLayout.astro";
+import { SITE_URL } from "../lib/site";
 
 // Color tokens — sourced from src/styles/tokens.css (single source of truth).
 const surfaces = [
@@ -32,7 +33,7 @@ const sizes = [16, 20, 28, 40, 56];
 
 // Downloadable brand assets — files live in public/brand/ (regenerable via
 // scripts/gen-brand-assets.ts). SITE is the hotlinkable origin.
-const SITE = "https://agentstate.app";
+const SITE = SITE_URL;
 const logoAssets: {
   label: string;
   fmt: string;

--- a/packages/dashboard/src/pages/docs.astro
+++ b/packages/dashboard/src/pages/docs.astro
@@ -3,6 +3,7 @@
 import Card from "../components/ui/card.astro";
 // biome-ignore lint/correctness/noUnusedImports: used in the template below
 import MarketingLayout from "../layouts/MarketingLayout.astro";
+import { AGENTS_MD_URL, API_BASE_URL, MCP_URL, SITE_URL } from "../lib/site";
 
 // Section nav groups (mono labels). IDs map to headings in <article>.
 // biome-ignore lint/correctness/noUnusedVariables: used in the template below
@@ -86,18 +87,18 @@ const conv = await state.createConversation({
 
 // biome-ignore lint/correctness/noUnusedVariables: used in the template below
 const authCode = `# every request carries a bearer key (starts with as_live_)
-curl https://agentstate.app/api/v1/conversations \\
+curl ${API_BASE_URL}/v1/conversations \\
   -H "Authorization: Bearer as_live_your_key"`;
 
 // biome-ignore lint/correctness/noUnusedVariables: used in the template below
 const agentPromptCode = `I want to integrate AgentState (a conversation-history database-as-a-service for AI agents) into this project.
 
 First, discover the API by reading:
-- https://agentstate.app/llms.txt
-- https://agentstate.app/agents.md
-- https://agentstate.app/openapi.json
+- ${SITE_URL}/llms.txt
+- ${AGENTS_MD_URL}
+- ${SITE_URL}/openapi.json
 
-Then help me: create a project, generate an API key, and store + retrieve conversation history using the REST API at https://agentstate.app/api/v1. Use the snake_case JSON contract and Bearer API-key auth described in those docs.`;
+Then help me: create a project, generate an API key, and store + retrieve conversation history using the REST API at ${API_BASE_URL}/v1. Use the snake_case JSON contract and Bearer API-key auth described in those docs.`;
 
 // biome-ignore lint/correctness/noUnusedVariables: used in the template below
 const installSkillCode = `npx skills add duyet/agentstate`;
@@ -126,7 +127,7 @@ const mcpConfig = `{
   "mcpServers": {
     "agentstate": {
       "type": "http",
-      "url": "https://agentstate.app/api/mcp",
+      "url": "${MCP_URL}",
       "headers": { "Authorization": "Bearer as_live_your_key" }
     }
   }
@@ -343,7 +344,7 @@ const permissionScopes: [scope: string, grants: string][] = [
         <h2 id="mcp" class="mt-12 mb-1.5 scroll-mt-20 text-[22px] font-semibold tracking-[-0.02em] text-fg">Remote MCP</h2>
         <p class="mt-2 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
           Connect Cursor, Claude Desktop, Windsurf, and any MCP client to the hosted server at
-          <code class="font-mono text-fg">https://agentstate.app/api/mcp</code> — no install. Authenticate with a Bearer
+          <code class="font-mono text-fg">{MCP_URL}</code> — no install. Authenticate with a Bearer
           API key or capability token, or let the client run the OAuth flow.
         </p>
         <div class="mt-3.5 overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-panel">

--- a/packages/dashboard/src/pages/index.astro
+++ b/packages/dashboard/src/pages/index.astro
@@ -5,6 +5,7 @@ import CodeTabs from "../components/home/code-tabs.astro";
 import PrimitiveIcon from "../components/home/primitive-icon.astro";
 // biome-ignore lint/correctness/noUnusedImports: Astro component imports are used in the template below
 import MarketingLayout from "../layouts/MarketingLayout.astro";
+import { API_BASE_URL } from "../lib/site";
 
 // biome-ignore lint/correctness/noUnusedVariables: used in the template below
 const workflow = [
@@ -139,7 +140,7 @@ messages = client.get_conversation(conv.id).messages`,
               {
                 label: "REST",
                 lang: "bash",
-                code: `curl -X POST https://agentstate.app/api/v1/conversations \\
+                code: `curl -X POST ${API_BASE_URL}/v1/conversations \\
   -H "Authorization: Bearer as_live_..." \\
   -H "Content-Type: application/json" \\
   -d '{"messages":[{"role":"user","content":"Hi"}]}'`,

--- a/packages/dashboard/src/styles/global.css
+++ b/packages/dashboard/src/styles/global.css
@@ -196,6 +196,23 @@
   gap: 0.5rem; /* 8px */
 }
 
+/*
+ * Canonical dashboard page wrapper: every dashboard route (and its loading
+ * skeleton) uses this single token instead of repeating raw spacing classes,
+ * so page gutters/rhythm cannot drift between routes (#315).
+ * Equivalent to: flex flex-col gap-6 px-6 py-6 lg:px-8
+ */
+@utility page-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem; /* 24px */
+  padding: 1.5rem; /* 24px */
+  @media (min-width: 1024px) {
+    padding-left: 2rem; /* 32px */
+    padding-right: 2rem; /* 32px */
+  }
+}
+
 @utility page-padding {
   padding-left: 1rem; /* 16px */
   padding-right: 1rem; /* 16px */

--- a/packages/dashboard/src/styles/tokens.css
+++ b/packages/dashboard/src/styles/tokens.css
@@ -42,6 +42,16 @@
   --radius: 9px;
   --radius-lg: 12px;
   --radius-xl: 14px;
+
+  /*
+   * brand-asset swatch surfaces (#320) — intentionally theme-FIXED (not
+   * remapped by the light palette below): logo previews must always render
+   * on their designed light/dark background regardless of the page theme.
+   */
+  --color-swatch-light: #f4f4f5; /* zinc-100 */
+  --color-swatch-light-fg: #18181b; /* zinc-900 */
+  --color-swatch-dark: #09090b; /* dark app canvas */
+  --color-swatch-dark2: #0f0f11; /* dark icon-tile surface */
 }
 
 /*

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -125,9 +125,15 @@ Get conversation by ID.
 
 Get conversation by external ID (URL-encoded automatically).
 
-#### `list_conversations(limit=20, cursor=None, order=None)`
+#### `list_conversations(limit=None, cursor=None, order=None)`
 
-List conversations with pagination. Returns dict with `data` and `pagination`.
+List conversations with pagination. `limit` is omitted by default so the
+server default (50) applies. Returns dict with `data` and `pagination`.
+
+#### `search_conversations(q, limit=None, cursor=None)`
+
+Search conversations by message content (case-insensitive substring match).
+Returns dict with `data` (matches with snippets) and `next_cursor`.
 
 #### `update_conversation(conversation_id, title=None, metadata=None)`
 
@@ -136,6 +142,10 @@ Update a conversation's title or metadata.
 #### `delete_conversation(conversation_id)`
 
 Delete a conversation. Returns `None`.
+
+#### `bulk_delete_conversations(ids)`
+
+Delete multiple conversations (1-100) at once. Returns `{"deleted": N}`.
 
 #### `append_messages(conversation_id, messages)`
 
@@ -161,6 +171,34 @@ Generate a title for a conversation using AI. Returns `{"title": "..."}`.
 #### `generate_follow_ups(conversation_id)`
 
 Generate follow-up questions. Returns `{"questions": [...]}`.
+
+#### `generate_all(conversation_id)`
+
+Generate a title and follow-up questions in a single call. Returns
+`{"title": "...", "follow_ups": [...]}`.
+
+---
+
+### Traces
+
+These helpers target `/v1/conversations/traces`, for ingesting structured LLM
+observability data (spans/observations) as a conversation:
+
+#### `ingest_trace(trace, observations)`
+
+Batch-create a trace (conversation) plus all of its observations in one call.
+`trace` may include `external_id`, `title`, `metadata`; `observations` is a
+list of 1-100 observation dicts (each requires `content` and
+`observation_type`). Returns `{"conversation": {...}, "observations": [...]}`.
+
+#### `list_traces(limit=None, cursor=None, order=None)`
+
+List traces (conversations that contain at least one observation). Returns
+dict with `data`, `has_more`, and `next_cursor`.
+
+#### `get_trace(trace_id)`
+
+Get a trace with its observations arranged as a parent/child tree.
 
 ---
 

--- a/packages/python-sdk/agentstate/client.py
+++ b/packages/python-sdk/agentstate/client.py
@@ -300,6 +300,30 @@ class AgentStateClient:
 
         return self._request("GET", "/v1/conversations", params=params or None)
 
+    def search_conversations(
+        self,
+        q: str,
+        limit: Optional[int] = None,
+        cursor: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Search conversations by message content.
+
+        Args:
+            q: Search query — matches message content (case-insensitive substring)
+            limit: Number of results per page (max 100)
+            cursor: Pagination cursor from previous response
+
+        Returns:
+            Dict with data (list of matches with snippets) and next_cursor
+        """
+        params: Dict[str, Any] = {"q": q}
+        if limit is not None:
+            params["limit"] = limit
+        if cursor is not None:
+            params["cursor"] = cursor
+
+        return self._request("GET", "/v1/conversations/search", params=params)
+
     def update_conversation(
         self,
         conversation_id: str,
@@ -331,6 +355,21 @@ class AgentStateClient:
             conversation_id: The conversation ID
         """
         self._request("DELETE", f"/v1/conversations/{conversation_id}")
+
+    def bulk_delete_conversations(self, ids: List[str]) -> Dict[str, Any]:
+        """Delete multiple conversations at once.
+
+        Args:
+            ids: Conversation IDs to delete (1-100)
+
+        Returns:
+            Dict with 'deleted' count
+        """
+        return self._request(
+            "POST",
+            "/v1/conversations/bulk-delete",
+            json={"ids": ids},
+        )
 
     def append_messages(
         self,
@@ -430,6 +469,87 @@ class AgentStateClient:
         return self._request(
             "POST",
             f"/v1/conversations/{conversation_id}/follow-ups",
+        )
+
+    def generate_all(self, conversation_id: str) -> Dict[str, Any]:
+        """Generate a title and follow-up questions in a single call.
+
+        Args:
+            conversation_id: The conversation ID
+
+        Returns:
+            Dict with 'title' and 'follow_ups' keys
+        """
+        return self._request(
+            "POST",
+            f"/v1/conversations/{conversation_id}/generate-all",
+        )
+
+    # -------------------------------------------------------------------------
+    # Traces
+    # -------------------------------------------------------------------------
+
+    def ingest_trace(
+        self,
+        trace: Dict[str, Any],
+        observations: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Ingest a complete trace: create a conversation and its observations.
+
+        Args:
+            trace: Trace metadata dict — may include 'external_id', 'title',
+                'metadata'
+            observations: List of observation dicts (1-100). Each requires
+                'content' and 'observation_type'; a 'parent_message_id' of
+                the form "$N" resolves to the Nth observation in this batch.
+
+        Returns:
+            Dict with 'conversation' and 'observations' (flat, insertion order)
+        """
+        return self._request(
+            "POST",
+            "/v1/conversations/traces/ingest",
+            json={"trace": trace, "observations": observations},
+        )
+
+    def list_traces(
+        self,
+        limit: Optional[int] = None,
+        cursor: Optional[str] = None,
+        order: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """List traces (conversations containing at least one observation).
+
+        Args:
+            limit: Number of traces per page (max 100)
+            cursor: Pagination cursor from previous response
+            order: Sort order, 'asc' or 'desc'
+
+        Returns:
+            Dict with data (list), has_more, and next_cursor
+        """
+        params: Dict[str, Any] = {}
+        if limit is not None:
+            params["limit"] = limit
+        if cursor is not None:
+            params["cursor"] = cursor
+        if order is not None:
+            params["order"] = order
+
+        return self._request("GET", "/v1/conversations/traces", params=params or None)
+
+    def get_trace(self, trace_id: str) -> Dict[str, Any]:
+        """Get a trace with its observations arranged as a tree.
+
+        Args:
+            trace_id: The trace (conversation) ID
+
+        Returns:
+            Conversation dict with an 'observations' tree (nested 'children')
+        """
+        return self._request(
+            "GET",
+            f"/v1/conversations/traces/{urllib.parse.quote(trace_id, safe='')}",
         )
 
     # -------------------------------------------------------------------------

--- a/packages/python-sdk/agentstate/client.py
+++ b/packages/python-sdk/agentstate/client.py
@@ -150,7 +150,9 @@ class AgentStateClient:
             base = retry_after
         else:
             base = self.retry_delay_ms * (2 ** attempt) / 1000.0
-        delay = base + random.uniform(0.0, base * 0.5)
+        # Jitter to avoid thundering herds: base + U(0, base), i.e. 1x-2x the
+        # base delay. Canonical formula shared with the TypeScript SDK (#329).
+        delay = base + random.uniform(0.0, base)
         # Clamp so a misconfigured/huge Retry-After can't block the caller for long.
         return min(delay, 30.0)
 
@@ -273,27 +275,30 @@ class AgentStateClient:
 
     def list_conversations(
         self,
-        limit: int = 20,
+        limit: Optional[int] = None,
         cursor: Optional[str] = None,
         order: Optional[str] = None,
     ) -> Dict[str, Any]:
         """List conversations with pagination.
 
         Args:
-            limit: Number of conversations per page (max 100)
+            limit: Number of conversations per page (max 100). Omitted by
+                default so the server default (50) applies (#327).
             cursor: Pagination cursor from previous response
             order: Sort order, 'asc' or 'desc'
 
         Returns:
             Dict with data (list) and pagination
         """
-        params: Dict[str, Any] = {"limit": limit}
+        params: Dict[str, Any] = {}
+        if limit is not None:
+            params["limit"] = limit
         if cursor is not None:
             params["cursor"] = cursor
         if order is not None:
             params["order"] = order
 
-        return self._request("GET", "/v1/conversations", params=params)
+        return self._request("GET", "/v1/conversations", params=params or None)
 
     def update_conversation(
         self,
@@ -358,7 +363,9 @@ class AgentStateClient:
         Args:
             conversation_id: The conversation ID
             limit: Max messages to return
-            after: Cursor for pagination
+            after: Opaque MESSAGE-ID cursor — pass ``pagination.next_cursor``
+                from the previous page. Not a numeric sequence; not
+                interchangeable with ``list_state_events``' ``after``.
 
         Returns:
             Dict with data (list) and pagination
@@ -530,7 +537,10 @@ class AgentStateClient:
 
         Args:
             state_key: Caller-defined state key
-            after: Sequence cursor. Return events after this sequence
+            after: Exclusive NUMERIC sequence cursor — returns events with
+                ``sequence > after`` (ascending). Pass the last event's
+                ``sequence``. Not interchangeable with ``list_messages``'
+                opaque message-id ``after``.
             limit: Maximum number of events
             capability_token: Optional capability token to use instead of the API key
 

--- a/packages/python-sdk/tests/test_client.py
+++ b/packages/python-sdk/tests/test_client.py
@@ -711,8 +711,9 @@ def test_retry_honors_retry_after_header_with_jitter(mock_sleep):
     assert result["id"] == "c1"
     assert mock_sleep.call_count == 1
     delay = mock_sleep.call_args.args[0]
-    # base 2s honored, plus up to 50% jitter
-    assert 2.0 <= delay <= 3.0
+    # base 2s honored, plus up to 100% jitter (base + U(0, base) — the
+    # canonical formula shared with the TypeScript SDK, #329)
+    assert 2.0 <= delay <= 4.0
 
 
 @patch("agentstate.client.time.sleep")

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -62,8 +62,10 @@ for pagination just like an untagged list.
 - `getConversation(id)` — Get a conversation with all its messages
 - `getConversationByExternalId(externalId)` — Look up a conversation by your own external ID
 - `listConversations(params?)` — List conversations with cursor-based pagination and optional exact-match `tag` filtering
+- `searchConversations(params)` — Search conversations by message content (`q`, plus cursor-based pagination)
 - `updateConversation(id, data)` — Update title or metadata
 - `deleteConversation(id)` — Delete a conversation
+- `bulkDeleteConversations(ids)` — Delete multiple conversations at once
 
 ### Messages
 
@@ -74,10 +76,19 @@ for pagination just like an untagged list.
 
 - `generateTitle(conversationId)` — Auto-generate a title from conversation content
 - `generateFollowUps(conversationId)` — Generate follow-up questions
+- `generateAll(conversationId)` — Generate a title and follow-up questions in one call
 
 ### Export
 
 - `exportConversations(ids?)` — Export all or selected conversations with messages
+
+### Traces
+
+These helpers target `/v1/conversations/traces`, for ingesting structured LLM observability data (spans/observations) as a conversation:
+
+- `ingestTrace(data)` — Batch-create a trace (conversation) plus all of its observations in one call
+- `listTraces(params?)` — List traces (conversations that contain at least one observation)
+- `getTrace(id)` — Get a trace with its observations arranged as a parent/child tree
 
 ### State Platform
 

--- a/packages/sdk/dist/ai-sdk.mjs
+++ b/packages/sdk/dist/ai-sdk.mjs
@@ -1,6 +1,6 @@
 import {
   AgentStateError
-} from "./chunk-6JBLXPTC.mjs";
+} from "./chunk-GF4OMHXK.mjs";
 
 // src/ai-sdk.ts
 function buildChatKey(prefix, chatId) {

--- a/packages/sdk/dist/index.d.ts
+++ b/packages/sdk/dist/index.d.ts
@@ -42,6 +42,83 @@ interface ListResponse<T> {
         next_cursor: string | null;
     };
 }
+interface ConversationSearchResult {
+    id: string;
+    title: string | null;
+    /** Matching-message excerpt with ellipsis where truncated. */
+    snippet: string;
+    message_count: number;
+    created_at: number;
+    updated_at: number;
+}
+interface SearchConversationsResponse {
+    data: ConversationSearchResult[];
+    next_cursor: string | null;
+}
+interface TraceObservationInput {
+    role?: "user" | "assistant" | "system" | "tool";
+    content: string;
+    parent_message_id?: string;
+    observation_type: string;
+    metadata?: Record<string, unknown>;
+    model?: string;
+    input_tokens?: number;
+    output_tokens?: number;
+    token_count?: number;
+    cost_microdollars?: number;
+    start_time?: number;
+    end_time?: number;
+    status?: string;
+    level?: string;
+}
+interface IngestTraceRequest {
+    trace: {
+        external_id?: string;
+        title?: string;
+        metadata?: Record<string, unknown>;
+    };
+    observations: TraceObservationInput[];
+}
+interface TraceListResponse {
+    data: Conversation[];
+    has_more: boolean;
+    next_cursor: string | null;
+}
+/** A message persisted as a trace observation (flat, as returned by ingestTrace). */
+interface TraceObservationRecord extends Message {
+    model: string | null;
+    input_tokens: number | null;
+    output_tokens: number | null;
+    cost_microdollars: number | null;
+    parent_message_id: string | null;
+    observation_type: string | null;
+    start_time: number | null;
+    end_time: number | null;
+    status: string | null;
+    level: string | null;
+}
+/** A trace observation with nested child spans (tree form, as returned by getTrace). */
+type TraceObservation = TraceObservationRecord & {
+    children: TraceObservation[];
+};
+type TraceTree = Conversation & {
+    observations: TraceObservation[];
+};
+interface IngestTraceResponse {
+    conversation: Conversation;
+    observations: TraceObservationRecord[];
+}
+interface SearchConversationsParams {
+    /** Search query — matches message content (case-insensitive substring). */
+    q: string;
+    limit?: number;
+    cursor?: string;
+}
+interface ListTracesParams {
+    limit?: number;
+    cursor?: string;
+    order?: StateOrder;
+}
 type StateOrder = "asc" | "desc";
 type StateEventType = "upsert" | "delete";
 type CapabilityTokenScope = "state:read" | "state:write" | "state:watch" | "lease:write" | "claim:write";
@@ -52,7 +129,6 @@ interface StateListResponse<T> {
     pagination: {
         limit: number;
         next_cursor: string | null;
-        total?: number;
     };
 }
 interface StateRecord {
@@ -103,16 +179,17 @@ interface StateEvent {
     created_at: number;
 }
 interface ListStateEventsParams {
+    /**
+     * Exclusive NUMERIC sequence cursor: returns events with `sequence > after`
+     * (ascending). Pass the last event's `sequence` from the previous page.
+     * Not interchangeable with the opaque string cursors used by
+     * `listMessages` (message-id) or `queryStates` (`next_cursor`).
+     */
     after?: number;
     limit?: number;
 }
 interface DeleteStateRequest {
     lease_id?: string;
-}
-interface StateMutationResponse {
-    state?: StateRecord;
-    deleted?: true;
-    event: StateEvent;
 }
 interface CreateStateLeaseRequest {
     holder: string;
@@ -254,16 +331,25 @@ declare class AgentState {
     getConversation(id: string): Promise<ConversationWithMessages>;
     getConversationByExternalId(externalId: string): Promise<ConversationWithMessages>;
     listConversations(params?: ListConversationsParams): Promise<ListResponse<Conversation>>;
+    searchConversations(params: SearchConversationsParams): Promise<SearchConversationsResponse>;
     updateConversation(id: string, data: {
         title?: string;
         metadata?: Record<string, unknown>;
     }): Promise<Conversation>;
     deleteConversation(id: string): Promise<void>;
+    bulkDeleteConversations(ids: string[]): Promise<{
+        deleted: number;
+    }>;
     appendMessages(conversationId: string, messages: Omit<Message, "id" | "created_at">[]): Promise<{
         messages: Message[];
     }>;
     listMessages(conversationId: string, params?: {
         limit?: number;
+        /**
+         * Opaque message-id cursor: pass `pagination.next_cursor` from the
+         * previous page. NOT a numeric sequence — not interchangeable with
+         * `listStateEvents`' `after`.
+         */
         after?: string;
     }): Promise<ListResponse<Message>>;
     generateTitle(conversationId: string): Promise<{
@@ -272,10 +358,17 @@ declare class AgentState {
     generateFollowUps(conversationId: string): Promise<{
         questions: string[];
     }>;
+    generateAll(conversationId: string): Promise<{
+        title: string;
+        follow_ups: string[];
+    }>;
     exportConversations(ids?: string[]): Promise<{
         data: ConversationWithMessages[];
         count: number;
     }>;
+    ingestTrace(data: IngestTraceRequest): Promise<IngestTraceResponse>;
+    listTraces(params?: ListTracesParams): Promise<TraceListResponse>;
+    getTrace(id: string): Promise<TraceTree>;
     upsertState(stateKey: string, data: UpsertStateRequest, options?: {
         idempotencyKey?: string;
     }): Promise<StateRecord>;
@@ -314,4 +407,4 @@ declare class AgentStateError extends Error {
     constructor(message: string, code: string, status: number);
 }
 
-export { AgentState, type AgentStateConfig, AgentStateError, type CapabilityToken, type CapabilityTokenCreated, type CapabilityTokenListResponse, type CapabilityTokenScope, type Claim, type ClaimEvidence, type ClaimEvidenceInput, type ClaimEvidenceKind, type ClaimStatus, type ClaimVerificationEvidenceResult, type ClaimVerificationRun, type Conversation, type ConversationWithMessages, type CreateCapabilityTokenRequest, type CreateClaimRequest, type CreateStateLeaseRequest, type DeleteStateRequest, type JsonObject, type JsonPrimitive, type JsonValue, type JsonValueClaimEvidenceInput, type ListClaimsParams, type ListConversationsParams, type ListResponse, type ListStateEventsParams, type Message, type RenewStateLeaseRequest, type StateEvent, type StateEventClaimEvidenceInput, type StateEventType, type StateLease, type StateListResponse, type StateMutationResponse, type StateOrder, type StateQueryPredicate, type StateQueryRequest, type StateRecord, type TextHashClaimEvidenceInput, type UpsertStateRequest };
+export { AgentState, type AgentStateConfig, AgentStateError, type CapabilityToken, type CapabilityTokenCreated, type CapabilityTokenListResponse, type CapabilityTokenScope, type Claim, type ClaimEvidence, type ClaimEvidenceInput, type ClaimEvidenceKind, type ClaimStatus, type ClaimVerificationEvidenceResult, type ClaimVerificationRun, type Conversation, type ConversationSearchResult, type ConversationWithMessages, type CreateCapabilityTokenRequest, type CreateClaimRequest, type CreateStateLeaseRequest, type DeleteStateRequest, type IngestTraceRequest, type IngestTraceResponse, type JsonObject, type JsonPrimitive, type JsonValue, type JsonValueClaimEvidenceInput, type ListClaimsParams, type ListConversationsParams, type ListResponse, type ListStateEventsParams, type ListTracesParams, type Message, type RenewStateLeaseRequest, type SearchConversationsParams, type SearchConversationsResponse, type StateEvent, type StateEventClaimEvidenceInput, type StateEventType, type StateLease, type StateListResponse, type StateOrder, type StateQueryPredicate, type StateQueryRequest, type StateRecord, type TextHashClaimEvidenceInput, type TraceListResponse, type TraceObservation, type TraceObservationInput, type TraceObservationRecord, type TraceTree, type UpsertStateRequest };

--- a/packages/sdk/dist/index.js
+++ b/packages/sdk/dist/index.js
@@ -69,7 +69,7 @@ var AgentState = class {
       if (attempt > 0) {
         const backoff = this.retryDelayMs * 2 ** (attempt - 1);
         const jittered = backoff + Math.floor(Math.random() * backoff);
-        const delay = nextDelayMs ?? jittered;
+        const delay = Math.min(nextDelayMs ?? jittered, 3e4);
         nextDelayMs = null;
         await new Promise((resolve) => setTimeout(resolve, delay));
       }
@@ -144,6 +144,9 @@ var AgentState = class {
   async listConversations(params) {
     return this.request(this.withQuery("/v1/conversations", params));
   }
+  async searchConversations(params) {
+    return this.request(this.withQuery("/v1/conversations/search", params));
+  }
   async updateConversation(id, data) {
     return this.request(`/v1/conversations/${id}`, {
       method: "PUT",
@@ -152,6 +155,12 @@ var AgentState = class {
   }
   async deleteConversation(id) {
     return this.request(`/v1/conversations/${id}`, { method: "DELETE" });
+  }
+  async bulkDeleteConversations(ids) {
+    return this.request("/v1/conversations/bulk-delete", {
+      method: "POST",
+      body: JSON.stringify({ ids })
+    });
   }
   // Messages
   async appendMessages(conversationId, messages) {
@@ -170,12 +179,28 @@ var AgentState = class {
   async generateFollowUps(conversationId) {
     return this.request(`/v1/conversations/${conversationId}/follow-ups`, { method: "POST" });
   }
+  async generateAll(conversationId) {
+    return this.request(`/v1/conversations/${conversationId}/generate-all`, { method: "POST" });
+  }
   // Export
   async exportConversations(ids) {
     return this.request("/v1/conversations/export", {
       method: "POST",
       body: JSON.stringify(ids ? { ids } : {})
     });
+  }
+  // Traces
+  async ingestTrace(data) {
+    return this.request("/v1/conversations/traces/ingest", {
+      method: "POST",
+      body: JSON.stringify(data)
+    });
+  }
+  async listTraces(params) {
+    return this.request(this.withQuery("/v1/conversations/traces", params));
+  }
+  async getTrace(id) {
+    return this.request(`/v1/conversations/traces/${encodeURIComponent(id)}`);
   }
   // State records
   async upsertState(stateKey, data, options) {

--- a/packages/sdk/dist/index.mjs
+++ b/packages/sdk/dist/index.mjs
@@ -1,7 +1,7 @@
 import {
   AgentState,
   AgentStateError
-} from "./chunk-6JBLXPTC.mjs";
+} from "./chunk-GF4OMHXK.mjs";
 export {
   AgentState,
   AgentStateError

--- a/packages/sdk/dist/langgraph.mjs
+++ b/packages/sdk/dist/langgraph.mjs
@@ -1,6 +1,6 @@
 import {
   AgentStateError
-} from "./chunk-6JBLXPTC.mjs";
+} from "./chunk-GF4OMHXK.mjs";
 
 // src/langgraph.ts
 import {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -62,7 +62,6 @@ export interface StateListResponse<T> {
   pagination: {
     limit: number;
     next_cursor: string | null;
-    total?: number;
   };
 }
 
@@ -119,18 +118,18 @@ export interface StateEvent {
 }
 
 export interface ListStateEventsParams {
+  /**
+   * Exclusive NUMERIC sequence cursor: returns events with `sequence > after`
+   * (ascending). Pass the last event's `sequence` from the previous page.
+   * Not interchangeable with the opaque string cursors used by
+   * `listMessages` (message-id) or `queryStates` (`next_cursor`).
+   */
   after?: number;
   limit?: number;
 }
 
 export interface DeleteStateRequest {
   lease_id?: string;
-}
-
-export interface StateMutationResponse {
-  state?: StateRecord;
-  deleted?: true;
-  event: StateEvent;
 }
 
 export interface CreateStateLeaseRequest {
@@ -349,7 +348,9 @@ export class AgentState {
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       if (attempt > 0) {
         const backoff = this.retryDelayMs * 2 ** (attempt - 1);
-        // Full jitter on the exponential backoff to avoid thundering herds.
+        // Jitter to avoid thundering herds: backoff + U(0, backoff), i.e.
+        // 1x-2x the exponential base. Canonical formula shared with the
+        // Python SDK's _backoff_delay (#329).
         const jittered = backoff + Math.floor(Math.random() * backoff);
         // Clamp to 30s so a misconfigured/huge Retry-After can't hang the client
         // (Workers execution limits especially).
@@ -482,6 +483,11 @@ export class AgentState {
     conversationId: string,
     params?: {
       limit?: number;
+      /**
+       * Opaque message-id cursor: pass `pagination.next_cursor` from the
+       * previous page. NOT a numeric sequence — not interchangeable with
+       * `listStateEvents`' `after`.
+       */
       after?: string;
     },
   ): Promise<ListResponse<Message>> {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -46,6 +46,90 @@ export interface ListResponse<T> {
   pagination: { limit: number; next_cursor: string | null };
 }
 
+export interface ConversationSearchResult {
+  id: string;
+  title: string | null;
+  /** Matching-message excerpt with ellipsis where truncated. */
+  snippet: string;
+  message_count: number;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface SearchConversationsResponse {
+  data: ConversationSearchResult[];
+  next_cursor: string | null;
+}
+
+export interface TraceObservationInput {
+  role?: "user" | "assistant" | "system" | "tool";
+  content: string;
+  parent_message_id?: string;
+  observation_type: string;
+  metadata?: Record<string, unknown>;
+  model?: string;
+  input_tokens?: number;
+  output_tokens?: number;
+  token_count?: number;
+  cost_microdollars?: number;
+  start_time?: number;
+  end_time?: number;
+  status?: string;
+  level?: string;
+}
+
+export interface IngestTraceRequest {
+  trace: {
+    external_id?: string;
+    title?: string;
+    metadata?: Record<string, unknown>;
+  };
+  observations: TraceObservationInput[];
+}
+
+export interface TraceListResponse {
+  data: Conversation[];
+  has_more: boolean;
+  next_cursor: string | null;
+}
+
+/** A message persisted as a trace observation (flat, as returned by ingestTrace). */
+export interface TraceObservationRecord extends Message {
+  model: string | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cost_microdollars: number | null;
+  parent_message_id: string | null;
+  observation_type: string | null;
+  start_time: number | null;
+  end_time: number | null;
+  status: string | null;
+  level: string | null;
+}
+
+/** A trace observation with nested child spans (tree form, as returned by getTrace). */
+export type TraceObservation = TraceObservationRecord & { children: TraceObservation[] };
+
+export type TraceTree = Conversation & { observations: TraceObservation[] };
+
+export interface IngestTraceResponse {
+  conversation: Conversation;
+  observations: TraceObservationRecord[];
+}
+
+export interface SearchConversationsParams {
+  /** Search query — matches message content (case-insensitive substring). */
+  q: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface ListTracesParams {
+  limit?: number;
+  cursor?: string;
+  order?: StateOrder;
+}
+
 export type StateOrder = "asc" | "desc";
 export type StateEventType = "upsert" | "delete";
 export type CapabilityTokenScope =
@@ -451,6 +535,12 @@ export class AgentState {
     return this.request(this.withQuery("/v1/conversations", params));
   }
 
+  async searchConversations(
+    params: SearchConversationsParams,
+  ): Promise<SearchConversationsResponse> {
+    return this.request(this.withQuery("/v1/conversations/search", params));
+  }
+
   async updateConversation(
     id: string,
     data: {
@@ -466,6 +556,13 @@ export class AgentState {
 
   async deleteConversation(id: string): Promise<void> {
     return this.request(`/v1/conversations/${id}`, { method: "DELETE" });
+  }
+
+  async bulkDeleteConversations(ids: string[]): Promise<{ deleted: number }> {
+    return this.request("/v1/conversations/bulk-delete", {
+      method: "POST",
+      body: JSON.stringify({ ids }),
+    });
   }
 
   // Messages
@@ -503,6 +600,10 @@ export class AgentState {
     return this.request(`/v1/conversations/${conversationId}/follow-ups`, { method: "POST" });
   }
 
+  async generateAll(conversationId: string): Promise<{ title: string; follow_ups: string[] }> {
+    return this.request(`/v1/conversations/${conversationId}/generate-all`, { method: "POST" });
+  }
+
   // Export
   async exportConversations(
     ids?: string[],
@@ -511,6 +612,22 @@ export class AgentState {
       method: "POST",
       body: JSON.stringify(ids ? { ids } : {}),
     });
+  }
+
+  // Traces
+  async ingestTrace(data: IngestTraceRequest): Promise<IngestTraceResponse> {
+    return this.request("/v1/conversations/traces/ingest", {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+  }
+
+  async listTraces(params?: ListTracesParams): Promise<TraceListResponse> {
+    return this.request(this.withQuery("/v1/conversations/traces", params));
+  }
+
+  async getTrace(id: string): Promise<TraceTree> {
+    return this.request(`/v1/conversations/traces/${encodeURIComponent(id)}`);
   }
 
   // State records

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -410,7 +410,6 @@ export type ClaimEvidenceKind = "state_event" | "text_hash" | "json_value";
 export interface StatePagination {
   limit: number;
   next_cursor: string | null;
-  total?: number;
 }
 
 export interface StateListResponse<T> {
@@ -477,12 +476,6 @@ export interface ListStateEventsRequest {
 
 export interface DeleteStateRequest {
   lease_id?: string;
-}
-
-export interface StateMutationResponse {
-  state?: StateRecordResponse;
-  deleted?: true;
-  event: StateEventResponse;
 }
 
 export interface CreateStateLeaseRequest {


### PR DESCRIPTION
Batch of triaged fixes from the open-issue backlog, highest severity first. Each issue lands as its own commit.

## Included

- **#289 — state leases don't atomically gate writes (TOCTOU).** The lease check is now a SQL guard evaluated inside the mutation batch itself (D1 batches are transactional), so a write presenting a stale/superseded `lease_id` writes exactly nothing and returns `409 LEASE_CONFLICT`. Applies to both `PUT` and `DELETE /api/v1/states/:key`. Regression tests cover the expiry hand-off replay scenario for both verbs.
- **#290 — Idempotency-Key doesn't prevent double-execution of concurrent duplicates.** The key claim is now a plain (non-IGNORE) INSERT inside the same atomic batch as the mutation: a concurrent duplicate fails the whole batch on the unique index and rolls back, then either replays the winner's stored response or gets a retriable `409 IDEMPOTENCY_IN_PROGRESS`. Orphaned reservations are reclaimed after 60s. Tests assert exactly one `state_events`/`state_snapshots` row after a duplicate race.
- **#291 — blank `RATE_LIMIT_MAX` / `PROJECT_CREATION_RATE_LIMIT_MAX` silently rate-limits every request to zero.** `Number("")` is `0`, which is finite, so an empty override previously became a hard `rateLimit = 0` DoS. Both middlewares now go through a shared `parsePositiveIntEnv` helper (`packages/api/src/lib/env.ts`) that falls back to the documented default for any non-positive-integer value.
- **#292 — hand-written migrations weren't registered in the drizzle journal**, so the next `drizzle-kit generate` would diff against a stale baseline and emit broken migrations. Journal entries added in wrangler-apply order.
- **#277 — `projects` service silently fell back to a "default org"** instead of requiring `clerkOrgId` at the type level; removed the fallback so a missing org fails loudly instead of writing to the wrong tenant.
- **#278 — OAuth `authenticateClient` leaked confidential-client existence via a response-shape/timing oracle.** Unknown `client_id` now takes the same timing-safe-compare + `401 invalid_client` path (against a decoy secret) as a known client with a wrong secret, instead of falling through to a later `400`.
- **#315 — page-wrapper spacing drift.** One `page-wrap` utility now backs all 16 dashboard page wrappers.
- **#316 — hardcoded `https://agentstate.app`** across 10 files replaced with a single `src/lib/site.ts` sourced from `PUBLIC_SITE_URL`.
- **#317, #318, #319 — stale-response/unmount races in data-fetching hooks** (analytics, conversations, project, domains pages): mirrored the existing `active`-flag guard pattern so a slower stale response can't overwrite fresher data, and no `setState` fires after unmount.
- **#320 — brand-page swatches used hardcoded hex/zinc** instead of theme tokens; replaced with generated `bg-swatch-*` utilities backed by new CSS custom properties.
- **#321 — create-org page had no sign-in fallback** if mounted outside the app-shell Gate; now shows the same `SignIn` prompt.
- **#322 — create-org name input got stomped mid-edit** by a defaults refetch; now only seeds from Clerk's suggested default until the user starts typing.
- **#323 — analytics page rendered a stale chart and the loading skeleton simultaneously** during a refetch; data is now cleared before refetch starts.
- **#324 — sidebar Docs/Home links gave no non-visual cue that they leave the dashboard**; added an `sr-only` "(leaves dashboard)" suffix.
- **#326–#330 — SDK contract drift:** dead `StateMutationResponse` TS type removed (#326), Python `list_conversations` default aligned to the server's 50 instead of a stale 20 (#327), unused `pagination.total` dropped (#328), TS/Python retry-jitter formulas aligned to `base + U(0, base)` (#329), the two incompatible `after` cursor kinds (opaque message-id vs. numeric sequence) documented on every method that takes one (#330).
- **#325 — SDK coverage gap for search, bulk-delete, traces, generate-all.** Both the TS (`@agentstate/sdk`) and Python (`agentstate`) SDKs had server routes (`/v1/conversations/search`, `/bulk-delete`, `/traces*`, `/:id/generate-all`) with no client wrapper. Added `searchConversations`/`search_conversations`, `bulkDeleteConversations`/`bulk_delete_conversations`, `generateAll`/`generate_all`, and `ingestTrace`/`listTraces`/`getTrace` (snake_case Python equivalents) to both SDKs, matching the actual server response shapes. `packages/sdk/dist/` rebuilt via `bun run build` (tsup) rather than hand-edited. Both SDKs' READMEs updated.

Fixes #289
Fixes #290
Fixes #291
Fixes #292
Fixes #277
Fixes #278
Fixes #315
Fixes #316
Fixes #317
Fixes #318
Fixes #319
Fixes #320
Fixes #321
Fixes #322
Fixes #323
Fixes #324
Fixes #326
Fixes #327
Fixes #328
Fixes #329
Fixes #330
Fixes #325

---
_Generated by [Claude Code](https://claude.ai/code/session_016vP4zhjjwLqUxW3sUBiWuP)_