### PR TITLE
feat(dashboard): restore primitives grid, comparison table, API surface

### DIFF
--- a/packages/dashboard/src/layouts/MarketingLayout.astro
+++ b/packages/dashboard/src/layouts/MarketingLayout.astro
@@ -61,6 +61,7 @@ const canonicalUrl = new URL(canonical ?? Astro.url.pathname, SITE).href;
         <a href="/" class="flex items-center gap-2 text-foreground"><Logo size={20} /><span class="text-[15px] font-semibold tracking-tight">AgentState</span></a>
         <nav class="ml-8 hidden items-center gap-6 text-[13.5px] text-muted-foreground sm:flex">
           <a href="/docs" class="hover:text-foreground">Docs</a>
+          <a href="/compare" class="hover:text-foreground">Compare</a>
           <a href="/#pricing" class="hover:text-foreground">Pricing</a>
           <a href="https://github.com/duyet/agentstate" class="hover:text-foreground">GitHub</a>
         </nav>
@@ -100,6 +101,7 @@ const canonicalUrl = new URL(canonical ?? Astro.url.pathname, SITE).href;
             <div class="text-[12px] font-medium text-foreground">Product</div>
             <ul class="mt-3 flex flex-col gap-2 text-[13px] text-muted-foreground">
               <li><a href="/docs" class="hover:text-foreground">Docs</a></li>
+              <li><a href="/compare" class="hover:text-foreground">Compare</a></li>
               <li><a href="/#pricing" class="hover:text-foreground">Pricing</a></li>
               <li><a href="/dashboard" class="hover:text-foreground">Dashboard</a></li>
             </ul>

--- a/packages/dashboard/src/pages/compare.astro
+++ b/packages/dashboard/src/pages/compare.astro
@@ -1,0 +1,83 @@
+---
+// biome-ignore lint/correctness/noUnusedImports: Astro component imports are used in the template below
+import MarketingLayout from "../layouts/MarketingLayout.astro";
+
+// biome-ignore lint/correctness/noUnusedVariables: used in the template below
+const rows = [
+  {
+    capability: "Conversation history",
+    diy: "Yes — most tools cover this",
+    agentstate: "Yes — CRUD, search, tags, bulk export",
+  },
+  {
+    capability: "Versioned key/value state",
+    diy: "DIY — wire up your own store",
+    agentstate: "Built in — append-only event log, fleet-queryable",
+  },
+  {
+    capability: "Distributed leases",
+    diy: "DIY — Redis, DynamoDB, or hope for the best",
+    agentstate: "Built in — exactly-one-writer across N agents",
+  },
+  {
+    capability: "Scoped capability tokens",
+    diy: "Not typically available",
+    agentstate: "Built in — revocable, time-bounded, auditable",
+  },
+  {
+    capability: "Verifiable claims / evidence",
+    diy: "Not typically available",
+    agentstate: "Built in — attach evidence to decisions, audit later",
+  },
+  {
+    capability: "Pricing / hosting",
+    diy: "Varies — often proprietary or self-managed infra",
+    agentstate: "Free to start · open source (MIT) · self-host anytime",
+  },
+] as const;
+---
+<MarketingLayout
+  title="Compare — AgentState vs. memory-only stores"
+  description="Memory and history tools store what happened. AgentState also coordinates what happens next — distributed locks, scoped delegation, and verifiable evidence baked in."
+  canonical="/compare"
+>
+  <main>
+    <section data-reveal>
+      <div class="mx-auto w-full max-w-6xl px-6 py-24 md:py-32">
+        <span class="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 text-[12.5px] text-muted-foreground"><span class="size-1.5 rounded-full bg-accent"></span>why AgentState</span>
+        <h1 class="mt-6 max-w-2xl text-3xl font-semibold leading-tight tracking-tight text-foreground md:text-4xl">
+          More than memory — coordination included.
+        </h1>
+        <p class="mt-4 max-w-xl text-[15px] leading-relaxed text-muted-foreground">
+          Memory and history tools store what happened. AgentState also coordinates what happens next — distributed locks, scoped delegation, and verifiable evidence baked in.
+        </p>
+
+        <div class="mt-12 overflow-hidden overflow-x-auto rounded-xl border border-border bg-card">
+          <table class="w-full text-left text-[13.5px]">
+            <thead>
+              <tr class="border-b border-border font-mono text-[11px] uppercase text-muted-foreground">
+                <th class="px-5 py-3 font-medium">Capability</th>
+                <th class="px-5 py-3 font-medium">Memory-only / roll your own</th>
+                <th class="px-5 py-3 font-medium">AgentState</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr class="border-b border-border last:border-0 hover:bg-muted">
+                  <td class="px-5 py-3.5 text-foreground">{r.capability}</td>
+                  <td class="px-5 py-3.5 text-muted-foreground">{r.diy}</td>
+                  <td class="px-5 py-3.5 text-pos">{r.agentstate}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div class="mt-10 flex flex-wrap items-center gap-3">
+          <a href="/dashboard" class="inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-[opacity,transform] duration-150 hover:opacity-90 active:scale-[0.96]">Start for free →</a>
+          <a href="/docs" class="inline-flex items-center gap-1.5 rounded-[var(--radius)] border border-border px-5 py-2.5 text-sm font-medium text-foreground transition-[background-color,transform] duration-150 hover:bg-muted active:scale-[0.96]">View docs</a>
+        </div>
+      </div>
+    </section>
+  </main>
+</MarketingLayout>

--- a/packages/dashboard/src/pages/docs.astro
+++ b/packages/dashboard/src/pages/docs.astro
@@ -20,6 +20,7 @@ const navGroups: { group: string; items: [id: string, label: string][] }[] = [
   {
     group: "Reference",
     items: [
+      ["api-surface", "API surface"],
       ["conversations", "Conversations"],
       ["analytics", "Analytics"],
     ],
@@ -44,6 +45,7 @@ const onThisPage: [id: string, label: string][] = [
   ["agent-prompt", "Use with your AI agent"],
   ["quickstart", "Quickstart"],
   ["auth", "Authentication"],
+  ["api-surface", "API surface"],
   ["conversations", "Conversations"],
   ["ai-sdk", "Adapters"],
   ["mcp", "Remote MCP"],
@@ -58,6 +60,14 @@ const methodTone: Record<string, "pos" | "accent" | "warn" | "neg"> = {
   PATCH: "warn",
   DELETE: "neg",
 };
+
+// biome-ignore lint/correctness/noUnusedVariables: used in the template below
+const apiSurfaceEndpoints: [string, string, string][] = [
+  ["PUT", "/api/v1/states/:key", "Create or replace versioned state"],
+  ["POST", "/api/v1/states/:key/lease", "Acquire a distributed lock"],
+  ["POST", "/api/v1/conversations", "Create a conversation with messages"],
+  ["GET", "/api/v1/analytics/summary", "Usage summary across all agents"],
+] as const;
 
 // biome-ignore lint/correctness/noUnusedVariables: used in the template below
 const conversationEndpoints: [string, string, string][] = [
@@ -297,6 +307,29 @@ const permissionScopes: [scope: string, grants: string][] = [
           </span>
         </div>
 
+        <!-- API surface -->
+        <h2 id="api-surface" class="mt-12 mb-1.5 scroll-mt-20 text-[22px] font-semibold tracking-[-0.02em] text-fg">API surface</h2>
+        <p class="mt-2 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
+          Small enough for agents and humans to keep in context. A representative slice across
+          state, leases, conversations, and analytics — see the sections below for the full list.
+        </p>
+        <Card class="mt-3.5 overflow-hidden p-0">
+          <ul class="divide-y divide-edge-soft">
+            {
+              apiSurfaceEndpoints.map(([m, path, desc]) => (
+                <li class="flex flex-wrap items-baseline gap-x-3 gap-y-1 px-4 py-3">
+                  <span class={`font-mono text-[11.5px] font-medium uppercase ${methodColor(m)}`}>{m}</span>
+                  <span class="font-mono text-[12.5px] text-fg">{path}</span>
+                  <span class="ml-auto text-right text-[12.5px] text-fg-4">{desc}</span>
+                </li>
+              ))
+            }
+          </ul>
+          <div class="border-t border-edge-soft px-4 py-2.5 font-mono text-[11.5px] text-fg-4">
+            base <span class="text-fg-3">https://agentstate.app/api/v1</span> · bearer auth · cursor pagination
+          </div>
+        </Card>
+
         <!-- Conversations -->
         <h2 id="conversations" class="mt-12 mb-1.5 scroll-mt-20 text-[22px] font-semibold tracking-[-0.02em] text-fg">Conversations</h2>
         <p class="mt-2 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
@@ -455,7 +488,7 @@ const permissionScopes: [scope: string, grants: string][] = [
     // Scrollspy: mark the section nearest the viewport top as current in both nav and TOC.
     const navLinks = document.querySelectorAll<HTMLAnchorElement>("[data-nav]");
     const tocLinks = document.querySelectorAll<HTMLAnchorElement>("[data-toc]");
-    const sections = ["overview", "agent-prompt", "quickstart", "auth", "conversations", "ai-sdk", "mcp", "oauth", "permissions", "analytics"]
+    const sections = ["overview", "agent-prompt", "quickstart", "auth", "api-surface", "conversations", "ai-sdk", "mcp", "oauth", "permissions", "analytics"]
       .map((id) => document.getElementById(id))
       .filter((el): el is HTMLElement => el !== null);
 

--- a/packages/dashboard/src/pages/docs.astro
+++ b/packages/dashboard/src/pages/docs.astro
@@ -326,7 +326,7 @@ const permissionScopes: [scope: string, grants: string][] = [
             }
           </ul>
           <div class="border-t border-edge-soft px-4 py-2.5 font-mono text-[11.5px] text-fg-4">
-            base <span class="text-fg-3">https://agentstate.app/api/v1</span> · bearer auth · cursor pagination
+            base <span class="text-fg-3">{API_BASE_URL}/v1</span> · bearer auth · cursor pagination
           </div>
         </Card>
 

--- a/packages/dashboard/src/pages/index.astro
+++ b/packages/dashboard/src/pages/index.astro
@@ -8,6 +8,40 @@ import MarketingLayout from "../layouts/MarketingLayout.astro";
 import { API_BASE_URL } from "../lib/site";
 
 // biome-ignore lint/correctness/noUnusedVariables: used in the template below
+const primitives = [
+  {
+    name: "state",
+    eyebrow: "State",
+    title: "Versioned key/value state",
+    body: "Append-only event log; query across all agents in a fleet. Any shape, typed.",
+  },
+  {
+    name: "lease",
+    eyebrow: "Leases",
+    title: "Distributed locks",
+    body: "Exactly-one-writer coordination across N concurrent agents — no double-writes.",
+  },
+  {
+    name: "claim",
+    eyebrow: "Claims",
+    title: "Verifiable assertions",
+    body: "Attach evidence to decisions so you can audit them later. Built-in provenance.",
+  },
+  {
+    name: "token",
+    eyebrow: "Capability tokens",
+    title: "Scoped delegation",
+    body: "Sub-agents get only the access they need — revocable, time-bounded, auditable.",
+  },
+  {
+    name: "conversation",
+    eyebrow: "Conversations",
+    title: "Full message history",
+    body: "CRUD, search, tags, bulk export, and AI-generated titles — for agents and humans.",
+  },
+] as const;
+
+// biome-ignore lint/correctness/noUnusedVariables: used in the template below
 const workflow = [
   {
     n: "01",
@@ -147,6 +181,33 @@ messages = client.get_conversation(conv.id).messages`,
               },
             ]}
           />
+        </div>
+      </div>
+    </section>
+
+    <!-- five primitives -->
+    <section data-reveal class="border-b border-border">
+      <div class="mx-auto w-full max-w-6xl px-6 py-24 md:py-32">
+        <h2 class="max-w-xl text-3xl font-semibold leading-tight tracking-tight text-foreground md:text-4xl">
+          Five primitives, one API.
+        </h2>
+        <p class="mt-4 max-w-lg text-[15px] leading-relaxed text-muted-foreground">Conversation history is the flagship, but every fleet also gets versioned state, distributed leases, verifiable claims, and scoped capability tokens — sharing the same auth, projects, and analytics.</p>
+        <div class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {primitives.map((p) => (
+            <div class="rounded-xl border border-border bg-card p-6 transition-colors hover:bg-muted">
+              <div class="grid size-9 place-items-center rounded-[var(--radius)] border border-border text-muted-foreground">
+                <PrimitiveIcon name={p.name} class="size-[18px]" />
+              </div>
+              <div class="mt-4 font-mono text-[11px] uppercase tracking-wider text-muted-foreground">{p.eyebrow}</div>
+              <div class="mt-1.5 text-[15px] font-medium text-foreground">{p.title}</div>
+              <p class="mt-1.5 text-[13.5px] leading-relaxed text-muted-foreground">{p.body}</p>
+            </div>
+          ))}
+          <div class="flex flex-col justify-center rounded-xl border border-border bg-card p-6">
+            <div class="text-[15px] font-medium text-foreground">Why not just memory?</div>
+            <p class="mt-1.5 text-[13.5px] leading-relaxed text-muted-foreground">See how these primitives stack up against a roll-your-own memory store.</p>
+            <a href="/compare" class="mt-3 inline-flex items-center gap-1 text-[13px] font-medium text-accent hover:opacity-80">Compare →</a>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

PR #339 (shadcn redesign) rebuilt the landing page on the landing-page11 structure and dropped three content blocks that weren't preserved anywhere else. All three were recovered from `ce9a1fa^:packages/dashboard/src/pages/index.astro` (the pre-#339 tree) and restyled for the current shadcn token system rather than pasted back verbatim.

Closes #354

### Where each block landed, and why

- **Five-primitives grid** (state, lease, claim, token, conversation) → **landing page**, new section right after the hero. This is core product identity, not supplementary content — the current feature grid had quietly stopped mentioning three of the five primitives (state, lease, claim never appear at all), even though they're still live in the API (see `permissionScopes` in docs.astro: `state:read`, `state:write`, `lease:write`, `claim:write`). Restyled with `bg-card` / `border-border` / `hover:bg-muted` to match the PR #339 system; kept `--color-accent` for the CTA link per the "accent is brand vermilion, not shadcn hover" rule.
- **Memory-vs-AgentState comparison table** → **new `/compare` page**. This is "why choose us" content that doesn't fit the trimmed shadcnblocks landing structure, but is valuable enough to deserve a permanent, linkable home rather than being buried. Linked from the header nav, footer "Product" list, and a callout in the new primitives section ("Why not just memory? → Compare").
- **API-surface endpoint table** → **docs.astro**, new "API surface" section in the Reference group (before Conversations). This is developer reference material, so it belongs in the docs where people already look for endpoint tables. Reuses the existing `methodColor()` helper and `<ul>/<li>` endpoint-list pattern already used by the Conversations/Analytics sections in that file, rather than reintroducing the old `<table>` markup — docs.astro wasn't touched by #339 and still uses the pre-shadcn token names (`fg`, `edge`, `panel`), so the new section matches that file's existing conventions instead of mixing token systems within one file.

Not in scope: the dropped 6th "Workers AI Durable Object" code-tab example mentioned in the issue as context — the issue's actual "Fix:" only calls out the three content blocks, and re-adding a 6th CodeTabs example is a separate, larger change (needs its own copy review). Flagging it here in case it should be a follow-up.

## Test plan
- [x] `bunx biome check packages/dashboard/src/` — clean (pre-existing single-file-check false positives on `MarketingLayout.astro`/`brand.astro` confirmed present on `main` too, not introduced by this change)
- [x] `bunx astro check --minimumSeverity error` — 0 errors across 201 files
- [x] Manually reviewed recovered content maps 1:1 to the pre-#339 source, restyled (no copy/data dropped)