### PR TITLE
fix(api): rate-limit states/leases/claims/mcp coordination routes

### DIFF
--- a/packages/api/src/routes/claims/index.ts
+++ b/packages/api/src/routes/claims/index.ts
@@ -6,6 +6,7 @@ import {
   parseLimitParam,
   parseOrderParam,
 } from "../../lib/helpers";
+import { rateLimitMiddleware } from "../../middleware/rate-limit";
 import { scopedAuth } from "../../middleware/scoped-auth";
 import {
   type CreateEvidenceInput,
@@ -84,6 +85,7 @@ const CreateClaimSchema = z.object({
 const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
 router.use("*", scopedAuth({ scope: "claim:write" }));
+router.use("*", rateLimitMiddleware);
 
 router.post("/", async (c) => {
   const { data, error } = await parseAndValidateBody(c, CreateClaimSchema);

--- a/packages/api/src/routes/leases/index.ts
+++ b/packages/api/src/routes/leases/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { errorResponse, parseAndValidateBody } from "../../lib/helpers";
 import { RenewLeaseSchema } from "../../lib/validation";
+import { rateLimitMiddleware } from "../../middleware/rate-limit";
 import { scopedAuth } from "../../middleware/scoped-auth";
 import { releaseLease, renewLease } from "../../services/leases";
 import type { Bindings, Variables } from "../../types";
@@ -13,7 +14,7 @@ const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 // of being duplicated here. This router only operates on an existing lease
 // by id (renew/release).
 
-router.post("/:id/renew", scopedAuth({ scope: "lease:write" }), async (c) => {
+router.post("/:id/renew", scopedAuth({ scope: "lease:write" }), rateLimitMiddleware, async (c) => {
   const { data, error } = await parseAndValidateBody(c, RenewLeaseSchema);
   if (error) return error;
   if (!data) return errorResponse(c, "BAD_REQUEST", "Invalid request body", 400);
@@ -26,7 +27,7 @@ router.post("/:id/renew", scopedAuth({ scope: "lease:write" }), async (c) => {
   return c.json(result.lease);
 });
 
-router.delete("/:id", scopedAuth({ scope: "lease:write" }), async (c) => {
+router.delete("/:id", scopedAuth({ scope: "lease:write" }), rateLimitMiddleware, async (c) => {
   const error = await releaseLease(c.get("db"), c.get("projectId"), c.req.param("id"));
   if (error) return errorResponse(c, error.code, error.message, error.status);
   return c.body(null, 204);

--- a/packages/api/src/routes/mcp/index.ts
+++ b/packages/api/src/routes/mcp/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { scopeSatisfies } from "../../lib/scopes";
 import { mcpAuth } from "../../middleware/mcp-auth";
+import { rateLimitMiddleware } from "../../middleware/rate-limit";
 import type { Bindings, Variables } from "../../types";
 import { TOOLS, TOOLS_BY_NAME, type ToolContext, ToolError } from "./tools";
 
@@ -55,6 +56,7 @@ function rpcError(id: string | number | null, code: number, message: string) {
 }
 
 router.use("*", mcpAuth);
+router.use("*", rateLimitMiddleware);
 
 // Server-initiated SSE is not supported in stateless mode.
 router.get("/", (c) =>

--- a/packages/api/src/routes/states/index.ts
+++ b/packages/api/src/routes/states/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { errorResponse, parseAndValidateBody, parseLimitParam } from "../../lib/helpers";
 import { CreateLeaseSchema, QueryStatesSchema, UpsertStateSchema } from "../../lib/validation";
+import { rateLimitMiddleware } from "../../middleware/rate-limit";
 import { scopedAuth } from "../../middleware/scoped-auth";
 import { createLease } from "../../services/leases";
 import {
@@ -47,45 +48,52 @@ function notifyStateEvent(c: any, event: StateEventResponse) {
 // GET /watch — SSE state event stream
 // ---------------------------------------------------------------------------
 
-router.get("/watch", scopedAuth({ scope: "state:watch", allowQueryToken: true }), async (c) => {
-  const after =
-    parsePositiveInt(c.req.query("after")) ?? parsePositiveInt(c.req.header("Last-Event-ID")) ?? 0;
-  const once = c.req.query("once") === "true";
-  const hub = stateHub(c);
+router.get(
+  "/watch",
+  scopedAuth({ scope: "state:watch", allowQueryToken: true }),
+  rateLimitMiddleware,
+  async (c) => {
+    const after =
+      parsePositiveInt(c.req.query("after")) ??
+      parsePositiveInt(c.req.header("Last-Event-ID")) ??
+      0;
+    const once = c.req.query("once") === "true";
+    const hub = stateHub(c);
 
-  if (hub && !once) {
-    const url = new URL("https://state-stream.local/watch");
-    url.searchParams.set("after", String(after));
-    return hub.fetch(
-      new Request(url, {
-        headers: { "X-Project-Id": c.get("projectId") },
-      }),
-    );
-  }
+    if (hub && !once) {
+      const url = new URL("https://state-stream.local/watch");
+      url.searchParams.set("after", String(after));
+      return hub.fetch(
+        new Request(url, {
+          headers: { "X-Project-Id": c.get("projectId") },
+        }),
+      );
+    }
 
-  return streamSSE(c, async (stream) => {
-    const events = await c
-      .get("d1Db")
-      .prepare(
-        `SELECT sequence, id, state_key, agent_id, event_type, data, metadata, tags, idempotency_key, created_at
+    return streamSSE(c, async (stream) => {
+      const events = await c
+        .get("d1Db")
+        .prepare(
+          `SELECT sequence, id, state_key, agent_id, event_type, data, metadata, tags, idempotency_key, created_at
          FROM state_events
          WHERE project_id = ? AND sequence > ?
          ORDER BY sequence ASC
          LIMIT 1000`,
-      )
-      .bind(c.get("projectId"), after)
-      .all<any>();
+        )
+        .bind(c.get("projectId"), after)
+        .all<any>();
 
-    for (const event of events.results ?? []) {
-      await stream.writeSSE({
-        id: String(event.sequence),
-        event: `state.${event.event_type}`,
-        data: JSON.stringify(event),
-      });
-    }
-    stream.close();
-  });
-});
+      for (const event of events.results ?? []) {
+        await stream.writeSSE({
+          id: String(event.sequence),
+          event: `state.${event.event_type}`,
+          data: JSON.stringify(event),
+        });
+      }
+      stream.close();
+    });
+  },
+);
 
 // ---------------------------------------------------------------------------
 // POST /query — Rich state query
@@ -98,7 +106,7 @@ router.get("/watch", scopedAuth({ scope: "state:watch", allowQueryToken: true })
 // whose `after` cursor is ascending (`sequence > after`).
 // ---------------------------------------------------------------------------
 
-router.post("/query", scopedAuth({ scope: "state:read" }), async (c) => {
+router.post("/query", scopedAuth({ scope: "state:read" }), rateLimitMiddleware, async (c) => {
   const { data, error } = await parseAndValidateBody(c, QueryStatesSchema);
   if (error) return error;
   if (!data) return errorResponse(c, "BAD_REQUEST", "Invalid request body", 400);
@@ -122,55 +130,65 @@ router.post("/query", scopedAuth({ scope: "state:read" }), async (c) => {
 // POST /:state_key/lease — Acquire lease
 // ---------------------------------------------------------------------------
 
-router.post("/:state_key/lease", scopedAuth({ scope: "lease:write" }), async (c) => {
-  const { data, error } = await parseAndValidateBody(c, CreateLeaseSchema);
-  if (error) return error;
-  if (!data) return errorResponse(c, "BAD_REQUEST", "Invalid request body", 400);
+router.post(
+  "/:state_key/lease",
+  scopedAuth({ scope: "lease:write" }),
+  rateLimitMiddleware,
+  async (c) => {
+    const { data, error } = await parseAndValidateBody(c, CreateLeaseSchema);
+    if (error) return error;
+    if (!data) return errorResponse(c, "BAD_REQUEST", "Invalid request body", 400);
 
-  const result = await createLease(
-    c.get("db"),
-    c.get("projectId"),
-    c.req.param("state_key"),
-    data.holder,
-    data.ttl_ms,
-  );
+    const result = await createLease(
+      c.get("db"),
+      c.get("projectId"),
+      c.req.param("state_key"),
+      data.holder,
+      data.ttl_ms,
+    );
 
-  if (result.error) {
-    return errorResponse(c, result.error.code, result.error.message, result.error.status);
-  }
+    if (result.error) {
+      return errorResponse(c, result.error.code, result.error.message, result.error.status);
+    }
 
-  return c.json(result.lease, 201);
-});
+    return c.json(result.lease, 201);
+  },
+);
 
 // ---------------------------------------------------------------------------
 // GET /:state_key/events — WAL events
 // ---------------------------------------------------------------------------
 
-router.get("/:state_key/events", scopedAuth({ scope: "state:read" }), async (c) => {
-  const after = parsePositiveInt(c.req.query("after")) ?? 0;
-  const limit = parseLimitParam(c.req.query("limit"), 50, 500);
-  const events = await listStateEvents(
-    c.get("d1Db"),
-    c.get("projectId"),
-    c.req.param("state_key"),
-    after,
-    limit,
-  );
+router.get(
+  "/:state_key/events",
+  scopedAuth({ scope: "state:read" }),
+  rateLimitMiddleware,
+  async (c) => {
+    const after = parsePositiveInt(c.req.query("after")) ?? 0;
+    const limit = parseLimitParam(c.req.query("limit"), 50, 500);
+    const events = await listStateEvents(
+      c.get("d1Db"),
+      c.get("projectId"),
+      c.req.param("state_key"),
+      after,
+      limit,
+    );
 
-  return c.json({
-    data: events,
-    pagination: {
-      limit: events.length,
-      next_cursor: events.length ? String(events[events.length - 1].sequence) : null,
-    },
-  });
-});
+    return c.json({
+      data: events,
+      pagination: {
+        limit: events.length,
+        next_cursor: events.length ? String(events[events.length - 1].sequence) : null,
+      },
+    });
+  },
+);
 
 // ---------------------------------------------------------------------------
 // PUT /:state_key — Upsert full state
 // ---------------------------------------------------------------------------
 
-router.put("/:state_key", scopedAuth({ scope: "state:write" }), async (c) => {
+router.put("/:state_key", scopedAuth({ scope: "state:write" }), rateLimitMiddleware, async (c) => {
   const { data, error } = await parseAndValidateBody(c, UpsertStateSchema);
   if (error) return error;
   if (!data) return errorResponse(c, "BAD_REQUEST", "Invalid request body", 400);
@@ -219,7 +237,7 @@ router.put("/:state_key", scopedAuth({ scope: "state:write" }), async (c) => {
 // GET /:state_key — Latest or historical state
 // ---------------------------------------------------------------------------
 
-router.get("/:state_key", scopedAuth({ scope: "state:read" }), async (c) => {
+router.get("/:state_key", scopedAuth({ scope: "state:read" }), rateLimitMiddleware, async (c) => {
   const atSequence = parsePositiveInt(c.req.query("at_sequence"));
   const atTime = parsePositiveInt(c.req.query("at_time"));
   const state =
@@ -241,46 +259,53 @@ router.get("/:state_key", scopedAuth({ scope: "state:read" }), async (c) => {
 // DELETE /:state_key — Tombstone state
 // ---------------------------------------------------------------------------
 
-router.delete("/:state_key", scopedAuth({ scope: "state:write" }), async (c) => {
-  const stateKey = c.req.param("state_key");
-  const leaseId = c.req.header("X-Lease-Id") ?? c.req.query("lease_id");
-  const idempotencyKey = c.req.header("Idempotency-Key");
-  const requestHash = await buildIdempotencyHash("DELETE", stateKey, { lease_id: leaseId ?? null });
-  const cached = await readIdempotency(
-    c.get("d1Db"),
-    c.get("projectId"),
-    idempotencyKey,
-    requestHash,
-  );
-  if (cached.error)
-    return errorResponse(c, cached.error.code, cached.error.message, cached.error.status);
-  if (cached.replay) return cached.replay;
+router.delete(
+  "/:state_key",
+  scopedAuth({ scope: "state:write" }),
+  rateLimitMiddleware,
+  async (c) => {
+    const stateKey = c.req.param("state_key");
+    const leaseId = c.req.header("X-Lease-Id") ?? c.req.query("lease_id");
+    const idempotencyKey = c.req.header("Idempotency-Key");
+    const requestHash = await buildIdempotencyHash("DELETE", stateKey, {
+      lease_id: leaseId ?? null,
+    });
+    const cached = await readIdempotency(
+      c.get("d1Db"),
+      c.get("projectId"),
+      idempotencyKey,
+      requestHash,
+    );
+    if (cached.error)
+      return errorResponse(c, cached.error.code, cached.error.message, cached.error.status);
+    if (cached.replay) return cached.replay;
 
-  const result = await deleteState(
-    c.get("d1Db"),
-    c.get("projectId"),
-    stateKey,
-    leaseId,
-    idempotencyKey,
-    requestHash,
-  );
-  if (result.error)
-    return errorResponse(c, result.error.code, result.error.message, result.error.status);
-  // A concurrent duplicate carried the same Idempotency-Key: this request's
-  // mutation was rolled back atomically; serve the winner's stored response.
-  if (result.replay) return result.replay;
-  if (!result.result) return errorResponse(c, "INTERNAL_ERROR", "State delete failed", 500);
+    const result = await deleteState(
+      c.get("d1Db"),
+      c.get("projectId"),
+      stateKey,
+      leaseId,
+      idempotencyKey,
+      requestHash,
+    );
+    if (result.error)
+      return errorResponse(c, result.error.code, result.error.message, result.error.status);
+    // A concurrent duplicate carried the same Idempotency-Key: this request's
+    // mutation was rolled back atomically; serve the winner's stored response.
+    if (result.replay) return result.replay;
+    if (!result.result) return errorResponse(c, "INTERNAL_ERROR", "State delete failed", 500);
 
-  await storeIdempotency(
-    c.get("d1Db"),
-    c.get("projectId"),
-    idempotencyKey,
-    requestHash,
-    result.result.status,
-    result.result.body,
-  );
-  notifyStateEvent(c, result.result.event);
-  return c.json(result.result.body, 200);
-});
+    await storeIdempotency(
+      c.get("d1Db"),
+      c.get("projectId"),
+      idempotencyKey,
+      requestHash,
+      result.result.status,
+      result.result.body,
+    );
+    notifyStateEvent(c, result.result.event);
+    return c.json(result.result.body, 200);
+  },
+);
 
 export default router;

--- a/packages/api/test/coordination-rate-limit.test.ts
+++ b/packages/api/test/coordination-rate-limit.test.ts
@@ -1,0 +1,125 @@
+import { env, SELF } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import { applyMigrations, authHeaders, seedProject, TEST_API_KEY } from "./setup";
+
+// ---------------------------------------------------------------------------
+// Rate limiting on the coordination surface (states, leases, claims, MCP).
+// These routers previously had no limiter; this suite confirms the limiter
+// is wired in and triggers a 429 with the standard error envelope once the
+// per-key window is exceeded, mirroring the assertions in rate-limit.test.ts
+// but exercised against the newly-wired routes instead of /v1/conversations.
+// ---------------------------------------------------------------------------
+
+const TEST_RATE_LIMIT = 10000;
+
+async function computeSHA256Hex(input: string): Promise<string> {
+  const encoded = new TextEncoder().encode(input);
+  const buffer = await crypto.subtle.digest("SHA-256", encoded);
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** Seed the rate_limits table so the key is already at the limit for the current window. */
+async function exhaustRateLimit(): Promise<void> {
+  await env.DB.prepare("DELETE FROM rate_limits").run();
+  const keyHash = await computeSHA256Hex(TEST_API_KEY);
+  const now = Date.now();
+  const windowStart = now - (now % 60_000);
+  await env.DB.prepare(
+    `INSERT INTO rate_limits (id, api_key_hash, window_start, request_count, updated_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  )
+    .bind("rl_coord_test", keyHash, windowStart, TEST_RATE_LIMIT, now)
+    .run();
+}
+
+describe("Coordination routes rate limiting", () => {
+  beforeEach(async () => {
+    await applyMigrations();
+    await seedProject();
+  });
+
+  it("PUT /api/v1/states/:state_key returns 429 past the limit", async () => {
+    await exhaustRateLimit();
+
+    const res = await SELF.fetch("http://localhost/api/v1/states/rate-limit-test", {
+      method: "PUT",
+      headers: authHeaders(),
+      body: JSON.stringify({ agent_id: "agent-a", data: { status: "draft" } }),
+    });
+
+    expect(res.status).toBe(429);
+    const body = await res.json<{ error: { code: string; message: string } }>();
+    expect(body.error.code).toBe("RATE_LIMITED");
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  it("PUT /api/v1/states/:state_key succeeds when under the limit", async () => {
+    await env.DB.prepare("DELETE FROM rate_limits").run();
+
+    const res = await SELF.fetch("http://localhost/api/v1/states/rate-limit-ok", {
+      method: "PUT",
+      headers: authHeaders(),
+      body: JSON.stringify({ agent_id: "agent-a", data: { status: "draft" } }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-RateLimit-Remaining")).toBeTruthy();
+  });
+
+  it("POST /api/v1/leases/:id/renew returns 429 past the limit", async () => {
+    await exhaustRateLimit();
+
+    const res = await SELF.fetch("http://localhost/api/v1/leases/some-lease-id/renew", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ ttl_ms: 30_000 }),
+    });
+
+    expect(res.status).toBe(429);
+    const body = await res.json<{ error: { code: string; message: string } }>();
+    expect(body.error.code).toBe("RATE_LIMITED");
+  });
+
+  it("POST /api/v1/claims returns 429 past the limit", async () => {
+    await exhaustRateLimit();
+
+    const res = await SELF.fetch("http://localhost/api/v1/claims", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        subject_type: "test",
+        subject_id: "subject-1",
+        statement: "test statement",
+        evidence: [{ kind: "text_hash", source: "test", data: "x", hash: "0".repeat(64) }],
+      }),
+    });
+
+    expect(res.status).toBe(429);
+    const body = await res.json<{ error: { code: string; message: string } }>();
+    expect(body.error.code).toBe("RATE_LIMITED");
+  });
+
+  it("POST /api/mcp tools/call returns the JSON-RPC result with a 429 HTTP status past the limit", async () => {
+    await exhaustRateLimit();
+
+    const res = await SELF.fetch("http://localhost/api/mcp", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${TEST_API_KEY}`,
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+      }),
+    });
+
+    expect(res.status).toBe(429);
+    const body = await res.json<{ error: { code: string; message: string } }>();
+    expect(body.error.code).toBe("RATE_LIMITED");
+  });
+});


### PR DESCRIPTION
## Summary

Every conversation-facing router (conversations, tags, keys, ai, webhooks, capability-tokens, analytics-public) chains `rateLimitMiddleware`, but the write-heavy coordination surface — states, leases, claims, and the MCP endpoint — had no rate limiting at all. A single authenticated key (or a leaked capability token) could drive unlimited D1 writes and Durable Object notify traffic.

- Wire `rateLimitMiddleware` after `scopedAuth(...)` on every route in `states/index.ts` (watch, query, lease, events, PUT, GET, DELETE) and `leases/index.ts` (renew, release).
- Add `router.use("*", rateLimitMiddleware)` after the shared `scopedAuth`/`mcpAuth` middleware in `claims/index.ts` and `mcp/index.ts`.
- No changes to the limiter's algorithm or limits — wiring only, per the plan's explicit constraint.
- New test suite `coordination-rate-limit.test.ts` seeds the `rate_limits` table directly at the limit (avoiding 10k real requests) and asserts a 429 with the standard `{ error: { code: "RATE_LIMITED", ... } }` envelope on states PUT, leases renew, claims create, and an MCP `tools/list` call, plus a states PUT still succeeding under the limit.

Closes #340
Closes #349
Closes #350

## Test plan
- [x] `bunx biome check packages/api/src/` — passes on all 4 modified files; 1 pre-existing unrelated failure in `lib/validation.ts` (confirmed present on unmodified `main`, out of scope for this change)
- [x] `bunx tsc --noEmit -p packages/api/tsconfig.json` — exit 0
- [x] `cd packages/api && bunx vitest run` — 358/358 tests pass across 26 files, including 5 new rate-limit tests
- [x] `grep -L rateLimitMiddleware` on the four target files prints nothing (all reference it)
- [x] `git status` — only in-scope files + new test file changed

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>