### PR TITLE
fix(seo): robots.txt, noindex, JSON-LD, sitemap drift check, keywords, README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: API E2E smoke test
         run: cd packages/api && bunx vitest run test/e2e.test.ts
 
+      - name: Sitemap coverage check
+        run: node scripts/check-sitemap.mjs
+
       - name: TypeScript SDK typecheck, build, and tests
         run: cd packages/sdk && bun run typecheck && bun run build && bun run test
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AgentState
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+[![CI](https://github.com/duyet/agentstate/actions/workflows/ci.yml/badge.svg)](https://github.com/duyet/agentstate/actions/workflows/ci.yml) [![npm](https://img.shields.io/npm/v/@agentstate/sdk.svg)](https://www.npmjs.com/package/@agentstate/sdk) [![PyPI](https://img.shields.io/pypi/v/agentstate.svg)](https://pypi.org/project/agentstate/) [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
 Open source (MIT), self-host anytime, free to start — no credit card.
 

--- a/bun.lock
+++ b/bun.lock
@@ -85,7 +85,7 @@
     },
     "packages/sdk": {
       "name": "@agentstate/sdk",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "devDependencies": {
         "@langchain/core": "^1.1.49",
         "@langchain/langgraph-checkpoint": "^1.1.1",

--- a/packages/dashboard/public/robots.txt
+++ b/packages/dashboard/public/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+Disallow: /dashboard
+Disallow: /oauth
+
+Sitemap: https://agentstate.app/sitemap.xml

--- a/packages/dashboard/public/sitemap.xml
+++ b/packages/dashboard/public/sitemap.xml
@@ -2,16 +2,19 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://agentstate.app/</loc>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://agentstate.app/docs</loc>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://agentstate.app/brand</loc>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/packages/dashboard/src/layouts/RootLayout.astro
+++ b/packages/dashboard/src/layouts/RootLayout.astro
@@ -8,11 +8,14 @@ import ThemeScript from "../components/theme-script.astro";
 interface Props {
   title?: string;
   description?: string;
+  /** Dashboard/app routes are auth-gated shells with nothing to index. */
+  noindex?: boolean;
 }
 
 const {
   title = "AgentState — One state layer for every AI agent",
   description = "Store conversations, UI messages and graph state behind one API — with drop-in adapters for every framework you already use. Built on Cloudflare D1, MIT licensed.",
+  noindex = true,
 } = Astro.props;
 ---
 
@@ -23,6 +26,7 @@ const {
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{title}</title>
     <meta name="description" content={description} />
+    <meta name="robots" content={noindex ? "noindex, nofollow" : "index, follow"} />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" href="/icon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png" />

--- a/packages/dashboard/src/pages/index.astro
+++ b/packages/dashboard/src/pages/index.astro
@@ -58,12 +58,37 @@ const features = [
     body: "SHA-256-hashed bearer keys with subset delegation — issue a key that can only do what a sub-agent needs.",
   },
 ] as const;
+
+// biome-ignore lint/correctness/noUnusedVariables: used in the template below
+const softwareJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "AgentState",
+  description:
+    "Database-as-a-service for AI agent conversation history — REST API, SDKs, MCP server, full-text search, and analytics behind one call.",
+  applicationCategory: "DeveloperApplication",
+  operatingSystem: "Any",
+  offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+  license: "https://github.com/duyet/agentstate/blob/main/LICENSE",
+  url: "https://agentstate.app",
+};
+
+// biome-ignore lint/correctness/noUnusedVariables: used in the template below
+const organizationJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "AgentState",
+  url: "https://agentstate.app",
+  sameAs: ["https://github.com/duyet/agentstate"],
+};
 ---
 <MarketingLayout
   title="AgentState — Conversation history database for AI agent fleets"
   description="Stop reinventing conversation storage. AgentState is a database-as-a-service for AI agent conversation history — REST API, SDKs, MCP server, full-text search, and analytics behind one call."
   canonical="/"
 >
+  <script type="application/ld+json" set:html={JSON.stringify(softwareJsonLd)} />
+  <script type="application/ld+json" set:html={JSON.stringify(organizationJsonLd)} />
   <main>
     <!-- hero -->
     <section class="border-b border-border">

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -1,9 +1,21 @@
 [project]
 name = "agentstate"
-version = "0.1.1"
+version = "0.1.2"
 description = "AgentState API client for Python"
 readme = "README.md"
 requires-python = ">=3.9"
+keywords = [
+    "ai-agents",
+    "agent-memory",
+    "conversation-history",
+    "langgraph",
+    "mcp",
+    "agent-state",
+]
+classifiers = [
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
 dependencies = [
     "httpx>=0.28.1",
 ]

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,17 @@
 {
   "name": "@agentstate/sdk",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "TypeScript SDK for AgentState — conversation history for AI agents",
+  "keywords": [
+    "ai-agents",
+    "agent-memory",
+    "conversation-history",
+    "langgraph",
+    "vercel-ai-sdk",
+    "mcp",
+    "agent-state",
+    "cloudflare-workers"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/scripts/check-sitemap.mjs
+++ b/scripts/check-sitemap.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// Fails CI if a public marketing page under packages/dashboard/src/pages is
+// missing a corresponding <loc> entry in packages/dashboard/public/sitemap.xml,
+// so the sitemap can never silently drift from the real route list.
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pagesDir = join(here, "..", "packages", "dashboard", "src", "pages");
+const sitemapPath = join(here, "..", "packages", "dashboard", "public", "sitemap.xml");
+const SITE = "https://agentstate.app";
+
+const files = readdirSync(pagesDir, { recursive: true })
+  .filter((f) => f.endsWith(".astro"))
+  .map((f) => f.split(sep).join("/"));
+
+// Dashboard and oauth routes are auth-gated app shells, intentionally
+// excluded from the sitemap (and noindex'd — see RootLayout.astro).
+const isExcluded = (path) => path.startsWith("dashboard/") || path.startsWith("oauth/");
+
+const routes = files.filter((f) => !isExcluded(f)).map((f) => {
+  const withoutExt = f.replace(/\.astro$/, "");
+  return withoutExt === "index" ? "/" : `/${withoutExt.replace(/\/index$/, "")}`;
+});
+
+const sitemap = readFileSync(sitemapPath, "utf8");
+const missing = routes.filter((route) => !sitemap.includes(`<loc>${SITE}${route}</loc>`));
+
+if (missing.length > 0) {
+  console.error("sitemap.xml is missing entries for:");
+  for (const route of missing) console.error(`  - ${SITE}${route}`);
+  console.error("\nAdd a <url> entry to packages/dashboard/public/sitemap.xml.");
+  process.exit(1);
+}
+
+console.log(`sitemap.xml covers all ${routes.length} public marketing route(s).`);


### PR DESCRIPTION
## Summary
- Add `robots.txt` with `Disallow: /dashboard`, `/oauth`, and a `Sitemap:` pointer — previously the SPA fallback silently served `index.html` for `/robots.txt`.
- Add a `noindex` prop (default `true`) to `RootLayout.astro`, which is exclusively used by `DashboardLayout.astro` (every `dashboard/*` route + `oauth/consent`), so `<meta name="robots" content="noindex, nofollow">` now covers all auth-gated app shells.
- Add `SoftwareApplication` + `Organization` JSON-LD to the marketing homepage (`index.astro`).
- Add `<lastmod>` to `sitemap.xml` and a new `scripts/check-sitemap.mjs` (wired into `ci.yml`) that fails CI if a public marketing page under `src/pages/` has no matching sitemap entry.
- Add `keywords` to `packages/sdk/package.json` (+ patch bump to 0.1.4 so `publish-sdk.yml` ships it) and `keywords`/`classifiers` to `packages/python-sdk/pyproject.toml` (bumped to 0.1.2 — note there's no automated PyPI publish workflow in this repo, so that bump only takes effect on the next manual publish).
- Add CI/npm/PyPI badges to `README.md` alongside the existing License/PRs-welcome badges.

Closes #307, #308, #310, #311, #313, #314

**Skipped (need real image assets, out of scope for this PR):**
- #309 — OG/Twitter card image needs a real 1200x630 design
- #312 — README screenshot/demo GIF

## Test plan
- [x] `bunx biome check packages/api/src/` — pre-existing failure in `validation.ts` confirmed unrelated (no diff vs `main` for that file)
- [x] `bunx tsc --noEmit -p packages/api/tsconfig.json` — passes
- [x] `bun scripts/check-sitemap.mjs` — passes, confirms all 3 marketing routes covered
- [x] Dashboard build intentionally skipped per project convention (OOM risk in parallel agents) — to be verified after merge