### PR TITLE
fix(api): invalidate analytics cache on conversation create/delete

### DIFF
--- a/packages/api/src/lib/analytics-cache.ts
+++ b/packages/api/src/lib/analytics-cache.ts
@@ -1,0 +1,36 @@
+/**
+ * analytics-cache.ts — Cache key + invalidation for the dashboard analytics
+ * endpoint (`GET /v1/projects/:id/analytics`, see routes/analytics.ts).
+ *
+ * Results are cached in AUTH_CACHE per project+range for 60-300s. The range
+ * affected by a given write isn't known ahead of time, so a write busts all
+ * ranges for the project.
+ */
+
+import type { ExecutionContext } from "hono";
+
+/** Time ranges the analytics endpoint caches (see routes/analytics.ts). */
+export const ANALYTICS_CACHE_RANGES = ["7d", "30d", "90d"] as const;
+
+/** Build the AUTH_CACHE key used by the dashboard analytics endpoint. */
+export function analyticsCacheKey(projectId: string, range: string): string {
+  return `analytics:public:${projectId}:${range}`;
+}
+
+/**
+ * Bust cached analytics for a project across all ranges. Call after any
+ * write that changes conversation/message counts (create, delete) so the
+ * dashboard doesn't serve stale aggregates for up to the cache TTL.
+ */
+export function invalidateAnalyticsCache(
+  cache: KVNamespace | undefined,
+  executionCtx: ExecutionContext,
+  projectId: string,
+): void {
+  if (!cache) return;
+  executionCtx.waitUntil(
+    Promise.all(
+      ANALYTICS_CACHE_RANGES.map((range) => cache.delete(analyticsCacheKey(projectId, range))),
+    ),
+  );
+}

--- a/packages/api/src/routes/analytics.ts
+++ b/packages/api/src/routes/analytics.ts
@@ -1,6 +1,7 @@
 import { and, eq, gte, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { conversations, messages, organizations, projects } from "../db/schema";
+import { analyticsCacheKey } from "../lib/analytics-cache";
 import { MS_PER_DAY } from "../lib/config";
 import { errorResponse } from "../lib/helpers";
 import type { Bindings, Variables } from "../types";
@@ -57,7 +58,7 @@ app.get("/:id/analytics", async (c) => {
   const cutoff = Date.now() - days * MS_PER_DAY;
 
   // Build cache key
-  const cacheKey = `analytics:public:${projectId}:${rangeParam}`;
+  const cacheKey = analyticsCacheKey(projectId, rangeParam);
   const ttl = getTtlForRange(rangeParam);
 
   // Try cache first

--- a/packages/api/src/routes/conversations/crud.ts
+++ b/packages/api/src/routes/conversations/crud.ts
@@ -53,6 +53,7 @@ router.post("/", requireScope("conversations:write"), async (c) => {
       inputMessages,
     },
     c.executionCtx,
+    c.env.AUTH_CACHE,
   );
 
   if (result.error) {
@@ -211,7 +212,13 @@ router.delete("/:id", requireScope("conversations:write"), async (c) => {
 
   const db = c.get("db");
 
-  await ConversationService.deleteConversation(db, id);
+  await ConversationService.deleteConversation(
+    db,
+    id,
+    existing.projectId,
+    c.executionCtx,
+    c.env.AUTH_CACHE,
+  );
 
   return c.body(null, 204);
 });

--- a/packages/api/src/services/conversations.ts
+++ b/packages/api/src/services/conversations.ts
@@ -8,6 +8,7 @@ import type { DrizzleD1Database } from "drizzle-orm/d1";
 // `c.executionCtx` actually provides at every call site.
 import type { ExecutionContext } from "hono";
 import { conversations, conversationTags, messages } from "../db/schema";
+import { invalidateAnalyticsCache } from "../lib/analytics-cache";
 import { generateId } from "../lib/id";
 import { serializeMetadata } from "../lib/serialization";
 import { TagSchema } from "../lib/validation";
@@ -168,6 +169,7 @@ export async function createConversation(
   db: DrizzleD1Database,
   options: CreateConversationOptions,
   executionCtx: ExecutionContext,
+  cache?: KVNamespace,
 ): Promise<{
   conversation: typeof conversations.$inferSelect;
   messages: (typeof messages.$inferSelect)[];
@@ -252,6 +254,8 @@ export async function createConversation(
     tokenCount,
     now,
   );
+
+  invalidateAnalyticsCache(cache, executionCtx, projectId);
 
   return {
     conversation: {
@@ -461,6 +465,9 @@ export async function updateConversation(
 export async function deleteConversation(
   db: DrizzleD1Database,
   conversationId: string,
+  projectId: string,
+  executionCtx: ExecutionContext,
+  cache?: KVNamespace,
 ): Promise<void> {
   // Batch delete: tags → messages → conversation (order respects FK constraints)
   await db.batch([
@@ -468,6 +475,8 @@ export async function deleteConversation(
     db.delete(messages).where(eq(messages.conversationId, conversationId)),
     db.delete(conversations).where(eq(conversations.id, conversationId)),
   ]);
+
+  invalidateAnalyticsCache(cache, executionCtx, projectId);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/test/analytics.test.ts
+++ b/packages/api/test/analytics.test.ts
@@ -1,4 +1,4 @@
-import { env, SELF } from "cloudflare:test";
+import { SELF } from "cloudflare:test";
 import { beforeAll, describe, expect, it } from "vitest";
 import { sessionCookie, signTestSessionToken } from "./clerk-jwt";
 import { applyMigrations, authHeaders, seedProject, TEST_PROJECT_ID } from "./setup";
@@ -31,22 +31,18 @@ async function createConversation(body: Record<string, unknown> = {}) {
   });
 }
 
+function deleteConversation(id: string) {
+  return SELF.fetch(`http://localhost/v1/conversations/${id}`, {
+    method: "DELETE",
+    headers: authHeaders(),
+  });
+}
+
 /** Fetch the analytics endpoint with a valid dashboard session. */
 function fetchAnalytics(suffix = ""): Promise<Response> {
   return SELF.fetch(`http://localhost/api/v1/projects/${TEST_PROJECT_ID}/analytics${suffix}`, {
     headers: dashboardHeaders(),
   });
-}
-
-/**
- * Bust the analytics cache for the test project. The analytics route caches
- * results in AUTH_CACHE; tests that mutate data and re-fetch must clear it so
- * they observe fresh data (creating a conversation does not invalidate it).
- */
-async function clearAnalyticsCache(range = "30d"): Promise<void> {
-  if (env.AUTH_CACHE) {
-    await env.AUTH_CACHE.delete(`analytics:public:${TEST_PROJECT_ID}:${range}`);
-  }
 }
 
 interface AnalyticsResponse {
@@ -123,8 +119,8 @@ describe("Analytics", () => {
       expect(Array.isArray(body.conversations_per_day)).toBe(true);
     });
 
-    it("counts match actual data after creating conversations", async () => {
-      // Record baseline
+    it("counts match actual data after creating conversations, with no stale cache", async () => {
+      // Record baseline (this also populates the analytics cache).
       const baselineRes = await fetchAnalytics();
       const baseline = await baselineRes.json<AnalyticsResponse>();
       const baseConvs = baseline.summary.total_conversations;
@@ -140,8 +136,8 @@ describe("Analytics", () => {
         ],
       });
 
-      // Verify counts increased
-      await clearAnalyticsCache();
+      // The write must invalidate the cache populated above — re-fetching
+      // immediately (no manual cache clear) should already reflect the write.
       const afterRes = await fetchAnalytics();
       const after = await afterRes.json<AnalyticsResponse>();
 
@@ -150,17 +146,45 @@ describe("Analytics", () => {
       expect(after.summary.total_tokens).toBe(baseTokens + 15);
     });
 
-    it("includes recently created conversations in recent_conversations", async () => {
+    it("includes recently created conversations in recent_conversations, with no stale cache", async () => {
+      // Populate the cache before the write.
+      await fetchAnalytics();
+
       const createRes = await createConversation({ title: "Recent Analytics Conv" });
       expect(createRes.status).toBe(201);
       const created = await createRes.json<{ id: string }>();
 
-      await clearAnalyticsCache();
       const res = await fetchAnalytics();
       const body = await res.json<AnalyticsResponse>();
 
       const recentIds = body.recent_conversations.map((c) => c.id);
       expect(recentIds).toContain(created.id);
+    });
+
+    it("reflects deleted conversations immediately, with no stale cache (issue #352)", async () => {
+      const createRes = await createConversation({
+        title: "To Be Deleted",
+        messages: [{ role: "user", content: "Hello", token_count: 3 }],
+      });
+      const created = await createRes.json<{ id: string }>();
+
+      // Populate the cache with the conversation still present.
+      const beforeRes = await fetchAnalytics();
+      const before = await beforeRes.json<AnalyticsResponse>();
+      const baseConvs = before.summary.total_conversations;
+      const baseMsgs = before.summary.total_messages;
+
+      const deleteRes = await deleteConversation(created.id);
+      expect(deleteRes.status).toBe(204);
+
+      // Re-fetching immediately (no manual cache clear) must not serve the
+      // stale, too-high pre-delete counts.
+      const afterRes = await fetchAnalytics();
+      const after = await afterRes.json<AnalyticsResponse>();
+
+      expect(after.summary.total_conversations).toBe(baseConvs - 1);
+      expect(after.summary.total_messages).toBe(baseMsgs - 1);
+      expect(after.recent_conversations.map((c) => c.id)).not.toContain(created.id);
     });
 
     it("reports active_api_keys count", async () => {


### PR DESCRIPTION
## Summary

Closes #352.

The dashboard analytics endpoint (`GET /v1/projects/:id/analytics`, `packages/api/src/routes/analytics.ts`) caches its aggregated result in `AUTH_CACHE` (KV) per project+range for 60-300s under the key `analytics:public:{projectId}:{range}`. Nothing ever busted that key on writes, so after a user deleted (or created) conversations, the dashboard could show stale — and in the delete case, too-high — counts for up to 5 minutes with no way to force a refresh.

## Fix chosen: explicit invalidation on write

Three options were on the table: explicit invalidation, a shorter TTL, or a cache-key version bump. Explicit invalidation is the simplest fix that's actually correct:

- A shorter TTL only shrinks the staleness window, it doesn't close it, and the endpoint already tiers TTL by range (60s/180s/300s) for a reason (heavier ranges are more expensive to recompute) — shrinking it further trades correctness for cost without fixing the bug.
- A version-bump key (e.g. an epoch stored in KV/D1) adds a second piece of state to keep in sync and a read-time indirection, for no benefit over just deleting the stale key directly — over-engineering for what's a straightforward "delete on write" case.

Since the cache key is range-specific but a write doesn't know which range(s) a user has open, the fix busts all three known ranges (`7d`/`30d`/`90d`) for the project on write. This is centralized in a new `packages/api/src/lib/analytics-cache.ts` (`analyticsCacheKey`, `invalidateAnalyticsCache`) so the key format has one source of truth (routes/analytics.ts now uses it too) and is called from both `createConversation` and `deleteConversation` in `services/conversations.ts` — matching exactly the two write paths the issue names. Invalidation is fire-and-forget via `executionCtx.waitUntil`, consistent with how the route already populates the cache.

## Scope notes (not fixed, flagged per review guidance)

- **Cloudflare Workers Cache (commit dcea999)**: verified this is **not** a factor here. That layer only sets `Cache-Control: public` on genuinely static, unauthenticated routes (`/api` health check, `/llms.txt`, `/agents.md`, `/openapi.json`); the analytics routes require a Clerk session or API key (`Authorization`/session cookie present), and per the Workers Cache docs/comments in that commit, requests carrying auth headers are never cached at that layer. So Workers Cache is not serving stale analytics — only the `AUTH_CACHE` KV layer this PR fixes was the culprit.
- **MCP write path**: there's a second, separate conversation-service module (`services/mcp-conversations.ts`, used by the MCP tool `store_conversation`/delete) with its own `createConversation`/`deleteConversation`, kept intentionally separate from `services/conversations.ts` per an existing code comment (different response contracts, no webhook trigger). It writes to the same `conversations`/`messages` tables, so it has the same latent analytics-cache-staleness gap this issue described — just not the two functions the issue named. Left unaddressed here to keep this fix scoped to what's asked; worth a small follow-up if the MCP write path is a live traffic source for dashboard analytics viewers.

## Changes

- `packages/api/src/lib/analytics-cache.ts` (new): `ANALYTICS_CACHE_RANGES`, `analyticsCacheKey()`, `invalidateAnalyticsCache()`.
- `packages/api/src/routes/analytics.ts`: use `analyticsCacheKey()` instead of an inline template literal (DRY with the new invalidation helper).
- `packages/api/src/services/conversations.ts`: `createConversation` and `deleteConversation` now accept the KV cache binding (and `deleteConversation` now also takes `projectId` + `executionCtx`, needed to invalidate) and call `invalidateAnalyticsCache` after a successful write.
- `packages/api/src/routes/conversations/crud.ts`: thread `c.env.AUTH_CACHE` (and for delete, `existing.projectId` + `c.executionCtx`) through to the service calls.
- `packages/api/test/analytics.test.ts`: removed the manual `clearAnalyticsCache()` test workaround (its own comment said "creating a conversation does not invalidate it" — that was the bug) and added a new test, `"reflects deleted conversations immediately, with no stale cache (issue #352)"`, that populates the cache, deletes a conversation, and asserts the very next fetch (no manual cache clear) shows the decremented counts — this is the exact regression test for the reported bug. The two existing create-path tests were also tightened to assert no manual cache clear is needed anymore.

## Test plan

- [x] `bunx biome check packages/api/src/` — clean (one pre-existing, unrelated formatting diagnostic in `lib/validation.ts` predates this branch; confirmed via `git show main:...validation.ts | biome check --stdin-file-path=validation.ts -`, left untouched per surgical-changes convention)
- [x] `bunx tsc --noEmit -p packages/api/tsconfig.json` — no errors
- [x] `cd packages/api && bunx vitest run` — **354/354 tests passed** (25 test files), including the new/updated analytics cache-invalidation tests
- [x] `bun build` intentionally **not** run per instructions

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>