### PR TITLE
fix(api): CORS credential leak + empty-scopes privilege escalation

### DIFF
--- a/packages/api/scripts/prepare-wrangler-deploy-config.sh
+++ b/packages/api/scripts/prepare-wrangler-deploy-config.sh
@@ -39,6 +39,11 @@ try {
       "::warning title=Cron triggers omitted::Deploy config does not manage cron triggers to avoid Cloudflare account plan limits.",
     );
   }
+  // Mark the deployed Worker as production so CORS excludes localhost origins
+  // (see src/lib/cors.ts). Only stamped here — local `wrangler dev` uses
+  // wrangler.jsonc directly and never gets this var, so localhost dev origins
+  // keep working there.
+  config.vars = { ...config.vars, ENVIRONMENT: "production" };
   fs.writeFileSync(deployConfigPath, `${JSON.stringify(config, null, 2)}\n`);
 } catch (error) {
   console.error(

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { OPENAPI_SPEC } from "./content/openapi";
 import { AGENTS_MD, LLMS_TXT } from "./content/static";
+import { resolveAllowedOrigin } from "./lib/cors";
 import { errorResponse } from "./lib/helpers";
 import { clerkDashboardAuth } from "./middleware/clerk-dashboard-auth";
 import { dbMiddleware } from "./middleware/db";
@@ -43,23 +44,14 @@ const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 app.use("*", requestIdMiddleware);
 app.use("*", securityHeaders);
 
-// CORS configuration with origin reflection for security
-const ALLOWED_ORIGINS = [
-  "https://agentstate.app",
-  "http://localhost:3000",
-  "http://localhost:8787",
-  "http://127.0.0.1:3000",
-  "http://127.0.0.1:8787",
-];
-
+// CORS configuration with origin reflection for security.
+// See lib/cors.ts: with credentials: true, we may never answer "*" or reflect
+// an origin that isn't actually on the allow list, and localhost is only
+// allowed outside of production (ENVIRONMENT binding).
 app.use(
   "*",
   cors({
-    origin: (origin) => {
-      if (!origin) return "*";
-      if (ALLOWED_ORIGINS.includes(origin)) return origin;
-      return ALLOWED_ORIGINS[0];
-    },
+    origin: (origin, c) => resolveAllowedOrigin(origin, c.env.ENVIRONMENT),
     allowHeaders: [
       "Authorization",
       "Content-Type",

--- a/packages/api/src/lib/api-key.ts
+++ b/packages/api/src/lib/api-key.ts
@@ -23,8 +23,11 @@ export async function buildApiKey(projectId: string, name: string, scopes?: stri
       name,
       keyPrefix: prefix,
       keyHash: hash,
-      // null = full access (legacy/unscoped); a non-empty list = restricted key.
-      scopes: scopes && scopes.length > 0 ? JSON.stringify(scopes) : null,
+      // null = full access (legacy/unscoped, `scopes` omitted entirely). An
+      // explicit list — including an empty one — is persisted as-is: [] means
+      // "no permissions", never "no restrictions". Only `undefined` maps to
+      // null; do not conflate it with an explicit empty array.
+      scopes: scopes === undefined ? null : JSON.stringify(scopes),
       createdAt: now,
     },
     prefix,

--- a/packages/api/src/lib/cors.ts
+++ b/packages/api/src/lib/cors.ts
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------------------
+// CORS origin resolution
+// ---------------------------------------------------------------------------
+//
+// Pulled out of index.ts as a pure function so the allow/deny logic can be
+// unit tested without spinning up the Worker. The global CORS middleware sets
+// `credentials: true`, so per the Fetch spec we must NEVER answer with `"*"`
+// and must NEVER reflect an origin that isn't actually allowed — both are
+// invalid/misleading when credentials are in play.
+
+/** Origins allowed in every environment, including production. */
+const PRODUCTION_ORIGINS = ["https://agentstate.app"];
+
+/** Additional origins allowed only outside of production (local dev servers). */
+const DEV_ORIGINS = [
+  "http://localhost:3000",
+  "http://localhost:8787",
+  "http://127.0.0.1:3000",
+  "http://127.0.0.1:8787",
+];
+
+/**
+ * Resolve the Access-Control-Allow-Origin value for a request.
+ *
+ * Returns `null` when no header should be sent — for a missing Origin header,
+ * or an Origin that isn't on the allow list. Never falls back to `"*"` or to
+ * an unrelated allowed origin, since either would be sent alongside
+ * `Access-Control-Allow-Credentials: true`.
+ *
+ * `environment` should be the Worker's `ENVIRONMENT` binding. Localhost
+ * origins are only permitted when it is not `"production"`.
+ */
+export function resolveAllowedOrigin(
+  origin: string | undefined,
+  environment: string | undefined,
+): string | null {
+  if (!origin) return null;
+  const allowedOrigins =
+    environment === "production" ? PRODUCTION_ORIGINS : [...PRODUCTION_ORIGINS, ...DEV_ORIGINS];
+  return allowedOrigins.includes(origin) ? origin : null;
+}

--- a/packages/api/src/routes/keys.ts
+++ b/packages/api/src/routes/keys.ts
@@ -49,7 +49,10 @@ app.post("/:projectId/keys", requireScope("keys:write"), async (c) => {
   const callerScopes = c.get("capabilityScopes") ?? [];
   const callerHasFullAccess = callerScopes.includes("*");
   let childScopes = parsed.data.scopes;
-  if (childScopes) {
+  // Explicit checks against undefined (not a truthy check): an explicit `[]`
+  // must still be validated here rather than falling through to the
+  // "omitted" inheritance branch below.
+  if (childScopes !== undefined) {
     if (!scopesSatisfyAll(callerScopes, childScopes)) {
       return errorResponse(
         c,

--- a/packages/api/src/routes/v1-keys.ts
+++ b/packages/api/src/routes/v1-keys.ts
@@ -44,7 +44,10 @@ app.post("/", requireScope("keys:write"), async (c) => {
   const callerScopes = c.get("capabilityScopes") ?? [];
   const callerHasFullAccess = callerScopes.includes("*");
   let childScopes = parsed.data.scopes;
-  if (childScopes) {
+  // Explicit checks against undefined (not a truthy check): an explicit `[]`
+  // must still be validated here rather than falling through to the
+  // "omitted" inheritance branch below.
+  if (childScopes !== undefined) {
     if (!scopesSatisfyAll(callerScopes, childScopes)) {
       return errorResponse(
         c,

--- a/packages/api/src/services/keys.ts
+++ b/packages/api/src/services/keys.ts
@@ -51,7 +51,9 @@ export async function createApiKey(
     name,
     key_prefix: key.prefix,
     key: key.rawKey,
-    scopes: scopes && scopes.length > 0 ? scopes : null,
+    // Mirror buildApiKey's null/[] distinction: only an omitted `scopes`
+    // (undefined) means full access; an explicit [] means no permissions.
+    scopes: scopes === undefined ? null : scopes,
     created_at: key.now,
     last_used_at: null,
     revoked_at: null,

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -15,6 +15,12 @@ export type Bindings = {
   CLERK_SECRET_KEY?: string;
   /** Optional Clerk JWT public key (PEM) for networkless session verification. */
   CLERK_JWT_KEY?: string;
+  /**
+   * Deployment environment, e.g. "production". Set on the deployed Worker only
+   * (via the deploy config); unset in local `wrangler dev` and tests. Used to
+   * exclude localhost origins from CORS outside of local development.
+   */
+  ENVIRONMENT?: string;
 };
 
 export type Variables = {

--- a/packages/api/test/cors.test.ts
+++ b/packages/api/test/cors.test.ts
@@ -1,0 +1,64 @@
+import { SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { resolveAllowedOrigin } from "../src/lib/cors";
+
+describe("resolveAllowedOrigin", () => {
+  it("returns null for a missing origin (never falls back to '*')", () => {
+    // Regression: with credentials: true, "*" + Access-Control-Allow-Credentials
+    // is invalid per the Fetch spec and rejected by browsers.
+    expect(resolveAllowedOrigin(undefined, undefined)).toBeNull();
+    expect(resolveAllowedOrigin("", undefined)).toBeNull();
+  });
+
+  it("returns null for a disallowed origin (never reflects an unrelated allowed origin)", () => {
+    // Regression: the old fallback reflected ALLOWED_ORIGINS[0] for any
+    // disallowed origin instead of omitting the header.
+    expect(resolveAllowedOrigin("https://evil.example", undefined)).toBeNull();
+    expect(resolveAllowedOrigin("https://evil.example", "production")).toBeNull();
+  });
+
+  it("reflects the production origin in every environment", () => {
+    expect(resolveAllowedOrigin("https://agentstate.app", undefined)).toBe(
+      "https://agentstate.app",
+    );
+    expect(resolveAllowedOrigin("https://agentstate.app", "production")).toBe(
+      "https://agentstate.app",
+    );
+  });
+
+  it("allows localhost origins outside of production", () => {
+    expect(resolveAllowedOrigin("http://localhost:3000", undefined)).toBe("http://localhost:3000");
+    expect(resolveAllowedOrigin("http://127.0.0.1:8787", "development")).toBe(
+      "http://127.0.0.1:8787",
+    );
+  });
+
+  it("rejects localhost origins in production", () => {
+    // Regression: any page open on a loopback port must not be able to make
+    // credentialed cross-origin calls to the production API.
+    expect(resolveAllowedOrigin("http://localhost:3000", "production")).toBeNull();
+    expect(resolveAllowedOrigin("http://127.0.0.1:8787", "production")).toBeNull();
+  });
+});
+
+describe("CORS headers on live requests (ENVIRONMENT unset, dev-like)", () => {
+  it("reflects an allowed origin and sets credentials", async () => {
+    const res = await SELF.fetch("http://localhost/api", {
+      headers: { Origin: "https://agentstate.app" },
+    });
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://agentstate.app");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+  });
+
+  it("omits Access-Control-Allow-Origin for a disallowed origin", async () => {
+    const res = await SELF.fetch("http://localhost/api", {
+      headers: { Origin: "https://evil.example" },
+    });
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+  });
+
+  it("omits Access-Control-Allow-Origin when no Origin header is sent", async () => {
+    const res = await SELF.fetch("http://localhost/api");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+  });
+});

--- a/packages/api/test/scopes.test.ts
+++ b/packages/api/test/scopes.test.ts
@@ -1,6 +1,11 @@
-import { SELF } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
 import { beforeEach, describe, expect, it } from "vitest";
+import { apiKeys } from "../src/db/schema";
+import { buildApiKey } from "../src/lib/api-key";
 import { effectiveKeyScopes, scopeSatisfies, scopesSatisfyAll } from "../src/lib/scopes";
+import { createApiKey } from "../src/services/keys";
 import { applyMigrations, authHeaders, seedProject, TEST_PROJECT_ID } from "./setup";
 
 function bearer(key: string): Record<string, string> {
@@ -41,6 +46,52 @@ describe("scope helpers", () => {
     // An explicit empty list grants nothing — it never silently becomes full access.
     expect(effectiveKeyScopes("[]")).toEqual([]);
     expect(effectiveKeyScopes('["conversations:read"]')).toEqual(["conversations:read"]);
+  });
+});
+
+describe("buildApiKey / createApiKey: undefined vs. explicit [] scopes", () => {
+  beforeEach(async () => {
+    await applyMigrations();
+    await seedProject();
+  });
+
+  it("buildApiKey: omitted (undefined) scopes persist as null (legacy full access)", async () => {
+    const key = await buildApiKey(TEST_PROJECT_ID, "legacy", undefined);
+    expect(key.values.scopes).toBeNull();
+  });
+
+  it("buildApiKey: an explicit empty array persists as '[]', never null", async () => {
+    // Regression: this used to collapse to null, which effectiveKeyScopes(null)
+    // resolves to full access ("*") — the opposite of "no permissions".
+    const key = await buildApiKey(TEST_PROJECT_ID, "no-access", []);
+    expect(key.values.scopes).toBe("[]");
+    expect(key.values.scopes).not.toBeNull();
+    expect(effectiveKeyScopes(key.values.scopes)).toEqual([]);
+  });
+
+  it("buildApiKey: a non-empty list persists as-is", async () => {
+    const key = await buildApiKey(TEST_PROJECT_ID, "scoped", ["conversations:read"]);
+    expect(key.values.scopes).toBe('["conversations:read"]');
+  });
+
+  it("createApiKey: explicit empty scopes are stored and reported as [] (not full access)", async () => {
+    const db = drizzle(env.DB);
+    const created = await createApiKey(db, TEST_PROJECT_ID, "no-access-key", []);
+    expect(created.scopes).toEqual([]);
+
+    const [row] = await db.select().from(apiKeys).where(eq(apiKeys.id, created.id));
+    expect(row?.scopes).toBe("[]");
+    expect(effectiveKeyScopes(row?.scopes)).toEqual([]);
+  });
+
+  it("createApiKey: omitted scopes remain full access (null), not conflated with []", async () => {
+    const db = drizzle(env.DB);
+    const created = await createApiKey(db, TEST_PROJECT_ID, "full-access-key", undefined);
+    expect(created.scopes).toBeNull();
+
+    const [row] = await db.select().from(apiKeys).where(eq(apiKeys.id, created.id));
+    expect(row?.scopes).toBeNull();
+    expect(effectiveKeyScopes(row?.scopes)).toEqual(["*"]);
   });
 });
 


### PR DESCRIPTION
## Summary

Two security fixes, each in its own commit:

**#345 — CORS reflects credentials for localhost origins in production, invalid wildcard-with-credentials**
- `ALLOWED_ORIGINS` hardcoded localhost/127.0.0.1 entries that were also served in production (single Worker, no per-env origin list). Any page open on those loopback ports could make credentialed cross-origin calls to the production API.
- The handler answered `Access-Control-Allow-Origin: *` for a missing `Origin`, which is invalid alongside `Access-Control-Allow-Credentials: true` and rejected by browsers.
- For a disallowed origin it reflected `ALLOWED_ORIGINS[0]` (`https://agentstate.app`) instead of omitting the header — misleading, since the response advertised an allow-origin that didn't match the request.
- Fix: `resolveAllowedOrigin()` (`packages/api/src/lib/cors.ts`) returns `null` (no header) for a missing/disallowed origin, and only allows localhost origins when the Worker's `ENVIRONMENT` binding isn't `"production"`. `ENVIRONMENT=production` is stamped only into the generated deploy config (`prepare-wrangler-deploy-config.sh`), so local `wrangler dev` and tests are unaffected.

**#346 — Empty scopes array mints a full-access API key (privilege-escalation landmine)**
- `buildApiKey` stored `scopes: scopes && scopes.length > 0 ? JSON.stringify(scopes) : null`. An **explicit empty array** (`[]`) collapsed to `null`, and `effectiveKeyScopes(null)` resolves to full access (`*`) — the opposite of "no permissions".
- `services/keys.ts`'s response shaping had the identical bug.
- The delegation guards in `routes/keys.ts` and `routes/v1-keys.ts` used `if (childScopes)`; changed to `if (childScopes !== undefined)` to make the undefined-vs-explicit-`[]` distinction explicit at the call site (functionally a no-op today since arrays are always truthy, but removes the ambiguity flagged by the audit).
- Only `scopes === undefined` (the field omitted entirely) now maps to `null`/full access. Legacy/unscoped keys (column `null`/absent) are unaffected and keep full access.
- Not currently reachable over HTTP (`CreateApiKeySchema.scopes` has `.min(1)`, unchanged), but the lib/service layer is the security-relevant unit — any future caller (internal job, new route, MCP tool) that reaches `createApiKey`/`buildApiKey` with `[]` now gets a zero-permission key instead of a god key.

Closes #345
Closes #346

## Test plan
- [x] New regression tests in `packages/api/test/cors.test.ts` (unit tests for `resolveAllowedOrigin` covering missing/disallowed/production/dev-localhost cases, plus live `SELF.fetch` assertions that disallowed/missing origins get no `Access-Control-Allow-Origin` header) — all fail against the pre-fix code.
- [x] New regression tests in `packages/api/test/scopes.test.ts` (`buildApiKey`/`createApiKey` with `undefined` vs. explicit `[]` scopes) — fail against the pre-fix code (previously resolved to `null`/full access).
- [x] `bunx biome check packages/api/src/` — clean
- [x] `bunx tsc --noEmit -p packages/api/tsconfig.json` — clean
- [x] `cd packages/api && bunx vitest run` — 366/366 passed (26 test files)