### PR TITLE
docs: fix API reference and project docs to match live code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ bun install
 cd packages/api
 bunx wrangler dev
 
-# Local dev — Dashboard (port 3000, separate dev server)
+# Local dev — Dashboard (port 4321, separate dev server)
 cd packages/dashboard
 bun run dev
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -154,7 +154,7 @@ Pick scenarios from the tables below. Spawn agents that touch **different files*
 
 - [x] API Core (Hono + D1 + Drizzle + auth + CRUD)
 - [x] AI Features (title generation, follow-ups)
-- [x] Dashboard (Next.js + shadcn sidebar + Clerk)
+- [x] Dashboard (Astro + React islands + Clerk + Tailwind v4)
 - [x] Agent endpoints (/llms.txt, /agents.md)
 - [x] CI/CD (GitHub Actions: lint → test → deploy)
 - [x] Custom domain (agentstate.app)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Built for vibe coders. No SDK needed — give your coding agent the [API docs](h
 - **Tags** — Organize conversations with tags and filter by tag
 - **Bulk Operations** — Bulk delete and export conversations
 - **Request Tracing** — X-Request-Id header on every response
+- **MCP Server** — Remote (`/api/mcp`, OAuth 2.1) and local stdio (`@agentstate/mcp`) Model Context Protocol servers for Cursor, Claude Desktop, and Windsurf — see [docs/mcp.md](docs/mcp.md)
 
 ## Quick Start
 
@@ -76,9 +77,8 @@ All endpoints are served under `/api/v1/`. See the [API Reference](docs/api-refe
 |--------|------|-------------|
 | POST | `/api/v1/conversations` | Create conversation |
 | GET | `/api/v1/conversations` | List conversations (cursor pagination) |
-| GET | `/api/v1/conversations/:id` | Get conversation (messages optional) |
-| GET | `/api/v1/conversations/:id?include=messages` | Get with messages |
-| PATCH | `/api/v1/conversations/:id` | Update title/metadata |
+| GET | `/api/v1/conversations/:id` | Get conversation (includes messages by default; `?fields=!messages` to exclude) |
+| PUT | `/api/v1/conversations/:id` | Update title/metadata |
 | DELETE | `/api/v1/conversations/:id` | Delete with messages |
 | POST | `/api/v1/conversations/:id/messages` | Append messages |
 | GET | `/api/v1/conversations/:id/messages` | List messages |
@@ -117,7 +117,7 @@ All endpoints are served under `/api/v1/`. See the [API Reference](docs/api-refe
 - **Dashboard**: Astro + React islands + Clerk + Tailwind v4
 - **Package Manager**: Bun
 - **Linter**: Biome
-- **Tests**: Vitest (276 tests)
+- **Tests**: Vitest (353 tests)
 
 ## Development
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,8 @@ Additional shipped work:
 - TypeScript SDK (`@agentstate/sdk`) and Python SDK (`agentstate` on PyPI)
 - Dashboard with project management, analytics, and API key management (Astro + React + Clerk)
 - Cursor-based pagination, full-text search, bulk operations, AI-generated titles and follow-up questions
-- 276 passing tests; Biome linting; strict TypeScript throughout
+- **Remote MCP server** — hosted Streamable-HTTP endpoint at `/api/mcp` plus a local stdio package (`@agentstate/mcp`), with OAuth 2.1 + PKCE and scope-gated tools mirroring all five primitives, so coding agents (Cursor, Claude Desktop, Windsurf) can use AgentState natively. See [docs/mcp.md](docs/mcp.md).
+- 353 passing tests; Biome linting; strict TypeScript throughout
 
 ---
 
@@ -34,9 +35,6 @@ These are the highest-priority items in active development or ready to start:
 - **Primitive docs and recipes** — focused how-to guides for each primitive (leases, claims, capability tokens), not just API reference. Show the why, not just the what.
 - **Flagship examples** — end-to-end examples: coordinate N agents using leases; produce a verifiable output with claims; delegate a subtask with a capability token. Runnable in minutes.
 - **Landing page clarity** — make it obvious within seconds what AgentState does and why you'd reach for it over ad-hoc solutions.
-
-### Ecosystem
-- **MCP server** — so coding agents (Cursor, Claude Desktop, Windsurf) can use AgentState natively via the Model Context Protocol. No manual wiring.
 
 ### SDK Breadth
 - Expanded SDK coverage for all primitives (leases, claims, capability tokens) in both TypeScript and Python SDKs

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,7 +2,12 @@
 
 Base URL: `https://agentstate.app/api`
 
-Backward-compatible base: `https://agentstate.app` (routes under `/v1/*` mirror `/api/v1/*`).
+Backward-compatible base: `https://agentstate.app`. `/v1/*` is **not** a general alias for
+`/api/v1/*` — it's a frozen legacy surface mounted for exactly four resources: conversations,
+AI features (title/follow-ups), tags, and public analytics (`packages/api/src/index.ts`). It
+predates projects and the state/lease/claim primitives, so `/v1/projects`, `/v1/states`, `/v1/keys`,
+etc. were never mounted and never will be — always use `/api/v1/*` for anything outside those
+four resources.
 
 ## Version Overview
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -13,8 +13,8 @@ The API provides improved performance, consistency, and developer experience:
 - **Snake_case field names**: All request and response fields use snake_case
 - **Timestamps in milliseconds**: All timestamps are Unix milliseconds (`Date.now()` format)
 - **Cursor-based pagination**: Efficient pagination with `next_cursor` and `total` count
-- **Conditional includes**: Use `?include=messages` to fetch messages only when needed
-- **HTTP method semantics**: PATCH for partial updates, proper status codes
+- **Field selection**: Messages are included by default on Get Conversation; use `?fields=` to select specific fields or `?fields=!messages` to exclude the messages array
+- **HTTP method semantics**: PUT to replace a conversation's title/metadata, PATCH for partial updates elsewhere (e.g. projects), proper status codes
 
 ---
 
@@ -28,7 +28,13 @@ The API provides improved performance, consistency, and developer experience:
 
 ## Authentication
 
-All `/v1/conversations/*` and `/v1/tags` endpoints require a valid API key.
+Nearly every endpoint requires authentication. Conversations, tags, messages, search, analytics,
+AI features, webhooks, API keys, states, leases, claims, and capability tokens all require a
+valid API key (optionally scoped — see [Permissions & scopes](#permissions--scopes)). Projects,
+organizations, custom domains, and dashboard-only analytics/traces instead require a Clerk
+session (they're called from the dashboard frontend, not with an API key). The only unauthenticated
+routes are the health check, static agent-readable content (`llms.txt`, `agents.md`, `openapi.json`),
+OAuth discovery, and domain verification.
 
 Pass the key as a Bearer token:
 
@@ -125,7 +131,7 @@ This applies to:
 - `GET /v1/analytics/timeseries`
 - `GET /v1/analytics/tags`
 - `GET /v1/conversations/:id/analytics`
-- `GET /v1/projects/:id/analytics`
+- `GET /api/v1/projects/:id/analytics`
 
 ### Data Freshness
 
@@ -151,7 +157,9 @@ If you need absolutely real-time data, consider:
 
 ## API Reference
 
-All endpoints require API key authentication and are located at `/api/v1/*`.
+Endpoints are located at `/api/v1/*`. Most require API key authentication; dashboard-management
+routes (projects, organizations, domains, dashboard analytics/traces) require a Clerk session
+instead. See [Authentication](#authentication) above for the full breakdown.
 
 ### Authentication
 
@@ -254,13 +262,21 @@ Each message object:
   "total_cost_microdollars": 0,
   "total_tokens": 0,
   "created_at": 1710000000000,
-  "updated_at": 1710000000000
+  "updated_at": 1710000000000,
+  "messages": [
+    {
+      "id": "xYz789_AbCdEfGhIjKlM",
+      "role": "user",
+      "content": "Hello",
+      "metadata": null,
+      "token_count": 0,
+      "created_at": 1710000000000
+    }
+  ]
 }
 ```
 
-**V2 Changes:**
-- Messages are NOT included in the create response for efficiency
-- Use `POST /api/v1/conversations/:id/messages` to add messages separately
+The `messages` array reflects whatever was passed in the request body (empty if none were sent).
 
 **Errors:**
 - `400 BAD_REQUEST` -- Invalid body or validation failure.
@@ -321,22 +337,27 @@ Returns conversations for the authenticated project, ordered by `updated_at`.
 GET /api/v1/conversations/:id
 ```
 
-Returns a single conversation. Messages are NOT included by default.
+Returns a single conversation. Messages are included by default.
 
 **Query parameters:**
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `include` | string | -- | Comma-separated resources to include. Use `messages` to include messages array. |
+| `fields` | string | all | Comma-separated field names to include. Special value `!messages` excludes the messages array. |
+
+**Valid fields**: `id`, `project_id`, `external_id`, `title`, `metadata`, `message_count`, `token_count`, `total_cost_microdollars`, `total_tokens`, `created_at`, `updated_at`, `messages`
 
 **Examples:**
 
 ```bash
-# Get conversation metadata only (no messages)
+# Get all fields, including messages (default)
 GET /api/v1/conversations/:id
 
-# Include messages
-GET /api/v1/conversations/:id?include=messages
+# Get only conversation metadata (no messages)
+GET /api/v1/conversations/:id?fields=id,title,updated_at
+
+# Exclude messages array, keep everything else
+GET /api/v1/conversations/:id?fields=!messages
 ```
 
 **Response:** `200 OK`
@@ -367,10 +388,6 @@ GET /api/v1/conversations/:id?include=messages
 }
 ```
 
-**V2 Changes:**
-- Messages NOT included by default (use `?include=messages`)
-- Uses `include` query param instead of `fields`
-
 **Errors:**
 - `404 NOT_FOUND` -- Conversation not found.
 
@@ -380,16 +397,16 @@ GET /api/v1/conversations/:id?include=messages
 GET /api/v1/conversations/by-external-id/:externalId
 ```
 
-Find a conversation by the caller-provided `external_id`. Messages are NOT included by default.
+Find a conversation by the caller-provided `external_id`. Returns the conversation with all messages, same as [Get Conversation](#get-conversation) (supports the same `fields` parameter).
 
-Response shape is identical to [Get Conversation](#get-conversation) (without `?include=messages`).
+Response shape is identical to [Get Conversation](#get-conversation).
 
 **Errors:** `404 NOT_FOUND`
 
 #### Update Conversation
 
 ```
-PATCH /api/v1/conversations/:id
+PUT /api/v1/conversations/:id
 ```
 
 Update a conversation's title and/or metadata.
@@ -418,9 +435,6 @@ Update a conversation's title and/or metadata.
   "updated_at": 1710000080000
 }
 ```
-
-**V2 Changes:**
-- Uses `PATCH` instead of `PUT` (HTTP semantic improvement)
 
 **Errors:** `404 NOT_FOUND`
 
@@ -456,11 +470,22 @@ Add one or more messages to an existing conversation. Automatically updates the 
 |-------|------|----------|-------------|
 | `messages` | array | Yes | At least 1 message. Same schema as [Create Conversation](#create-conversation) messages. |
 
-**Response:** `204 No Content`
+**Response:** `201 Created`
 
-**V2 Changes:**
-- Returns `204 No Content` instead of `201 Created` with message list
-- More efficient for bulk message inserts
+```json
+{
+  "messages": [
+    {
+      "id": "xYz789_AbCdEfGhIjKlM",
+      "role": "assistant",
+      "content": "Hi there!",
+      "metadata": null,
+      "token_count": 10,
+      "created_at": 1710000000000
+    }
+  ]
+}
+```
 
 **Errors:** `404 NOT_FOUND` -- Conversation does not exist.
 
@@ -477,7 +502,7 @@ Paginate through messages in chronological order.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `limit` | integer | 100 | Results per page (1-500). |
-| `after` | string | -- | Created-at timestamp (unix ms) to start after (cursor). |
+| `after` | string | -- | Message ID to start after (cursor). |
 
 **Response:** `200 OK`
 
@@ -495,15 +520,12 @@ Paginate through messages in chronological order.
   ],
   "pagination": {
     "limit": 100,
-    "next_cursor": "1710000005000"
+    "next_cursor": "msg_001"
   }
 }
 ```
 
-`next_cursor` is the created_at timestamp of the last message in the page. Pass it as the `after` parameter for the next page. `null` when there are no more results.
-
-**V2 Changes:**
-- Cursor is now `created_at` timestamp instead of message ID
+`next_cursor` is the ID of the last message in the page. Pass it as the `after` parameter for the next page. `null` when there are no more results.
 
 **Errors:** `404 NOT_FOUND` -- Conversation does not exist.
 
@@ -949,57 +971,12 @@ rule, and examples.
 
 ## Migration Guide (Historical)
 
-The API is now unified under `/api/v1/`. The improvements previously labeled "V2" (PATCH method, `?include=messages`, `pagination.total`, snake_case field names, etc.) are the current standard.
-
-### Key Changes from Legacy V1
-
-1. **Base Path**: Legacy `/v1/*` is consolidated into `/api/v1/*`
-2. **Messages in Get Conversation**: Legacy V1 included messages by default. Now requires `?include=messages`
-3. **Create Conversation Response**: Legacy V1 returned created messages. Now returns only conversation metadata
-4. **Update Method**: Legacy V1 used `PUT`. Now uses `PATCH`
-5. **Append Messages Response**: Legacy V1 returned created messages. Now returns `204 No Content`
-6. **Pagination**: Now includes `total` count in metadata
-7. **Analytics**: Derives `project_id` from API key, no need to pass it as query parameter
-8. **Field Names**: Consistently uses snake_case (e.g., `key_id` instead of `id`)
-
-### Migration Steps
-
-1. **Update base URLs**: Use `/api/v1/` for all API calls
-2. **Update conversation fetches**: Add `?include=messages` when you need messages
-3. **Handle create response**: Create no longer returns messages
-4. **Update field name references**: Use snake_case field names (e.g., `key_id`, `project_id`)
-5. **Remove project_id from analytics**: The API key determines the project automatically
-6. **Update pagination handling**: Use `pagination.total` for total counts
-
-### Example Migration
-
-**Legacy V1:**
-```javascript
-// Create conversation
-const response = await fetch('/api/v1/conversations', {
-  method: 'POST',
-  headers: { 'Authorization': 'Bearer as_live_xxx' },
-  body: JSON.stringify({ messages: [{ role: 'user', content: 'Hello' }] })
-});
-const { messages } = await response.json();
-// messages is available in response
-```
-
-**Current:**
-```javascript
-// Create conversation
-const response = await fetch('/api/v1/conversations', {
-  method: 'POST',
-  headers: { 'Authorization': 'Bearer as_live_xxx' },
-  body: JSON.stringify({ messages: [{ role: 'user', content: 'Hello' }] })
-});
-const conversation = await response.json();
-// messages NOT in response - conversation created efficiently
-
-// Later, fetch messages when needed
-const msgResponse = await fetch(`/api/v1/conversations/${conversation.id}/messages`);
-const { data: messages } = await msgResponse.json();
-```
+There is no "V2" API and no live migration in progress — `/api/v1/*` (with a deprecated `/v1/*`
+alias for conversations, tags, and public analytics) is the only API and always has been. A
+parallel "V2" convention set was drafted at one point (a `PATCH` update method, `?include=messages`,
+`pagination.total` everywhere, etc.) but most of those proposed changes were never adopted. See
+**[docs/v2-migration.md](./v2-migration.md)** for the full historical record of what was proposed
+versus what actually shipped.
 
 ---
 
@@ -1708,7 +1685,7 @@ Dashboard-internal endpoints for project management. These routes do **not** req
 ### Create Project
 
 ```
-POST /v1/projects
+POST /api/v1/projects
 ```
 
 Creates a new project and auto-generates a default API key.
@@ -1749,7 +1726,7 @@ Creates a new project and auto-generates a default API key.
 ### List Projects
 
 ```
-GET /v1/projects
+GET /api/v1/projects
 ```
 
 **Query parameters:**
@@ -1778,7 +1755,7 @@ GET /v1/projects
 ### Get Project by ID
 
 ```
-GET /v1/projects/:id
+GET /api/v1/projects/:id
 ```
 
 Returns the project with its API keys.
@@ -1810,7 +1787,7 @@ Returns the project with its API keys.
 ### Get Project by Slug
 
 ```
-GET /v1/projects/by-slug/:slug
+GET /api/v1/projects/by-slug/:slug
 ```
 
 Same response shape as [Get Project by ID](#get-project-by-id).
@@ -1820,7 +1797,7 @@ Same response shape as [Get Project by ID](#get-project-by-id).
 ### List Project Conversations (Dashboard)
 
 ```
-GET /v1/projects/:id/conversations
+GET /api/v1/projects/:id/conversations
 ```
 
 Returns conversations for a specific project (for dashboard display).
@@ -1838,7 +1815,7 @@ Same shape as [List Conversations](#list-conversations) `data` array, wrapped in
 ### List Conversation Messages (Dashboard)
 
 ```
-GET /v1/projects/:id/conversations/:convId/messages
+GET /api/v1/projects/:id/conversations/:convId/messages
 ```
 
 Returns up to 500 messages for a conversation within a project. Returns an empty array if the conversation is not found (does not 404).
@@ -1863,7 +1840,7 @@ Returns up to 500 messages for a conversation within a project. Returns an empty
 ### Project Analytics
 
 ```
-GET /v1/projects/:id/analytics
+GET /api/v1/projects/:id/analytics
 ```
 
 Usage analytics for a project.
@@ -1908,7 +1885,7 @@ Usage analytics for a project.
 ### Delete Project
 
 ```
-DELETE /v1/projects/:id
+DELETE /api/v1/projects/:id
 ```
 
 Permanently deletes a project and all associated data, including:
@@ -2058,15 +2035,15 @@ Evidence kinds are `state_event`, `text_hash`, and `json_value`.
 Two sets of key management endpoints exist:
 
 1. **Authenticated** (`/api/projects/:projectId/keys`) -- requires a valid API key. The caller can only manage keys for the project their key belongs to.
-2. **Dashboard** (`/v1/projects/:id/keys`) -- used by the dashboard frontend. Authenticated via Clerk session, not API key.
+2. **Dashboard** (`/api/v1/projects/:id/keys`) -- used by the dashboard frontend. Authenticated via Clerk session, not API key.
 
 Both sets share the same request/response shapes.
 
 ### Create API Key
 
 ```
-POST /api/projects/:projectId/keys       # Authenticated
-POST /v1/projects/:id/keys               # Dashboard
+POST /api/projects/:projectId/keys   # Authenticated
+POST /api/v1/projects/:id/keys       # Dashboard
 ```
 
 Creates a new API key for the project.
@@ -2133,8 +2110,8 @@ The full key is never returned after creation. `scopes` is `null` for full-acces
 ### Revoke API Key
 
 ```
-DELETE /api/projects/:projectId/keys/:keyId    # Authenticated
-DELETE /v1/projects/:id/keys/:keyId            # Dashboard
+DELETE /api/projects/:projectId/keys/:keyId   # Authenticated
+DELETE /api/v1/projects/:id/keys/:keyId       # Dashboard
 ```
 
 Soft-deletes an API key by setting `revoked_at`. The key immediately becomes invalid for authentication.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -65,8 +65,8 @@ Omitting these degrades features gracefully — the Worker still starts and hand
 | Binding | Type | Description |
 |---------|------|-------------|
 | `AUTH_CACHE` | KV Namespace | Caches API key → project ID lookups to reduce D1 reads. 300 s TTL. Declared in `kv_namespaces`. |
-| `RATE_LIMITS` | KV Namespace | Stores per-key request counters for the sliding-window rate limiter. Without this binding, the Worker falls back to a fixed-window counter that resets on UTC minute boundaries. |
-| `VECTORIZE_INDEX` | Vectorize Index | Stores message embeddings for semantic search (`GET /api/v1/conversations/search`). Without this binding, semantic search routes return 503. |
+| `RATE_LIMITS` | KV Namespace | Stores per-key request counters for the sliding-window rate limiter (see `USE_SLIDING_WINDOW` below — both must be set for the sliding window to actually be used). Without this binding, the Worker falls back to a fixed-window counter that resets on UTC minute boundaries. |
+| `VECTORIZE_INDEX` | Vectorize Index | Declared in `wrangler.jsonc` but has no runtime consumers — the semantic-search code that used to read it (`services/embeddings.ts`) was removed in the 2026-06-20 v2→v1 cleanup. `GET /api/v1/conversations/search` is a plain SQL `LIKE` full-text search over message content; it does not use this binding. Binding it has no effect on any endpoint. |
 | `STATE_STREAM_HUB` | Durable Object | Coordinates SSE connections for live state-change streaming. Without this binding, `GET /api/v1/states/watch` returns 503. |
 
 ### Worker secrets
@@ -86,6 +86,7 @@ These contain no secrets and may live in `wrangler.jsonc` `vars`. The test confi
 |----------|---------|-------------|
 | `RATE_LIMIT_MAX` | `100` | Maximum API requests per minute per API key. Override in `wrangler.jsonc` `vars` to tune per environment. |
 | `PROJECT_CREATION_RATE_LIMIT_MAX` | `10` | Maximum project-creation requests per hour per IP. Override in `wrangler.jsonc` `vars`. |
+| `USE_SLIDING_WINDOW` | unset (falsy) | Set to `"true"` to use the KV-backed sliding-window rate limiter (requires the `RATE_LIMITS` binding above). Otherwise the Worker always uses the fixed UTC-minute window, even if `RATE_LIMITS` is bound. |
 
 ---
 

--- a/docs/v2-migration.md
+++ b/docs/v2-migration.md
@@ -19,7 +19,7 @@ At one point a parallel "API v2" was drafted to change some conventions (a `PATC
 
 ## Deprecation headers
 
-The codebase contains a `setDeprecationHeaders` utility (`packages/api/src/lib/deprecation.ts`) that can emit `X-API-Deprecation`, `Sunset`, and `Link` response headers. No routes currently call it — no deprecation or sunset headers are emitted in production responses.
+The codebase used to contain a `setDeprecationHeaders` utility (`packages/api/src/lib/deprecation.ts`) that could emit `X-API-Deprecation`, `Sunset`, and `Link` response headers. No routes ever called it, and the file itself was removed in the 2026-06-20 v2→v1 dead-code collapse (see `docs/knowledge/core-memory.md`). No deprecation or sunset headers are emitted in production responses.
 
 ## Additional resources
 


### PR DESCRIPTION
## Summary

Docs-only fixes for a batch of documentation-accuracy issues. Every case was docs describing behavior the code does not actually have; each claim was verified directly against `packages/api/src` before the doc was corrected.

The biggest cluster (`docs/api-reference.md`) traces back to one root cause: the "current"/"V2" sections described a convention set (`PATCH` update, `?include=messages` opt-in, `204` append response, `created_at` cursor) that was drafted at some point but **never actually shipped**. The real, shared handler — used by both `/api/v1/*` and the deprecated `/v1/*` alias — uses `PUT`, includes messages by default (`?fields=` / `?fields=!messages`), returns `201` with the created messages on append, and pages messages by ID. `docs/v2-migration.md` already had this right in one place; the rest of the doc didn't.

### What the truth turned out to be, per issue

- **#332 / #301** — Conversation update route is `PUT`, not `PATCH`. Confirmed: `packages/api/src/routes/conversations/crud.ts:167` only registers `.put`.
- **#333** — Projects API docs used `/v1/projects/*`, which is **never mounted** (only `/api/v1/projects/*` is — confirmed in `packages/api/src/index.ts`). This is the one place where the automated audit flagged a possible code bug; see below.
- **#334** — Create-conversation response docs said messages are excluded; `crud.ts`'s `POST /` always returns the created `messages` array.
- **#335** — Append messages docs said `204 No Content`; the route returns `201 Created` with `{ messages: [...] }` (`routes/conversations/messages.ts`).
- **#336** — List-messages cursor docs said `created_at` timestamp; the `after` param is looked up by message ID and `next_cursor` is a message ID.
- **#337** — This one was backwards: `fields`/`!messages` **are** implemented (`services/conversations.ts` `parseFieldsParam`); it's the separate `?include=messages` documented in the main "current" section that's fictional. Fixed by making the main section describe `fields` and removing the `include` claim.
- **#338** — Auth section implied only conversations/tags need a key; in reality nearly every route needs either a scoped API key (states, leases, claims, capability tokens, messages, search, analytics, AI features, webhooks, API keys) or a Clerk session (projects, organizations, domains, dashboard analytics/traces).
- **#300** — Confirmed via `crud.ts:119-153` and `conversations.test.ts:293-310`: messages are included by default; `fields`/`!messages` is the real mechanism, not `include`.
- **#302** — `USE_SLIDING_WINDOW` (`middleware/rate-limit.ts:199-200`) gates the KV-backed sliding-window limiter but was undocumented; added alongside its `RATE_LIMITS` binding neighbor.
- **#303** — `AGENTS.md` said port 3000 (Next.js-era leftover); Astro's actual default is 4321, matching `CLAUDE.md`/`README.md`. `diff AGENTS.md CLAUDE.md` now clean.
- **#304** — `PLAN.md`'s Completed list still said "Next.js"; dashboard is Astro (confirmed via `packages/dashboard/package.json` and `astro.config.mjs`).
- **#305** — `docs/v2-migration.md` described `lib/deprecation.ts` in the present tense; confirmed the file no longer exists (removed in the 2026-06-20 cleanup per `docs/knowledge/core-memory.md`). Switched to past tense.
- **#306** — README's "276 tests" was stale. Ran `cd packages/api && bunx vitest run`: **353 tests pass**. Updated README and the same stale figure in ROADMAP.md.
- **#286** — MCP server (`packages/mcp`, `/api/mcp`, OAuth 2.1, `docs/mcp.md`) is fully shipped but ROADMAP.md listed it under "Next — Near-Term" and README never mentioned it. Moved to "Now — Shipped" and added a README feature-list line.
- **#288** — `VECTORIZE_INDEX` doc promised semantic search with a 503 fallback; confirmed `services/embeddings.ts` was already deleted and the binding has zero runtime consumers (`grep -rn "vectorize" packages/api/src` → only a dead type declaration). `GET /api/v1/conversations/search` is plain SQL `LIKE`, unrelated to this binding. Rewrote the doc row to say so honestly instead of describing a fallback that doesn't exist.

### Where the code may be the actual bug (flagged, not fixed here)

**#333**: `/v1/projects/*`, `/v1/projects/:id/keys`, etc. are documented but never mounted in `packages/api/src/index.ts` — only `/api/v1/*` versions exist. Given `/v1/conversations`, `/v1` (tags), and `/v1/analytics` **do** have backward-compat mounts but `/v1/projects` and `/v1/organizations` don't, this looks like an intentional omission (those routes are dashboard-internal, Clerk-authed, same-origin calls — no external caller would need a `/v1` alias). This PR treats it as a docs bug and corrects every path to `/api/v1/projects/*`, per this stream's docs-only scope. If the omission was actually unintentional, that's a separate follow-up for someone to file/fix in code.

### Verification

- `bunx biome check packages/api/src/` — same single pre-existing error as on `main` (unrelated `packages/api/src/lib/validation.ts` formatting nit); confirmed no source files were touched by this branch (`git diff main --stat` shows only doc/markdown files).
- `cd packages/api && bunx vitest run` — 353/353 passing (used to source the corrected test count).

## Test plan

- [x] `git diff main --stat` shows only `AGENTS.md`, `PLAN.md`, `README.md`, `ROADMAP.md`, `docs/api-reference.md`, `docs/environment-variables.md`, `docs/v2-migration.md`
- [x] `bunx biome check packages/api/src/` unchanged vs `main`
- [x] `cd packages/api && bunx vitest run` — 353 passed

Closes #300, #301, #302, #303, #304, #305, #306, #286, #288, #332, #333, #334, #335, #336, #337, #338

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>