### PR TITLE
fix(api): traces pagination, trace scoping, and claim:read scope

### DIFF
--- a/packages/api/src/lib/scopes.ts
+++ b/packages/api/src/lib/scopes.ts
@@ -20,6 +20,7 @@ export const API_SCOPES = [
   "state:write",
   "state:watch",
   "lease:write",
+  "claim:read",
   "claim:write",
   "analytics:read",
   "webhooks:write",

--- a/packages/api/src/lib/validation.ts
+++ b/packages/api/src/lib/validation.ts
@@ -165,13 +165,10 @@ export const WebhookEventSchema = z.enum(WEBHOOK_EVENT_TYPES);
  * A webhook URL must be https and must not point at a loopback / private /
  * link-local / metadata host (SSRF guard). See lib/url-safety.ts.
  */
-const WebhookUrlSchema = z
-  .string()
-  .url("Invalid webhook URL")
-  .refine(isSafeWebhookUrl, {
-    message:
-      "Webhook URL must be https and must not target a private, loopback, link-local, or metadata host",
-  });
+const WebhookUrlSchema = z.string().url("Invalid webhook URL").refine(isSafeWebhookUrl, {
+  message:
+    "Webhook URL must be https and must not target a private, loopback, link-local, or metadata host",
+});
 
 export const CreateWebhookSchema = z.object({
   url: WebhookUrlSchema,
@@ -241,6 +238,7 @@ export const CAPABILITY_SCOPES = [
   "state:write",
   "state:watch",
   "lease:write",
+  "claim:read",
   "claim:write",
 ] as const;
 export const CapabilityScopeSchema = z.enum(CAPABILITY_SCOPES);

--- a/packages/api/src/routes/claims/index.ts
+++ b/packages/api/src/routes/claims/index.ts
@@ -84,10 +84,12 @@ const CreateClaimSchema = z.object({
 
 const router = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
-router.use("*", scopedAuth({ scope: "claim:write" }));
-router.use("*", rateLimitMiddleware);
+// claim:read and claim:write are independent scopes (claim:write does not
+// imply claim:read, mirroring conversations:write/state:write not implying
+// their :read counterparts) — each route requires exactly what it needs.
+// rateLimitMiddleware runs after scopedAuth so apiKeyHash is populated.
 
-router.post("/", async (c) => {
+router.post("/", scopedAuth({ scope: "claim:write" }), rateLimitMiddleware, async (c) => {
   const { data, error } = await parseAndValidateBody(c, CreateClaimSchema);
   if (error) return error;
   if (!data) return errorResponse(c, "BAD_REQUEST", "Invalid request body", 400);
@@ -103,7 +105,7 @@ router.post("/", async (c) => {
   return c.json(claim, 201);
 });
 
-router.get("/", async (c) => {
+router.get("/", scopedAuth({ scope: "claim:read" }), rateLimitMiddleware, async (c) => {
   const result = await listClaims(c.get("db"), c.get("projectId"), {
     limit: parseLimitParam(c.req.query("limit"), 50, 100),
     cursor: c.req.query("cursor"),
@@ -125,14 +127,14 @@ router.get("/", async (c) => {
   });
 });
 
-router.post("/:id/verify", async (c) => {
+router.post("/:id/verify", scopedAuth({ scope: "claim:write" }), rateLimitMiddleware, async (c) => {
   const run = await verifyClaim(c.get("db"), c.get("projectId"), c.req.param("id"));
   if (!run) return errorResponse(c, "NOT_FOUND", "Claim not found", 404);
 
   return c.json(run, 201);
 });
 
-router.get("/:id", async (c) => {
+router.get("/:id", scopedAuth({ scope: "claim:read" }), rateLimitMiddleware, async (c) => {
   const claim = await getClaim(c.get("db"), c.get("projectId"), c.req.param("id"));
   if (!claim) return errorResponse(c, "NOT_FOUND", "Claim not found", 404);
 

--- a/packages/api/src/routes/conversations/traces.ts
+++ b/packages/api/src/routes/conversations/traces.ts
@@ -82,7 +82,8 @@ router.get("/traces/:id", requireScope("conversations:read"), async (c) => {
   if (!existing) return notFound(c, "Trace not found");
 
   const db = c.get("db");
-  const result = await tracesService.getTraceTree(db, id);
+  const projectId = c.get("projectId");
+  const result = await tracesService.getTraceTree(db, projectId, id);
 
   if (!result) return notFound(c, "Trace not found");
 

--- a/packages/api/src/routes/conversations/traces.ts
+++ b/packages/api/src/routes/conversations/traces.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import {
+  errorResponse,
   loadConversation,
   notFound,
   parseJsonBody,
@@ -60,7 +61,15 @@ router.get("/traces", requireScope("conversations:read"), async (c) => {
     order,
   });
 
-  return c.json(result);
+  if (result.error) {
+    return errorResponse(c, result.error.code, result.error.message, result.error.status);
+  }
+
+  return c.json({
+    data: result.data,
+    has_more: result.has_more,
+    next_cursor: result.next_cursor,
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/routes/project-traces.ts
+++ b/packages/api/src/routes/project-traces.ts
@@ -46,7 +46,15 @@ app.get("/:id/traces", async (c) => {
     order,
   });
 
-  return c.json(result);
+  if (result.error) {
+    return errorResponse(c, result.error.code, result.error.message, result.error.status);
+  }
+
+  return c.json({
+    data: result.data,
+    has_more: result.has_more,
+    next_cursor: result.next_cursor,
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/routes/project-traces.ts
+++ b/packages/api/src/routes/project-traces.ts
@@ -93,7 +93,7 @@ app.get("/:id/traces/:traceId", async (c) => {
     return errorResponse(c, "NOT_FOUND", "Trace not found", 404);
   }
 
-  const result = await tracesService.getTraceTree(db, traceId);
+  const result = await tracesService.getTraceTree(db, projectId, traceId);
   if (!result) {
     return errorResponse(c, "NOT_FOUND", "Trace not found", 404);
   }

--- a/packages/api/src/services/traces.ts
+++ b/packages/api/src/services/traces.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, lt, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, lt, or, sql } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { conversations, messages } from "../db/schema";
 import { generateId } from "../lib/id";
@@ -132,13 +132,19 @@ export async function ingestTrace(
 
 /**
  * List traces (conversations that contain at least one observation).
- * Uses cursor-based pagination on updated_at.
+ * Uses cursor-based pagination on (updated_at, id), mirroring
+ * listConversations in services/conversations.ts.
  */
 export async function listTraces(
   db: DrizzleD1Database,
   projectId: string,
   opts: ListTracesOptions,
-) {
+): Promise<{
+  data: ReturnType<typeof deserializeConversationFull>[];
+  has_more: boolean;
+  next_cursor: string | null;
+  error?: { code: string; message: string; status: 400 };
+}> {
   const { limit, cursor, order } = opts;
 
   // Build base conditions: project-scoped + has observations
@@ -147,29 +153,73 @@ export async function listTraces(
     sql`${conversations.id} IN (SELECT DISTINCT ${messages.conversationId} FROM ${messages} WHERE ${messages.observationType} IS NOT NULL)`,
   ];
 
-  if (cursor) {
-    const cursorTs = parseInt(cursor, 10);
-    if (!Number.isNaN(cursorTs)) {
-      conditions.push(
-        order === "desc"
-          ? lt(conversations.updatedAt, cursorTs)
-          : gt(conversations.updatedAt, cursorTs),
-      );
+  // Cursor format: "<updatedAt>.<id>" (composite, tie-break by id) or legacy
+  // bare "<updatedAt>". Ties on updatedAt are common — batch-ingested traces
+  // (one POST /traces/ingest burst) share one timestamp — so ordering and
+  // cursoring on (updatedAt, id) keeps tie groups intact across pages
+  // instead of dropping the rows after the page boundary.
+  if (cursor !== undefined) {
+    const dot = cursor.lastIndexOf(".");
+    const tsStr = dot === -1 ? cursor : cursor.slice(0, dot);
+    const idStr = dot === -1 ? undefined : cursor.slice(dot + 1);
+    const cursorNum = Number(tsStr);
+    if (
+      Number.isNaN(cursorNum) ||
+      !Number.isFinite(cursorNum) ||
+      cursorNum < 0 ||
+      cursorNum > Number.MAX_SAFE_INTEGER ||
+      (dot !== -1 && !idStr)
+    ) {
+      return {
+        data: [],
+        has_more: false,
+        next_cursor: null,
+        error: {
+          code: "INVALID_CURSOR",
+          message: "Cursor must be a valid positive number (Unix timestamp in milliseconds)",
+          status: 400 as const,
+        },
+      };
     }
+
+    const cursorCond =
+      idStr !== undefined
+        ? order === "desc"
+          ? or(
+              lt(conversations.updatedAt, cursorNum),
+              and(eq(conversations.updatedAt, cursorNum), lt(conversations.id, idStr)),
+            )
+          : or(
+              gt(conversations.updatedAt, cursorNum),
+              and(eq(conversations.updatedAt, cursorNum), gt(conversations.id, idStr)),
+            )
+        : order === "desc"
+          ? lt(conversations.updatedAt, cursorNum)
+          : gt(conversations.updatedAt, cursorNum);
+    if (cursorCond) conditions.push(cursorCond);
   }
 
+  const ordering =
+    order === "desc"
+      ? [desc(conversations.updatedAt), desc(conversations.id)]
+      : [asc(conversations.updatedAt), asc(conversations.id)];
+
+  // Fetch one extra row to detect a next page; this avoids emitting a
+  // trailing empty page when the final page is exactly full.
   const rows = await db
     .select()
     .from(conversations)
     .where(and(...conditions))
-    .orderBy(order === "desc" ? desc(conversations.updatedAt) : asc(conversations.updatedAt))
-    .limit(limit);
+    .orderBy(...ordering)
+    .limit(limit + 1);
 
-  const hasMore = rows.length === limit;
-  const nextCursor = hasMore ? String(rows[rows.length - 1].updatedAt) : null;
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+  const last = page[page.length - 1];
+  const nextCursor = hasMore && last ? `${last.updatedAt}.${last.id}` : null;
 
   return {
-    data: rows.map(deserializeConversationFull),
+    data: page.map(deserializeConversationFull),
     has_more: hasMore,
     next_cursor: nextCursor,
   };

--- a/packages/api/src/services/traces.ts
+++ b/packages/api/src/services/traces.ts
@@ -231,12 +231,19 @@ export async function listTraces(
 
 /**
  * Get a single trace with its observations arranged as a tree.
+ * Project-scoped: matches the pattern of every other single-resource loader
+ * (loadConversation, getClaim, getLatestState) so scoping doesn't depend on
+ * callers remembering to pre-check ownership themselves.
  */
-export async function getTraceTree(db: DrizzleD1Database, conversationId: string) {
+export async function getTraceTree(
+  db: DrizzleD1Database,
+  projectId: string,
+  conversationId: string,
+) {
   const [conversation] = await db
     .select()
     .from(conversations)
-    .where(eq(conversations.id, conversationId))
+    .where(and(eq(conversations.id, conversationId), eq(conversations.projectId, projectId)))
     .limit(1);
 
   if (!conversation) return null;

--- a/packages/api/test/scopes.test.ts
+++ b/packages/api/test/scopes.test.ts
@@ -195,4 +195,125 @@ describe("API key scope enforcement", () => {
     expect(res.status).not.toBe(403);
     expect([200, 201]).toContain(res.status);
   });
+
+  describe("/api/v1/claims — claim:read / claim:write separation (#348)", () => {
+    async function createClaimWithFullAccessKey(): Promise<string> {
+      const transcript = `claim-scope-test-${Date.now()}`;
+      const encoded = new TextEncoder().encode(transcript);
+      const digest = await crypto.subtle.digest("SHA-256", encoded);
+      const hash = Array.from(new Uint8Array(digest))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+
+      const res = await SELF.fetch("http://localhost/api/v1/claims", {
+        method: "POST",
+        headers: authHeaders(), // full-access seeded key
+        body: JSON.stringify({
+          subject_type: "conversation",
+          subject_id: "claim-scope-subject",
+          statement: "Scope test claim",
+          evidence: [{ kind: "text_hash", source: "transcript:1", data: transcript, hash }],
+        }),
+      });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as { id: string };
+      return body.id;
+    }
+
+    it("a key scoped only to claim:read can list and get claims", async () => {
+      const claimId = await createClaimWithFullAccessKey();
+      const readOnly = await createKey(["claim:read"]);
+
+      const listRes = await SELF.fetch("http://localhost/api/v1/claims", {
+        headers: bearer(readOnly),
+      });
+      expect(listRes.status).toBe(200);
+
+      const getRes = await SELF.fetch(`http://localhost/api/v1/claims/${claimId}`, {
+        headers: bearer(readOnly),
+      });
+      expect(getRes.status).toBe(200);
+    });
+
+    it("a key scoped only to claim:read cannot create or verify claims", async () => {
+      const claimId = await createClaimWithFullAccessKey();
+      const readOnly = await createKey(["claim:read"]);
+
+      const createRes = await SELF.fetch("http://localhost/api/v1/claims", {
+        method: "POST",
+        headers: bearer(readOnly),
+        body: JSON.stringify({
+          subject_type: "conversation",
+          subject_id: "should-fail",
+          statement: "Should fail",
+          evidence: [{ kind: "text_hash", source: "s", data: "d", hash: "0".repeat(64) }],
+        }),
+      });
+      expect(createRes.status).toBe(403);
+
+      const verifyRes = await SELF.fetch(`http://localhost/api/v1/claims/${claimId}/verify`, {
+        method: "POST",
+        headers: bearer(readOnly),
+      });
+      expect(verifyRes.status).toBe(403);
+    });
+
+    it("a key scoped only to claim:write can still create and verify claims", async () => {
+      // Regression guard: introducing claim:read must not regress the
+      // existing claim:write-only workflow (create + verify).
+      const writeOnly = await createKey(["claim:write"]);
+      const transcript = "write-only-claim-workflow";
+      const encoded = new TextEncoder().encode(transcript);
+      const digest = await crypto.subtle.digest("SHA-256", encoded);
+      const hash = Array.from(new Uint8Array(digest))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+
+      const createRes = await SELF.fetch("http://localhost/api/v1/claims", {
+        method: "POST",
+        headers: bearer(writeOnly),
+        body: JSON.stringify({
+          subject_type: "conversation",
+          subject_id: "write-only-subject",
+          statement: "Write-only workflow still works",
+          evidence: [{ kind: "text_hash", source: "transcript:1", data: transcript, hash }],
+        }),
+      });
+      expect(createRes.status).toBe(201);
+      const created = (await createRes.json()) as { id: string };
+
+      const verifyRes = await SELF.fetch(`http://localhost/api/v1/claims/${created.id}/verify`, {
+        method: "POST",
+        headers: bearer(writeOnly),
+      });
+      expect(verifyRes.status).toBe(201);
+    });
+
+    it("claim:write does NOT imply claim:read (explicit design decision)", async () => {
+      // Decision: claim:write and claim:read are independent, mirroring how
+      // conversations:write/state:write do not imply their :read counterparts
+      // elsewhere in this scope set. A caller needing both must request both
+      // scopes (or claim:*) explicitly.
+      const claimId = await createClaimWithFullAccessKey();
+      const writeOnly = await createKey(["claim:write"]);
+
+      const listRes = await SELF.fetch("http://localhost/api/v1/claims", {
+        headers: bearer(writeOnly),
+      });
+      expect(listRes.status).toBe(403);
+
+      const getRes = await SELF.fetch(`http://localhost/api/v1/claims/${claimId}`, {
+        headers: bearer(writeOnly),
+      });
+      expect(getRes.status).toBe(403);
+    });
+
+    it("a key without any claim scope cannot access claim routes", async () => {
+      const noScope = await createKey(["conversations:read"]);
+      const res = await SELF.fetch("http://localhost/api/v1/claims", {
+        headers: bearer(noScope),
+      });
+      expect(res.status).toBe(403);
+    });
+  });
 });

--- a/packages/api/test/traces.test.ts
+++ b/packages/api/test/traces.test.ts
@@ -374,6 +374,106 @@ describe("Traces", () => {
       }
     });
 
+    it("does not report has_more when the final page is exactly full", async () => {
+      // Regression for #341 bug 1: the old implementation fetched exactly
+      // `limit` rows and set has_more = rows.length === limit, so a final
+      // page that happens to be exactly full is misreported as having more
+      // data (and the client fetches a bogus empty extra page).
+      const eid = `false-has-more-${Date.now()}`;
+      for (let i = 0; i < 2; i++) {
+        const res = await ingestTrace(
+          validIngestBody({
+            trace: { title: `False has_more ${eid} ${i}`, external_id: `${eid}-${i}` },
+            observations: [{ content: `Obs ${i}`, observation_type: "span" }],
+          }),
+        );
+        expect(res.status).toBe(201);
+      }
+
+      // Discover the exact current total, then request precisely that many.
+      // A limit equal to the true total must yield has_more === false — the
+      // buggy code sets has_more = rows.length === limit, which is always
+      // true whenever the fetch happens to land exactly on the total count.
+      const allRes = await SELF.fetch(`${BASE}/traces?limit=100`, {
+        headers: authHeaders(),
+      });
+      expect(allRes.status).toBe(200);
+      const all = await allRes.json<ListTracesResponse>();
+      const total = all.data.length;
+      // This test only holds if every trace in the project fits on one
+      // max-size page; if a prior test in this file ever grows the fixture
+      // past 100 traces, raise the limit and split the fetch into two pages.
+      expect(total).toBeGreaterThan(0);
+      expect(all.has_more).toBe(false);
+
+      const res = await SELF.fetch(`${BASE}/traces?limit=${total}`, {
+        headers: authHeaders(),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json<ListTracesResponse>();
+      expect(body.data.length).toBe(total);
+      expect(body.has_more).toBe(false);
+      expect(body.next_cursor).toBeNull();
+    });
+
+    it("does not drop traces sharing an updated_at value at a page boundary", async () => {
+      // Regression for #341 bug 2: cursoring on bare updated_at with no
+      // tie-break drops rows that share a timestamp with the cursor row when
+      // they fall on the far side of a page boundary. Batch-ingested traces
+      // (e.g. from one POST /traces/ingest burst) commonly share one `now`.
+      const tag = `boundary-${Date.now()}`;
+      const ids: string[] = [];
+      for (let i = 0; i < 3; i++) {
+        const res = await ingestTrace(
+          validIngestBody({
+            trace: { title: `Boundary ${tag} ${i}`, external_id: `${tag}-${i}` },
+            observations: [{ content: `Obs ${i}`, observation_type: "span" }],
+          }),
+        );
+        expect(res.status).toBe(201);
+        const created = await res.json<IngestResponse>();
+        ids.push(created.conversation.id);
+      }
+
+      // Force all 3 traces to share the exact same updated_at, simulating a
+      // single batch-ingested burst.
+      const sharedTs = Date.now();
+      for (const id of ids) {
+        await env.DB.prepare(`UPDATE conversations SET updated_at = ? WHERE id = ?`)
+          .bind(sharedTs, id)
+          .run();
+      }
+
+      // Walk the full list with a page size smaller than the tie group and
+      // confirm every one of the 3 same-timestamp traces is returned exactly
+      // once, with no bogus trailing empty page.
+      const seen: string[] = [];
+      let cursor: string | null = null;
+      let pages = 0;
+      while (true) {
+        pages += 1;
+        if (pages > 20) throw new Error("pagination did not terminate");
+        const url = `${BASE}/traces?limit=2&order=desc${cursor ? `&cursor=${cursor}` : ""}`;
+        const pageRes = await SELF.fetch(url, { headers: authHeaders() });
+        expect(pageRes.status).toBe(200);
+        const page = await pageRes.json<ListTracesResponse>();
+        expect(page.data.length).toBeGreaterThan(0);
+        for (const trace of page.data) {
+          if (ids.includes(trace.id)) seen.push(trace.id);
+        }
+        cursor = page.next_cursor;
+        if (!cursor) {
+          expect(page.has_more).toBe(false);
+          break;
+        }
+      }
+
+      expect(new Set(seen).size).toBe(3);
+      for (const id of ids) {
+        expect(seen).toContain(id);
+      }
+    });
+
     it("returns empty list for conversations without observations", async () => {
       // Create a regular conversation (no observations)
       await SELF.fetch(BASE, {

--- a/packages/api/test/traces.test.ts
+++ b/packages/api/test/traces.test.ts
@@ -1,5 +1,7 @@
 import { env, SELF } from "cloudflare:test";
+import { drizzle } from "drizzle-orm/d1";
 import { beforeAll, describe, expect, it } from "vitest";
+import * as tracesService from "../src/services/traces";
 import { applyMigrations, authHeaders, seedProject, TEST_PROJECT_ID } from "./setup";
 
 // ---------------------------------------------------------------------------
@@ -633,6 +635,32 @@ describe("Traces", () => {
     it("returns 401 without auth", async () => {
       const res = await SELF.fetch(`${BASE}/traces/any_id`);
       expect(res.status).toBe(401);
+    });
+
+    it("getTraceTree itself enforces project scoping (#347 defense-in-depth)", async () => {
+      // Regression: getTraceTree must reject cross-project reads on its own,
+      // not merely rely on route-level pre-checks (loadConversation /
+      // conv.projectId === projectId), so a future caller that forgets the
+      // guard cannot leak another project's trace.
+      const ingestRes = await ingestTrace(validIngestBody({ trace: { title: "Scoped trace" } }));
+      expect(ingestRes.status).toBe(201);
+      const ingested = await ingestRes.json<IngestResponse>();
+
+      const db = drizzle(env.DB);
+      const wrongProjectResult = await tracesService.getTraceTree(
+        db,
+        "some_other_project_id",
+        ingested.conversation.id,
+      );
+      expect(wrongProjectResult).toBeNull();
+
+      const correctResult = await tracesService.getTraceTree(
+        db,
+        TEST_PROJECT_ID,
+        ingested.conversation.id,
+      );
+      expect(correctResult).not.toBeNull();
+      expect(correctResult?.id).toBe(ingested.conversation.id);
     });
   });
 });


### PR DESCRIPTION
## Summary

Three API correctness fixes, one commit each:

**#341 — listTraces pagination could report false `has_more` and drop traces at a page boundary**
`listTraces` fetched exactly `limit` rows and set `has_more = rows.length === limit`, so an exactly-full final page was misreported as having more data. It also cursored on a bare `updated_at` with no tie-break, so traces sharing an `updated_at` (e.g. one batch ingested via `POST /traces/ingest`) could be dropped across a page boundary. Fixed by fetching `limit + 1` rows and switching to the composite `(updated_at, id)` cursor already used by `listConversations`.

**#347 — getTraceTree performed no project scoping (defense-in-depth gap)**
`getTraceTree` looked up the conversation by `id` alone. It was safe today only because both call sites pre-check ownership before calling it, which is a gap waiting for a third caller that forgets the guard. Added `projectId` to the function signature and its `WHERE` clause, matching every other single-resource loader (`loadConversation`, `getClaim`, `getLatestState`).

**#348 — Claim read operations required the `claim:write` scope (no `claim:read`)**
The claims router applied `scopedAuth({ scope: "claim:write" })` to every route including the read-only `GET /` and `GET /:id`, so a read-only auditor token had to be granted write access. Added a `claim:read` scope (to both `API_SCOPES` and `CAPABILITY_SCOPES`) and required it on the two GET routes, keeping `claim:write` on `POST /` and `POST /:id/verify`.

**Design decision (per review instructions):** `claim:write` does **not** imply `claim:read`. This mirrors every other scope pair already in the set — `conversations:write`/`state:write` do not imply their `:read` counterparts — so a caller needing both must request both scopes (or `claim:*`/`*`). A key holding only `claim:write` continues to work unchanged for create + verify (covered by a regression test).

## Test plan

- [x] Added regression tests that reproduce each bug and fail before the corresponding fix (verified by running them pre-fix)
- [x] `bunx biome check packages/api/src/` — clean (one pre-existing, unrelated formatting finding in `validation.ts` predates this branch and is untouched by these commits)
- [x] `bunx tsc --noEmit -p packages/api/tsconfig.json` — clean
- [x] `cd packages/api && bunx vitest run` — 370/370 passed
- [x] Rebased onto latest `main` (no conflicts with the concurrent rate-limit middleware work on `routes/claims`)

Closes #341
Closes #347
Closes #348

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>