### PR TITLE
fix(api): guard lease renew/release updates with state predicates

### DIFF
--- a/packages/api/src/services/leases.ts
+++ b/packages/api/src/services/leases.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNull, lte } from "drizzle-orm";
+import { and, desc, eq, gt, isNull, lte } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { stateLeases } from "../db/schema";
 import { LEASE_DEFAULT_TTL_MS } from "../lib/config";
@@ -102,6 +102,30 @@ export async function createLease(
   return { lease: toResponse(row) };
 }
 
+/**
+ * Re-select a lease after a guarded UPDATE affected 0 rows, and map its
+ * current state to the same error codes the pre-select branches already use.
+ * The row can only have changed because it was released or expired between
+ * the pre-select and the guarded UPDATE — never because it vanished (leases
+ * are never hard-deleted).
+ */
+async function reselectLeaseError(
+  db: DrizzleD1Database,
+  projectId: string,
+  leaseId: string,
+): Promise<{ error: LeaseError }> {
+  const [lease] = await db
+    .select()
+    .from(stateLeases)
+    .where(and(eq(stateLeases.id, leaseId), eq(stateLeases.projectId, projectId)))
+    .limit(1);
+
+  if (!lease || lease.releasedAt !== null) {
+    return { error: { code: "NOT_FOUND", message: "Lease not found", status: 404 } };
+  }
+  return { error: { code: "LEASE_EXPIRED", message: "Lease has expired", status: 409 } };
+}
+
 export async function renewLease(
   db: DrizzleD1Database,
   projectId: string,
@@ -124,7 +148,25 @@ export async function renewLease(
   }
 
   const updates = { expiresAt: now + ttlMs, renewedAt: now };
-  await db.update(stateLeases).set(updates).where(eq(stateLeases.id, leaseId));
+  // Guard against a concurrent release/expiry between the select above and
+  // this write: only apply the renewal if the lease is still live.
+  const rows = await db
+    .update(stateLeases)
+    .set(updates)
+    .where(
+      and(
+        eq(stateLeases.id, leaseId),
+        eq(stateLeases.projectId, projectId),
+        isNull(stateLeases.releasedAt),
+        gt(stateLeases.expiresAt, now),
+      ),
+    )
+    .returning({ id: stateLeases.id });
+
+  if (rows.length === 0) {
+    return reselectLeaseError(db, projectId, leaseId);
+  }
+
   return { lease: toResponse({ ...lease, ...updates }) };
 }
 
@@ -144,6 +186,23 @@ export async function releaseLease(
     return { code: "NOT_FOUND", message: "Lease not found", status: 404 };
   }
 
-  await db.update(stateLeases).set({ releasedAt: now }).where(eq(stateLeases.id, leaseId));
+  // Guard against a concurrent release racing this one: only the caller that
+  // actually transitions released_at from NULL wins.
+  const rows = await db
+    .update(stateLeases)
+    .set({ releasedAt: now })
+    .where(
+      and(
+        eq(stateLeases.id, leaseId),
+        eq(stateLeases.projectId, projectId),
+        isNull(stateLeases.releasedAt),
+      ),
+    )
+    .returning({ id: stateLeases.id });
+
+  if (rows.length === 0) {
+    return { code: "NOT_FOUND", message: "Lease not found", status: 404 };
+  }
+
   return null;
 }

--- a/packages/api/test/v2-leases-contention.test.ts
+++ b/packages/api/test/v2-leases-contention.test.ts
@@ -251,6 +251,96 @@ describe("Lease acquisition", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Lease: renew/release race guards
+// ---------------------------------------------------------------------------
+
+describe("Lease renew/release race guards", () => {
+  it("returns 404 on renew after release, and does not extend expires_at on the released row", async () => {
+    // WHY: renewLease used to UPDATE unconditionally after a check-then-act read,
+    // so a renew racing (or following) a release could stamp a fresh future
+    // expires_at onto an already-released lease — a misleading success for a
+    // coordination primitive. The guarded UPDATE (released_at IS NULL) must make
+    // this a clean 404 and leave the row untouched.
+    const token = await mintCapabilityToken(["lease:write"], "renew-after-release");
+
+    const acquired = await acquireLease("state:renew-after-release", token.token, {
+      holder: "worker-1",
+    });
+    expect(acquired.status).toBe(201);
+    const lease = await acquired.json<LeaseResponse>();
+
+    const released = await releaseLease(lease.id, token.token);
+    expect(released.status).toBe(204);
+
+    const renew = await SELF.fetch(`http://localhost/api/v1/leases/${lease.id}/renew`, {
+      method: "POST",
+      headers: capTokenHeaders(token.token),
+      body: JSON.stringify({ ttl_ms: 120_000 }),
+    });
+    expect(renew.status).toBe(404);
+    const renewBody = await renew.json<{ error: { code: string } }>();
+    expect(renewBody.error.code).toBe("NOT_FOUND");
+
+    const { env } = await import("cloudflare:test");
+    const row = await env.DB.prepare(
+      "SELECT released_at, expires_at FROM state_leases WHERE id = ?",
+    )
+      .bind(lease.id)
+      .first<{ released_at: number | null; expires_at: number }>();
+    expect(row?.released_at).toBeTypeOf("number");
+    expect(row?.expires_at).toBe(lease.expires_at);
+  });
+
+  it("never reports a renew success without actually applying it under concurrent release contention", async () => {
+    // WHY: fires release and renew concurrently against the same lease. Whichever
+    // guarded UPDATE lands first legitimately wins — if renew's write lands before
+    // release's, a 200 response with an extended expires_at is correct (the lease
+    // was still active at that instant); if release's write lands first, the guard
+    // must make renew's write a no-op. The bug this guards against is the OLD
+    // behavior: an unconditional UPDATE that would silently re-extend expires_at
+    // even after release had already landed. So the invariant that must hold
+    // regardless of which order actually occurred is that the response accurately
+    // reflects the write: a 200 implies expires_at was actually extended, and a
+    // non-200 implies expires_at was left untouched (the guard blocked the write
+    // rather than silently applying it and reporting failure anyway).
+    const token = await mintCapabilityToken(["lease:write"], "renew-release-race");
+
+    const acquired = await acquireLease("state:renew-release-race", token.token, {
+      holder: "worker-1",
+    });
+    expect(acquired.status).toBe(201);
+    const lease = await acquired.json<LeaseResponse>();
+
+    const [renewRes, releaseRes] = await Promise.all([
+      SELF.fetch(`http://localhost/api/v1/leases/${lease.id}/renew`, {
+        method: "POST",
+        headers: capTokenHeaders(token.token),
+        body: JSON.stringify({ ttl_ms: 120_000 }),
+      }),
+      releaseLease(lease.id, token.token),
+    ]);
+
+    expect([200, 404, 409]).toContain(renewRes.status);
+    // Nothing else races releasedAt for this lease, so release itself always wins.
+    expect(releaseRes.status).toBe(204);
+
+    const { env } = await import("cloudflare:test");
+    const row = await env.DB.prepare(
+      "SELECT released_at, expires_at FROM state_leases WHERE id = ?",
+    )
+      .bind(lease.id)
+      .first<{ released_at: number | null; expires_at: number }>();
+
+    expect(row?.released_at).toBeTypeOf("number");
+    if (renewRes.status === 200) {
+      expect(row?.expires_at).toBeGreaterThan(lease.expires_at);
+    } else {
+      expect(row?.expires_at).toBe(lease.expires_at);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Claims: json_value verification (isolated cases)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #367

## Summary

Implements plan 007 (`plans/007-lease-update-guards.md`).

`renewLease` and `releaseLease` did check-then-act: SELECT the lease,
branch on `releasedAt`/`expiresAt` in JS, then `UPDATE ... WHERE id = ?`
with no state guard in the `WHERE`. Between select and update, a
concurrent release or expiry-driven re-acquire could change the row —
`renewLease` would then stamp a fresh `expiresAt` onto an
already-released lease and return a misleading success for a
coordination primitive.

- Both `UPDATE`s now carry `releasedAt IS NULL` (+ `expiresAt > now` for
  renew) guards and use `.returning()` to detect a lost race.
- On a 0-row update, re-select once and map to the existing
  `NOT_FOUND` / `LEASE_EXPIRED` codes — client-visible semantics are
  unchanged; only the internal write is now correct under concurrency.
- Acquire's mutual-exclusion guarantee (the partial unique index) was
  already race-safe — this is a correctness-of-response fix, not a
  lock-safety hole.

**Plan 006 (idempotency claim-first, #365) is NOT included** — it was
already fixed on `main` by PR #355 (commit `aaf05ac`, closing #289/#290)
with a stronger design (idempotency claim embedded atomically in the
same D1 batch as the mutation, plus a 60s orphan-reservation reclaim).
This branch is rebased onto current `main` (includes #355 and #282), so
it does not duplicate or conflict with that fix. `services/leases.ts`'s
`renewLease`/`releaseLease` — this PR's target — were untouched by #355
(#355's lease fix guards a different function, the write-time lease gate
inside `upsertState`/`deleteState`), so no overlap there.

## Test plan

- [x] `bunx tsc --noEmit -p packages/api/tsconfig.json` — exit 0
- [x] `bunx biome check packages/api/src/` — clean except one
      pre-existing, unrelated formatting issue in `lib/validation.ts`
      that predates this branch (confirmed present on unmodified `main`)
- [x] `cd packages/api && bunx vitest run` — 364/364 pass, run after
      the rebase onto current main (not carried over from before)
- [x] New tests: sequential renew-after-release → 404 with
      `expires_at` unchanged; concurrent renew/release race → response
      always matches the actual write (no silent success without an
      actual write, no reported failure with a silent write)