### PR TITLE
fix(api): pad scope-denied timing, share AUTH_CACHE in scopedAuth, add dashboard CSP

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -15,6 +15,7 @@ import analyticsPublicRouter from "./routes/analytics-public";
 import capabilityTokensRouter from "./routes/capability-tokens";
 import claimsRouter from "./routes/claims";
 import conversationsRouter from "./routes/conversations";
+import cspReportRouter from "./routes/csp-report";
 import domainsRouter from "./routes/domains";
 import keysRouter from "./routes/keys";
 import leasesRouter from "./routes/leases";
@@ -214,6 +215,26 @@ app.route("/v1/analytics", analyticsPublicRouter);
 // Domain verification endpoint (no auth required, used by domain providers)
 app.route("/", verifyDomainRouter);
 
+// CSP violation reports from the dashboard's Report-Only policy (see
+// middleware/security-headers.ts). Public, unauthenticated, logging-only.
+app.route("/api/csp-report", cspReportRouter);
+
+// ---------------------------------------------------------------------------
+// Non-API routes → static assets (dashboard)
+// ---------------------------------------------------------------------------
+// `assets.run_worker_first: true` (wrangler.jsonc) routes every request
+// through this Worker first, so dashboard HTML/JS/CSS responses flow through
+// securityHeaders above (CSP, HSTS, etc.) instead of bypassing it via
+// Cloudflare's asset-first routing. Must be the last route: everything that
+// didn't match an API route above falls through to the ASSETS binding.
+// ---------------------------------------------------------------------------
+app.all("*", (c) => {
+  // The test Wrangler config has no assets binding — fall back to a plain
+  // 404 there instead of throwing on `c.env.ASSETS.fetch`.
+  if (!c.env.ASSETS) return c.notFound();
+  return c.env.ASSETS.fetch(c.req.raw);
+});
+
 // ---------------------------------------------------------------------------
 // Error handler
 // ---------------------------------------------------------------------------
@@ -233,7 +254,6 @@ app.onError((err, c) => {
   return errorResponse(c, "INTERNAL_ERROR", "Internal server error", 500);
 });
 
-// Non-API routes → static assets (dashboard)
 export default {
   fetch: app.fetch,
   scheduled: onScheduled,

--- a/packages/api/src/lib/validation.ts
+++ b/packages/api/src/lib/validation.ts
@@ -165,13 +165,10 @@ export const WebhookEventSchema = z.enum(WEBHOOK_EVENT_TYPES);
  * A webhook URL must be https and must not point at a loopback / private /
  * link-local / metadata host (SSRF guard). See lib/url-safety.ts.
  */
-const WebhookUrlSchema = z
-  .string()
-  .url("Invalid webhook URL")
-  .refine(isSafeWebhookUrl, {
-    message:
-      "Webhook URL must be https and must not target a private, loopback, link-local, or metadata host",
-  });
+const WebhookUrlSchema = z.string().url("Invalid webhook URL").refine(isSafeWebhookUrl, {
+  message:
+    "Webhook URL must be https and must not target a private, loopback, link-local, or metadata host",
+});
 
 export const CreateWebhookSchema = z.object({
   url: WebhookUrlSchema,

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -24,8 +24,10 @@ const authFailure = async (c: any, startedAt: number): Promise<Response> => {
 /**
  * Parse a cached auth entry. Current entries are JSON `{ projectId, scopes }`.
  * Legacy entries are a bare projectId string and are treated as full access.
+ * Exported so other auth middlewares (scoped-auth.ts) sharing the same
+ * `auth:hash:${hash}` cache entries can decode them identically.
  */
-function parseCacheValue(raw: string): { projectId: string; scopes: string[] } {
+export function parseCacheValue(raw: string): { projectId: string; scopes: string[] } {
   try {
     const obj = JSON.parse(raw);
     if (

--- a/packages/api/src/middleware/scoped-auth.ts
+++ b/packages/api/src/middleware/scoped-auth.ts
@@ -5,6 +5,7 @@ import { hashApiKey } from "../lib/crypto";
 import { errorResponse } from "../lib/helpers";
 import { effectiveKeyScopes, parseScopesJson, scopeSatisfies } from "../lib/scopes";
 import type { Bindings, Variables } from "../types";
+import { parseCacheValue } from "./auth";
 
 const AUTH_FAILURE_MIN_MS = 300;
 
@@ -13,10 +14,28 @@ export interface ScopedAuthOptions {
   allowQueryToken?: boolean;
 }
 
-async function authFailure(c: any, startedAt: number): Promise<Response> {
+/**
+ * Pad any credential-rejection branch (invalid/missing key, revoked, or
+ * insufficient scope) to a constant minimum elapsed time so a caller cannot
+ * use response speed to learn whether a credential is valid but underscoped
+ * versus outright invalid. Any future middleware that rejects a *valid*
+ * credential (expiry, revocation, scope) should route through this helper too.
+ */
+async function padAuthTiming(startedAt: number): Promise<void> {
   const remainingMs = Math.max(0, AUTH_FAILURE_MIN_MS - (performance.now() - startedAt));
-  await new Promise((resolve) => setTimeout(resolve, remainingMs));
+  if (remainingMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, remainingMs));
+  }
+}
+
+async function authFailure(c: any, startedAt: number): Promise<Response> {
+  await padAuthTiming(startedAt);
   return errorResponse(c, "UNAUTHORIZED", "Unauthorized", 401);
+}
+
+async function scopeDenied(c: any, startedAt: number, message: string): Promise<Response> {
+  await padAuthTiming(startedAt);
+  return errorResponse(c, "FORBIDDEN", message, 403);
 }
 
 export function scopedAuth(options: ScopedAuthOptions) {
@@ -59,7 +78,7 @@ export function scopedAuth(options: ScopedAuthOptions) {
 
       const scopes = parseScopesJson(token.scopes);
       if (!scopeSatisfies(scopes, options.scope)) {
-        return errorResponse(c, "FORBIDDEN", "Capability token does not have required scope", 403);
+        return scopeDenied(c, startedAt, "Capability token does not have required scope");
       }
 
       c.set("projectId", token.projectId);
@@ -78,6 +97,28 @@ export function scopedAuth(options: ScopedAuthOptions) {
 
     if (queryToken) return authFailure(c, startedAt);
 
+    // Try the shared KV auth cache first (same `auth:hash:${hash}` entries
+    // apiKeyAuth reads/writes) so high-throughput state/lease/claim routes
+    // don't pay a D1 read on every request. Capability tokens (above) are not
+    // cached — they carry their own expiry/revocation semantics.
+    const cacheKey = `auth:hash:${hash}`;
+    if (c.env.AUTH_CACHE) {
+      const cached = await c.env.AUTH_CACHE.get(cacheKey, "text");
+      if (cached) {
+        const { projectId, scopes } = parseCacheValue(cached);
+        if (!scopeSatisfies(scopes, options.scope)) {
+          return scopeDenied(c, startedAt, `Missing required scope: ${options.scope}`);
+        }
+        c.set("projectId", projectId);
+        c.set("apiKeyHash", hash);
+        c.set("authType", "api_key");
+        c.set("capabilityScopes", scopes);
+        // Skip the DB update for cache hits, matching apiKeyAuth's behavior.
+        await next();
+        return;
+      }
+    }
+
     const [apiKey] = await db
       .select({ id: apiKeys.id, projectId: apiKeys.projectId, scopes: apiKeys.scopes })
       .from(apiKeys)
@@ -90,13 +131,17 @@ export function scopedAuth(options: ScopedAuthOptions) {
     // `*` wildcard and satisfy every scope, preserving backward compatibility.
     const scopes = effectiveKeyScopes(apiKey.scopes);
     if (!scopeSatisfies(scopes, options.scope)) {
-      return errorResponse(c, "FORBIDDEN", `Missing required scope: ${options.scope}`, 403);
+      return scopeDenied(c, startedAt, `Missing required scope: ${options.scope}`);
     }
 
     c.set("projectId", apiKey.projectId);
     c.set("apiKeyHash", hash);
     c.set("authType", "api_key");
     c.set("capabilityScopes", scopes);
+    if (c.env.AUTH_CACHE) {
+      const cacheValue = JSON.stringify({ projectId: apiKey.projectId, scopes });
+      c.executionCtx.waitUntil(c.env.AUTH_CACHE.put(cacheKey, cacheValue, { expirationTtl: 300 }));
+    }
     c.executionCtx.waitUntil(
       db.update(apiKeys).set({ lastUsedAt: Date.now() }).where(eq(apiKeys.id, apiKey.id)),
     );

--- a/packages/api/src/middleware/security-headers.ts
+++ b/packages/api/src/middleware/security-headers.ts
@@ -2,6 +2,41 @@ import { createMiddleware } from "hono/factory";
 import type { Bindings, Variables } from "../types";
 
 /**
+ * Clerk frontend-API domain for the dashboard's live instance. Confirmed via
+ * DNS: `clerk.agentstate.app` CNAMEs to `frontend-api.clerk.services`. Clerk
+ * loads its script and makes session calls against this origin.
+ */
+const CLERK_FRONTEND_API = "https://clerk.agentstate.app";
+
+/**
+ * Content-Security-Policy for the dashboard (HTML responses). Shipped
+ * Report-Only first — see the flip note below. `'unsafe-inline'` on
+ * script-src is a pragmatic starting point for Astro's inlined bootstrap
+ * scripts and Clerk; dropping it in favor of nonces is the documented
+ * follow-up (see plans/010-dashboard-csp.md).
+ */
+const DASHBOARD_CSP = [
+  "default-src 'self'",
+  `script-src 'self' 'unsafe-inline' ${CLERK_FRONTEND_API}`,
+  `connect-src 'self' ${CLERK_FRONTEND_API}`,
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: https:",
+  "font-src 'self' data:",
+  `frame-src ${CLERK_FRONTEND_API}`,
+  "worker-src 'self' blob:",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  "report-uri /api/csp-report",
+].join("; ");
+
+/**
+ * Trivial enforcing policy for API (JSON) responses. Safe to enforce
+ * immediately — JSON responses never execute scripts or render as documents.
+ */
+const API_CSP = "default-src 'none'";
+
+/**
  * Sets standard security response headers on every response.
  *
  * Headers applied:
@@ -10,9 +45,14 @@ import type { Bindings, Variables } from "../types";
  * - Referrer-Policy: strict-origin-when-cross-origin — limits referrer leakage
  * - Strict-Transport-Security: max-age=31536000; includeSubDomains
  *                                           — enforces HTTPS (safe; no preload)
+ * - Content-Security-Policy-Report-Only (HTML responses) / Content-Security-Policy
+ *   (everything else) — see DASHBOARD_CSP / API_CSP above.
+ *
+ * FLIP TO ENFORCING: once production Report-Only violation reports are clean
+ * for a few days, rename `Content-Security-Policy-Report-Only` below to
+ * `Content-Security-Policy` for the HTML branch.
  *
  * Intentionally excluded (deferred for human review):
- * - Content-Security-Policy — needs careful tuning to avoid breaking the dashboard
  * - Cross-Origin-Opener-Policy / Cross-Origin-Embedder-Policy / Cross-Origin-Resource-Policy
  *   — can break legitimate cross-origin API fetches
  */
@@ -23,5 +63,12 @@ export const securityHeaders = createMiddleware<{ Bindings: Bindings; Variables:
     c.header("X-Frame-Options", "DENY");
     c.header("Referrer-Policy", "strict-origin-when-cross-origin");
     c.header("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+
+    const contentType = c.res.headers.get("Content-Type") ?? "";
+    if (contentType.includes("text/html")) {
+      c.header("Content-Security-Policy-Report-Only", DASHBOARD_CSP);
+    } else {
+      c.header("Content-Security-Policy", API_CSP);
+    }
   },
 );

--- a/packages/api/src/routes/csp-report.ts
+++ b/packages/api/src/routes/csp-report.ts
@@ -1,0 +1,27 @@
+import { Hono } from "hono";
+import type { Bindings, Variables } from "../types";
+
+/**
+ * Receives Content-Security-Policy violation reports (`report-uri`) from the
+ * dashboard's Report-Only policy (see middleware/security-headers.ts).
+ * Unauthenticated by design — browsers POST these with no credentials.
+ * Logs a summary only; no report bodies are persisted.
+ */
+const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+app.post("/", async (c) => {
+  const report = await c.req.json().catch(() => null);
+  const blockedUri = report?.["csp-report"]?.["blocked-uri"];
+  const violatedDirective = report?.["csp-report"]?.["violated-directive"];
+  console.log(
+    JSON.stringify({
+      level: "info",
+      message: "csp_report_only_violation",
+      blocked_uri: blockedUri,
+      violated_directive: violatedDirective,
+    }),
+  );
+  return c.body(null, 204);
+});
+
+export default app;

--- a/packages/api/test/fixtures/assets/index.html
+++ b/packages/api/test/fixtures/assets/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<!--
+  Minimal fixture standing in for the real dashboard build (packages/dashboard/out),
+  which is not guaranteed to exist when API tests run in CI. Exists only so the
+  ASSETS binding in wrangler.test.jsonc has something to serve, letting tests
+  exercise the index.ts asset fall-through route (CSP headers on HTML responses).
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>test fixture</title>
+  </head>
+  <body>
+    test fixture
+  </body>
+</html>

--- a/packages/api/test/scopes.test.ts
+++ b/packages/api/test/scopes.test.ts
@@ -1,4 +1,4 @@
-import { SELF } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 import { effectiveKeyScopes, scopeSatisfies, scopesSatisfyAll } from "../src/lib/scopes";
 import { applyMigrations, authHeaders, seedProject, TEST_PROJECT_ID } from "./setup";
@@ -16,6 +16,24 @@ async function createKey(scopes?: string[]): Promise<string> {
   expect(res.status).toBe(201);
   const body = (await res.json()) as { key: string; scopes: string[] | null };
   return body.key;
+}
+
+async function createKeyWithId(scopes?: string[]): Promise<{ id: string; key: string }> {
+  const res = await SELF.fetch(`http://localhost/api/projects/${TEST_PROJECT_ID}/keys`, {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify({ name: "scoped-cache", ...(scopes ? { scopes } : {}) }),
+  });
+  expect(res.status).toBe(201);
+  const body = (await res.json()) as { id: string; key: string };
+  return body;
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 describe("scope helpers", () => {
@@ -143,5 +161,126 @@ describe("API key scope enforcement", () => {
     });
     expect(res.status).not.toBe(403);
     expect([200, 201]).toContain(res.status);
+  });
+});
+
+describe("scopedAuth timing (plan 009: pad scope-denied like auth failures)", () => {
+  beforeEach(async () => {
+    await applyMigrations();
+    await seedProject();
+  });
+
+  it("pads a scope-denied 403 to the same ~300ms floor as an auth failure, and stays faster on success", async () => {
+    const limited = await createKey(["conversations:read"]); // lacks lease:write
+    const leaseKey = await createKey(["lease:write"]);
+
+    const measure = async (init: RequestInit, stateKey: string): Promise<number> => {
+      const start = performance.now();
+      await SELF.fetch(`http://localhost/api/v1/states/${stateKey}/lease`, init);
+      return performance.now() - start;
+    };
+
+    const scopeDeniedDurations: number[] = [];
+    for (let i = 0; i < 3; i++) {
+      scopeDeniedDurations.push(
+        await measure(
+          {
+            method: "POST",
+            headers: bearer(limited),
+            body: JSON.stringify({ holder: "worker-1", ttl_ms: 30_000 }),
+          },
+          `timing-scope-denied-${i}`,
+        ),
+      );
+    }
+    scopeDeniedDurations.sort((a, b) => a - b);
+    const medianScopeDenied = scopeDeniedDurations[1];
+
+    // Same floor as auth.test.ts asserts for authFailure (AUTH_FAILURE_MIN_MS = 300).
+    expect(medianScopeDenied).toBeGreaterThanOrEqual(200);
+
+    const successDuration = await measure(
+      {
+        method: "POST",
+        headers: bearer(leaseKey),
+        body: JSON.stringify({ holder: "worker-1", ttl_ms: 30_000 }),
+      },
+      "timing-scope-allowed",
+    );
+    expect(successDuration).toBeLessThan(medianScopeDenied);
+  }, 10_000);
+});
+
+describe("scopedAuth shares the AUTH_CACHE with apiKeyAuth (issue #343)", () => {
+  beforeEach(async () => {
+    await applyMigrations();
+    await seedProject();
+  });
+
+  it("populates the shared auth:hash:<hash> cache entry after a scopedAuth request", async () => {
+    const created = await createKeyWithId();
+    const hash = await sha256Hex(created.key);
+    if (env.AUTH_CACHE) await env.AUTH_CACHE.delete(`auth:hash:${hash}`);
+
+    const res = await SELF.fetch("http://localhost/api/v1/states/cache-populate-check/lease", {
+      method: "POST",
+      headers: bearer(created.key),
+      body: JSON.stringify({ holder: "worker-1", ttl_ms: 30_000 }),
+    });
+    expect([200, 201]).toContain(res.status);
+
+    const cached = await env.AUTH_CACHE.get(`auth:hash:${hash}`, "text");
+    expect(cached).not.toBeNull();
+    const parsed = JSON.parse(cached as string);
+    expect(parsed.projectId).toBe(TEST_PROJECT_ID);
+  });
+
+  it("a cache-hit request via scopedAuth still respects the granted scopes", async () => {
+    // Regression guard for the cache-hit branch added for issue #343: caching
+    // must not bypass scope enforcement (only the DB round-trip is skipped).
+    const limited = await createKeyWithId(["conversations:read"]);
+
+    // First request (DB path) populates the cache with the limited scope set.
+    const first = await SELF.fetch("http://localhost/api/v1/states/cache-scope-check/lease", {
+      method: "POST",
+      headers: bearer(limited.key),
+      body: JSON.stringify({ holder: "worker-1", ttl_ms: 30_000 }),
+    });
+    expect(first.status).toBe(403);
+
+    // Second request (cache-hit path) must still be denied for the same reason.
+    const second = await SELF.fetch("http://localhost/api/v1/states/cache-scope-check-2/lease", {
+      method: "POST",
+      headers: bearer(limited.key),
+      body: JSON.stringify({ holder: "worker-1", ttl_ms: 30_000 }),
+    });
+    expect(second.status).toBe(403);
+  });
+
+  it("revoking a key via the route invalidates the cache entry scopedAuth wrote", async () => {
+    const created = await createKeyWithId();
+
+    // First request via the scoped-auth code path populates AUTH_CACHE.
+    const first = await SELF.fetch("http://localhost/api/v1/states/cache-revoke-check/lease", {
+      method: "POST",
+      headers: bearer(created.key),
+      body: JSON.stringify({ holder: "worker-1", ttl_ms: 30_000 }),
+    });
+    expect([200, 201]).toContain(first.status);
+
+    // Revoke through the route — this calls invalidateAuthCacheEntries, which
+    // must clear the entry scopedAuth (not just apiKeyAuth) wrote.
+    const revokeRes = await SELF.fetch(
+      `http://localhost/api/projects/${TEST_PROJECT_ID}/keys/${created.id}`,
+      { method: "DELETE", headers: authHeaders() },
+    );
+    expect(revokeRes.status).toBe(204);
+
+    const second = await SELF.fetch("http://localhost/api/v1/states/cache-revoke-check-2/lease", {
+      method: "POST",
+      headers: bearer(created.key),
+      body: JSON.stringify({ holder: "worker-1", ttl_ms: 30_000 }),
+    });
+    expect(second.status).toBe(401);
   });
 });

--- a/packages/api/test/security-headers.test.ts
+++ b/packages/api/test/security-headers.test.ts
@@ -33,4 +33,28 @@ describe("Security headers", () => {
       "max-age=31536000; includeSubDomains",
     );
   });
+
+  it("sets an enforcing default-src 'none' CSP on JSON API responses", async () => {
+    const response = await SELF.fetch("http://localhost/api");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Security-Policy")).toBe("default-src 'none'");
+    expect(response.headers.get("Content-Security-Policy-Report-Only")).toBeNull();
+  });
+
+  it("sets a Report-Only CSP with frame-ancestors 'none' on dashboard HTML responses", async () => {
+    // Falls through index.ts's catch-all to the ASSETS binding (test fixture
+    // at test/fixtures/assets/), which stands in for the real dashboard build.
+    const response = await SELF.fetch("http://localhost/dashboard");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain("text/html");
+
+    const csp = response.headers.get("Content-Security-Policy-Report-Only");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("default-src 'self'");
+    expect(response.headers.get("Content-Security-Policy")).toBeNull();
+
+    // The baseline headers still apply to asset responses now that they flow
+    // through the Worker (assets.run_worker_first).
+    expect(response.headers.get("X-Frame-Options")).toBe("DENY");
+  });
 });

--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -8,7 +8,12 @@
   "assets": {
     "directory": "../dashboard/out",
     "binding": "ASSETS",
-    "not_found_handling": "single-page-application"
+    "not_found_handling": "single-page-application",
+    // Static assets are served ahead of the Worker by default, so the dashboard's
+    // HTML never reached the Hono middleware chain (no CSP, no security headers).
+    // Route all requests through the Worker first so index.ts's asset fall-through
+    // can attach a Content-Security-Policy to dashboard responses.
+    "run_worker_first": true
   },
 
   "observability": {

--- a/packages/api/wrangler.test.jsonc
+++ b/packages/api/wrangler.test.jsonc
@@ -14,6 +14,17 @@
     }
   ],
 
+  // Minimal fixture (test/fixtures/assets/) standing in for the real dashboard
+  // build, which is not guaranteed to exist when API tests run in CI. Lets
+  // tests exercise index.ts's asset fall-through route (CSP on HTML responses)
+  // without depending on packages/dashboard/out.
+  "assets": {
+    "directory": "test/fixtures/assets",
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+    "run_worker_first": true
+  },
+
   "kv_namespaces": [
     {
       "binding": "AUTH_CACHE",


### PR DESCRIPTION
## Summary

Three related security/perf fixes to the auth middleware layer, executed together per plans/009 and plans/010 (both touch `scoped-auth.ts` / `security-headers.ts`):

- **Plan 009 / #368** — `scopedAuth`'s scope-denied 403 branches returned immediately while auth failures are padded to a 300ms floor, letting a caller with a valid-but-underscoped credential distinguish itself from an invalid one via timing. Both 403 branches now go through the same `padAuthTiming`/`scopeDenied` helper as the 401 path. Status codes and messages are unchanged.
- **#343** — `scopedAuth` (states/leases/claims/capability-token routes — the highest-throughput surface) ran a fresh D1 query on every request instead of sharing the `apiKeyAuth` KV cache (`auth:hash:<hash>`, 300s TTL). Bundled into the same commit since it touches the same branch the timing fix does. The regular-API-key branch now reads/writes the shared cache; capability tokens stay uncached per their own expiry/revocation semantics. Scopes are still evaluated per-request on cache hits — only the DB round-trip is skipped, matching `apiKeyAuth`'s existing behavior.
- **Plan 010 / #369** — The Clerk-authenticated dashboard had no CSP. Root cause: Cloudflare's assets binding serves static files ahead of the Worker by default, so dashboard HTML never reached the Hono middleware chain at all (confirmed via curl — no security headers of any kind on dashboard responses, not just missing CSP). Set `assets.run_worker_first: true` and added a catch-all route in `index.ts` that proxies to `env.ASSETS.fetch`, so dashboard responses now flow through `securityHeaders`. Shipped `Content-Security-Policy-Report-Only` first (per the plan's risk mitigation) with the Clerk frontend-API origin (`clerk.agentstate.app`, confirmed via DNS — CNAMEs to `frontend-api.clerk.services`). API/JSON responses get an enforcing `default-src 'none'` immediately (safe — JSON never executes scripts). Violations post to a new unauthenticated, logging-only `/api/csp-report` endpoint.

Closes #343
Closes #368
Closes #369

## Notes / limitations

- The test Wrangler config had no `assets` binding at all — added a minimal fixture (`packages/api/test/fixtures/assets/`) rather than pointing at the real dashboard build, since that build isn't guaranteed to exist when API tests run in CI.
- Manual dashboard exercising in a real browser (plan 010's Step 3 — checking DevTools console across landing/sign-in/dashboard/analytics for zero Report-Only violations) **could not be completed** — no working browser was available in this sandbox. Verified instead via curl (headers present and correct on both HTML and JSON response paths) and static analysis of the built dashboard output (all inline `<script>`/`<style>` tags are covered by `'unsafe-inline'`, fonts are self-hosted, no external script/font origins beyond Clerk). **A human should do a live-browser check before flipping the header from Report-Only to enforcing.**
- `require-scope.ts` (used post-auth for scope checks, e.g. read-only-key-tries-to-write) has the same fast-403-vs-padded-401 timing gap as `scoped-auth.ts` did, but it has no `startedAt`/timing baseline at all since it runs after auth already succeeded — per plan 009's scope, this is left unfixed rather than restructured, and is flagged here for a human to decide whether it's worth a follow-up.
- One incidental fix included: `lib/validation.ts`'s `WebhookUrlSchema` formatting, applied automatically by the repo's pre-commit hook (which runs `biome check --write` across `packages/*/src`) — unrelated to this branch's actual work, committed separately (`6ecf799`) for a clean diff.

## Test plan

- [x] `bunx biome check packages/api/src/` — clean
- [x] `bunx tsc --noEmit -p packages/api/tsconfig.json` — clean
- [x] `cd packages/api && bunx vitest run` — 359/359 passed (353 existing + 6 new: 2 CSP header-presence tests, 1 scope-denied timing test, 3 AUTH_CACHE tests for scopedAuth)
- [x] Manual `wrangler dev` + curl: confirmed dashboard HTML now carries `Content-Security-Policy-Report-Only` + baseline security headers (previously had none); API JSON carries enforcing `Content-Security-Policy: default-src 'none'`
- [ ] Live-browser DevTools console check across dashboard routes (not possible in this sandbox — see Notes above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Added stronger Content Security Policy protection for API responses.
  - Added report-only CSP monitoring for dashboard pages while preserving dashboard functionality.
  - Added CSP violation reporting support.

- **Authentication**
  - Improved scoped authentication response consistency and timing protection.
  - Improved authentication performance through short-lived authorization caching.
  - Ensured permission changes and revoked credentials are reflected promptly.

- **Reliability**
  - Improved fallback handling for dashboard and static asset requests, including safer behavior when assets are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->