### PR TITLE
fix(api): dedupe supported webhook event types into one constant

### DIFF
--- a/packages/api/src/lib/webhook.ts
+++ b/packages/api/src/lib/webhook.ts
@@ -1,9 +1,10 @@
 import { isSafeWebhookUrl } from "./url-safety";
+import { WEBHOOK_EVENT_TYPES } from "./validation";
 
 /**
  * Valid webhook event types.
  */
-export const WEBHOOK_EVENTS = ["conversation.created"] as const;
+export const WEBHOOK_EVENTS = WEBHOOK_EVENT_TYPES;
 export type WebhookEvent = (typeof WEBHOOK_EVENTS)[number];
 
 /**


### PR DESCRIPTION
Fixes #378

`WEBHOOK_EVENT_TYPES` (validation.ts) and `WEBHOOK_EVENTS` (webhook.ts) were two independent copies of the same list. Collapsed to one source of truth — `webhook.ts` now imports from `validation.ts`.

## Test plan
- [x] `bunx tsc --noEmit`
- [x] `bunx vitest run test/webhooks.test.ts test/webhook-retry.test.ts` (40 passed)
- [x] `bunx biome check`