### PR TITLE
chore: gitignore local agent-tool state dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ packages/api/wrangler.deploy.jsonc
 
 # Ralph loop local state
 .sisyphus/
+.omo/
+
+# Command Code local state
+.commandcode/

--- a/packages/dashboard/src/components/dashboard/organizations/create/create-org-content.tsx
+++ b/packages/dashboard/src/components/dashboard/organizations/create/create-org-content.tsx
@@ -1,4 +1,9 @@
-import { SignIn, useOrganizationCreationDefaults, useOrganizationList, useUser } from "@clerk/react";
+import {
+  SignIn,
+  useOrganizationCreationDefaults,
+  useOrganizationList,
+  useUser,
+} from "@clerk/react";
 import * as React from "react";
 import { CreateOrgForm } from "./_create-org-form";
 import { CreateOrgHeader } from "./_create-org-header";


### PR DESCRIPTION
## Summary
- Add `.omo/` and `.commandcode/` (local Ralph loop / Command Code scratch state, untracked repo-root dirs) to `.gitignore`.
- Let biome reflow a long import line in `create-org-content.tsx` (formatting only, no logic change).