### PR TITLE
fix: make the active org visible and org orphaning observable

### DIFF
--- a/packages/api/src/services/projects.ts
+++ b/packages/api/src/services/projects.ts
@@ -233,6 +233,22 @@ export async function listProjects(
   const org = await getOrgByClerkId(db, clerkOrgId);
 
   if (!org) {
+    // Org rows are created lazily (see getOrCreateOrg), so a missing row is
+    // legitimate for an org that has not created its first project yet — this
+    // must stay a 200 with an empty list, not an error (#388).
+    //
+    // It is ALSO how orphaned tenants look: #276 changed org-id derivation and
+    // silently stranded every project written under the old scheme. The two are
+    // indistinguishable from the response, so log the id shape to tell them
+    // apart. The value is a Clerk org id or `personal:<userId>`, not a secret.
+    console.warn(
+      JSON.stringify({
+        event: "org_not_found",
+        clerk_org_id: clerkOrgId,
+        kind: clerkOrgId.startsWith("personal:") ? "personal" : "clerk_org",
+        msg: "Session org resolved to no organization row; returning empty project list.",
+      }),
+    );
     return [];
   }
 

--- a/packages/dashboard/src/components/app-shell.tsx
+++ b/packages/dashboard/src/components/app-shell.tsx
@@ -23,7 +23,7 @@ import {
 } from "@phosphor-icons/react";
 import { AnimatePresence, motion } from "motion/react";
 import { useTheme } from "next-themes";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { type ReactNode, useEffect, useId, useRef, useState } from "react";
 import { toast } from "sonner";
 import { LogoMark } from "@/components/logo-mark";
 import { ProjectScopeProvider, useProjectScope } from "@/components/project-scope";
@@ -267,6 +267,9 @@ function SidebarOrgScope() {
   const { organizations, isLoaded, setActive } = useOrganizationsList();
   const { organization: activeOrg } = useOrganization();
   const [switching, setSwitching] = useState(false);
+  // The shell mounts this twice (desktop sidebar + mobile drawer), so a literal
+  // id would collide and both labels would resolve to the first select.
+  const selectId = useId();
 
   if (!isLoaded) {
     return (
@@ -293,7 +296,7 @@ function SidebarOrgScope() {
 
   return (
     <div className="border-b border-edge-soft px-3 py-2.5">
-      <label htmlFor="sidebar-org-scope" className="sr-only">
+      <label htmlFor={selectId} className="sr-only">
         Active organization
       </label>
       <div className="relative">
@@ -303,7 +306,7 @@ function SidebarOrgScope() {
           aria-hidden
         />
         <select
-          id="sidebar-org-scope"
+          id={selectId}
           aria-label="Active organization"
           disabled={switching}
           value={activeOrg?.id ?? ""}

--- a/packages/dashboard/src/components/app-shell.tsx
+++ b/packages/dashboard/src/components/app-shell.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { SignIn, UserButton, useAuth, useUser } from "@clerk/react";
+import { SignIn, UserButton, useAuth, useOrganization, useUser } from "@clerk/react";
 import {
   ArrowUpRight,
   BookOpen,
+  Buildings,
   CaretDown,
   ChartLine,
   ChatCircle,
@@ -26,6 +27,7 @@ import { type ReactNode, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { LogoMark } from "@/components/logo-mark";
 import { ProjectScopeProvider, useProjectScope } from "@/components/project-scope";
+import { useOrganizationsList } from "@/hooks/_use-organizations-list";
 import { SESSION_EXPIRED_EVENT } from "@/lib/api";
 
 interface NavItem {
@@ -250,6 +252,85 @@ function SidebarInner({
 }
 
 /**
+ * SidebarOrgScope — the active-organization switcher above the project scope.
+ *
+ * The org id is load-bearing for every project-scoped read (the API derives it
+ * from the session's `o_id` claim), so it needs to be both visible and
+ * selectable — an org mismatch otherwise presents as an empty account with no
+ * way to diagnose or correct it (#387).
+ *
+ * Switching orgs mints a new session token with a different `o_id`. Rather than
+ * refetch each project-scoped cache by hand, reload once so every consumer
+ * re-reads under the new org.
+ */
+function SidebarOrgScope() {
+  const { organizations, isLoaded, setActive } = useOrganizationsList();
+  const { organization: activeOrg } = useOrganization();
+  const [switching, setSwitching] = useState(false);
+
+  if (!isLoaded) {
+    return (
+      <div className="border-b border-edge-soft px-3 py-2.5" aria-live="polite">
+        <div className="h-9 animate-pulse rounded-[var(--radius)] bg-panel2" aria-hidden="true" />
+        <span className="sr-only">Loading organizations…</span>
+      </div>
+    );
+  }
+
+  if (organizations.length === 0) return null;
+
+  const handleChange = async (orgId: string) => {
+    if (!setActive || orgId === activeOrg?.id) return;
+    setSwitching(true);
+    try {
+      await setActive({ organization: orgId });
+      window.location.reload();
+    } catch {
+      setSwitching(false);
+      toast.error("Could not switch organization. Please try again.");
+    }
+  };
+
+  return (
+    <div className="border-b border-edge-soft px-3 py-2.5">
+      <label htmlFor="sidebar-org-scope" className="sr-only">
+        Active organization
+      </label>
+      <div className="relative">
+        <Buildings
+          size={14}
+          className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-fg-4"
+          aria-hidden
+        />
+        <select
+          id="sidebar-org-scope"
+          aria-label="Active organization"
+          disabled={switching}
+          value={activeOrg?.id ?? ""}
+          onChange={(e) => void handleChange(e.target.value)}
+          className="h-9 w-full appearance-none rounded-[var(--radius)] border border-edge bg-panel pl-8 pr-8 text-[13px] text-fg transition-colors hover:bg-panel2 focus-visible:bg-panel2 focus-visible:outline-none disabled:opacity-60"
+        >
+          {/* A session with no active org still has to render a selected value,
+              otherwise the select silently shows the first org as if it were
+              active while the API is scoped to `personal:<userId>` (#387). */}
+          {!activeOrg && <option value="">Select organization…</option>}
+          {organizations.map((org) => (
+            <option key={org.id} value={org.id}>
+              {org.name}
+            </option>
+          ))}
+        </select>
+        <CaretDown
+          size={13}
+          className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-fg-4"
+          aria-hidden
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
  * SidebarProjectScope — the active-project switcher under the logo. Reads/writes
  * the shared ProjectScope so it controls every project-scoped page at once.
  */
@@ -340,6 +421,7 @@ export function AppShell({ children }: { children: ReactNode }) {
                 <span className="text-[14.5px] font-semibold tracking-tight">AgentState</span>
               </a>
             </div>
+            <SidebarOrgScope />
             <SidebarProjectScope />
             <SidebarInner activeUrl={activeUrl} />
           </aside>
@@ -377,6 +459,7 @@ export function AppShell({ children }: { children: ReactNode }) {
                   <X size={18} />
                 </button>
               </div>
+              <SidebarOrgScope />
               <SidebarProjectScope />
               <SidebarInner activeUrl={activeUrl} onNavigate={() => setMenuOpen(false)} />
             </aside>


### PR DESCRIPTION
Fixes the two tractable parts of the empty-dashboard investigation.

Context: a production account showed 0 projects while D1 held 9. Root cause was #276 changing org-id derivation from a `"default"` sentinel to `personal:\${clerkUserId}` without a data migration, orphaning every existing project under `clerk_org_id = 'default'`. The org row has been re-pointed by hand; these changes stop it recurring silently.

## #387 — sidebar org switcher

`app-shell.tsx` had no active-org indicator and no switcher. Since the org id drives every project-scoped read but was invisible and unselectable, a mismatch looked like an empty account with no diagnosis or recovery path.

Adds `SidebarOrgScope`, mirroring the existing `SidebarProjectScope` and reusing the existing `useOrganizationsList` hook (which already exposed `setActive`). Hand-rolled select rather than Clerk's prebuilt `<OrganizationSwitcher>` to match the design system — consistent with this repo having removed shadcn/Kumo in favour of its own tokens.

## #388 — observable org orphaning

`listProjects` returned `[]` for a missing org row. That stays a 200 + empty list — org rows are created **lazily** by `getOrCreateOrg`, so a missing row is legitimate for an org that hasn't created its first project, and erroring would break the new-user empty state. Instead it now warns with the org id shape (`clerk_org` vs `personal`) so an orphaned tenant is distinguishable from a brand-new one.

## Not included

#389 (org rows are derived, not authoritative) is the durable structural fix and needs a design decision between three mutually-exclusive options — left for discussion rather than guessed at.

## Verification

- `bunx tsc --noEmit -p packages/api/tsconfig.json` — clean
- `bunx biome check` on both changed files — clean
- `bunx vitest run` — 417 passed / 29 files
- `bun run build` (dashboard) — 16 pages built

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an organization selector to the desktop sidebar and mobile navigation.
  - Users can switch the active organization and automatically refresh project-scoped data.
  - The selector displays loading and switching states to provide clear feedback.

- **Bug Fixes**
  - Improved handling when no organization is available by preserving an empty project list instead of failing.
  - Added user-facing error feedback if switching organizations cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->