### PR TITLE
fix(dashboard): render code-tabs lines as blocks + auto-activate sole org

### DIFF
--- a/packages/dashboard/src/components/app-shell.tsx
+++ b/packages/dashboard/src/components/app-shell.tsx
@@ -265,29 +265,56 @@ function SidebarInner({
  */
 function SidebarOrgScope() {
   const { organizations, isLoaded, setActive } = useOrganizationsList();
-  const { organization: activeOrg } = useOrganization();
+  const { isLoaded: isActiveOrgLoaded, organization: activeOrg } = useOrganization();
   const [switching, setSwitching] = useState(false);
   // The shell mounts this twice (desktop sidebar + mobile drawer), so a literal
   // id would collide and both labels would resolve to the first select.
   const selectId = useId();
 
+  // The sole org id, or null when membership is not exactly one org. Deriving a
+  // stable primitive here (rather than depending on the `organizations` array,
+  // whose reference changes every render) keeps the effect below from re-running
+  // on every render.
+  const soleOrgId = organizations.length === 1 ? organizations[0].id : null;
+
   // Clerk sessions start on the personal account (no `o_id` claim) even for a
   // user who belongs to exactly one org. AgentState scopes ALL data to orgs, so
   // that state renders an empty dashboard while the org's projects sit intact
-  // under `personal:<userId>` we never wrote to (#387/#389). When there is a
-  // single, unambiguous org, activate it so the user lands on their data instead
-  // of an empty personal scope. The sessionStorage guard makes this fire at most
-  // once per browser session, so a session that fails to persist the active org
-  // can't turn the post-activation reload into a loop.
+  // under the real org we never wrote to as `personal:<userId>` (#387/#389).
+  // When there is a single, unambiguous org, activate it so the user lands on
+  // their data instead of an empty personal scope.
   useEffect(() => {
-    if (!isLoaded || !setActive || activeOrg || organizations.length !== 1) return;
+    // Wait for BOTH hooks: `useOrganization` reports `activeOrg === undefined`
+    // while loading and `null` only once loaded with no active org. Gating on
+    // its own `isLoaded` avoids firing during that window and reloading a user
+    // who actually has an active org.
+    if (!isLoaded || !isActiveOrgLoaded || !setActive) return;
+    if (activeOrg || !soleOrgId) return;
+
+    // Persist a guard so a session that fails to activate can't loop on reload.
+    // The primary loop protection is that `activeOrg` becomes non-null after the
+    // reload; this is the backstop. sessionStorage can throw (private mode /
+    // storage disabled), so treat any access failure as "no guard available".
     const GUARD = "agentstate:auto-activated-org";
-    if (sessionStorage.getItem(GUARD)) return;
-    sessionStorage.setItem(GUARD, "1");
-    void setActive({ organization: organizations[0].id }).then(() => {
-      window.location.reload();
-    });
-  }, [isLoaded, setActive, activeOrg, organizations]);
+    try {
+      if (sessionStorage.getItem(GUARD)) return;
+      sessionStorage.setItem(GUARD, "1");
+    } catch {
+      // Storage unavailable — proceed relying on the post-reload activeOrg check.
+    }
+
+    setActive({ organization: soleOrgId })
+      .then(() => window.location.reload())
+      .catch(() => {
+        // Activation failed: clear the guard so a later attempt can retry, and
+        // do not reload since nothing changed.
+        try {
+          sessionStorage.removeItem(GUARD);
+        } catch {
+          // ignore — nothing to clean up if storage is unavailable
+        }
+      });
+  }, [isLoaded, isActiveOrgLoaded, setActive, activeOrg, soleOrgId]);
 
   if (!isLoaded) {
     return (

--- a/packages/dashboard/src/components/app-shell.tsx
+++ b/packages/dashboard/src/components/app-shell.tsx
@@ -271,6 +271,24 @@ function SidebarOrgScope() {
   // id would collide and both labels would resolve to the first select.
   const selectId = useId();
 
+  // Clerk sessions start on the personal account (no `o_id` claim) even for a
+  // user who belongs to exactly one org. AgentState scopes ALL data to orgs, so
+  // that state renders an empty dashboard while the org's projects sit intact
+  // under `personal:<userId>` we never wrote to (#387/#389). When there is a
+  // single, unambiguous org, activate it so the user lands on their data instead
+  // of an empty personal scope. The sessionStorage guard makes this fire at most
+  // once per browser session, so a session that fails to persist the active org
+  // can't turn the post-activation reload into a loop.
+  useEffect(() => {
+    if (!isLoaded || !setActive || activeOrg || organizations.length !== 1) return;
+    const GUARD = "agentstate:auto-activated-org";
+    if (sessionStorage.getItem(GUARD)) return;
+    sessionStorage.setItem(GUARD, "1");
+    void setActive({ organization: organizations[0].id }).then(() => {
+      window.location.reload();
+    });
+  }, [isLoaded, setActive, activeOrg, organizations]);
+
   if (!isLoaded) {
     return (
       <div className="border-b border-edge-soft px-3 py-2.5" aria-live="polite">

--- a/packages/dashboard/src/components/home/code-tabs.astro
+++ b/packages/dashboard/src/components/home/code-tabs.astro
@@ -47,7 +47,7 @@ const uid = Math.random().toString(36).slice(2, 8);
       <>
         <input class="ct-input" type="radio" name={`ct-${uid}`} id={`ct-${uid}-${i}`} checked={i === 0} />
         <div class="ct-panel">
-          <pre class="overflow-auto bg-[#0c0c0e] p-4 font-mono text-[12.5px] leading-[1.75] text-zinc-300"><code>{lines.map((line) => <span set:html={highlight(line) || "&nbsp;"} />)}</code></pre>
+          <pre class="overflow-auto bg-[#0c0c0e] p-4 font-mono text-[12.5px] leading-[1.75] text-zinc-300"><code>{lines.map((line) => <span class="block" set:html={highlight(line) || "&nbsp;"} />)}</code></pre>
         </div>
       </>
     );
@@ -75,15 +75,14 @@ const uid = Math.random().toString(36).slice(2, 8);
   .codetabs .ct-input:checked + .ct-panel {
     display: block;
   }
-  /* Highlight the active tab label (modern :has support). */
-  .codetabs:has(.ct-input:checked) .ct-tab {
-    color: var(--color-fg-4);
-  }
-  .codetabs:has(#ct-${uid}-0:checked) label[for="ct-${uid}-0"],
-  .codetabs:has(#ct-${uid}-1:checked) label[for="ct-${uid}-1"],
-  .codetabs:has(#ct-${uid}-2:checked) label[for="ct-${uid}-2"],
-  .codetabs:has(#ct-${uid}-3:checked) label[for="ct-${uid}-3"],
-  .codetabs:has(#ct-${uid}-4:checked) label[for="ct-${uid}-4"] {
+  /* Highlight the active tab label (modern :has support).
+     Correlate checked input N with label N by position — Astro <style> is
+     static CSS, so uid-based selectors can't be interpolated here. */
+  .codetabs:has(.ct-input:nth-of-type(1):checked) .ct-bar .ct-tab:nth-of-type(1),
+  .codetabs:has(.ct-input:nth-of-type(2):checked) .ct-bar .ct-tab:nth-of-type(2),
+  .codetabs:has(.ct-input:nth-of-type(3):checked) .ct-bar .ct-tab:nth-of-type(3),
+  .codetabs:has(.ct-input:nth-of-type(4):checked) .ct-bar .ct-tab:nth-of-type(4),
+  .codetabs:has(.ct-input:nth-of-type(5):checked) .ct-bar .ct-tab:nth-of-type(5) {
     background: var(--color-panel);
     color: var(--color-fg);
   }


### PR DESCRIPTION
## Summary
Two user-reported fixes, both deployed to production already.

### 1. Landing hero code block collapsed to one line
Each highlighted code line was an inline `<span>` with no newline between siblings, so inside `<pre>` the whole snippet flowed onto a single horizontal row (see the broken TypeScript/Vercel AI/LangGraph tabs). Each line now renders as a block.

While here, the active-tab highlight was also dead: Astro `<style>` blocks are static CSS, so the `${uid}` selectors never interpolated. Rewrote them with `:nth-of-type` correlation (no uid needed).

### 2. Dashboard shows no data for a user's org
A user who belongs to exactly one org still starts on Clerk's personal account (no `o_id` claim), so `verifyDashboardSession` resolves to `personal:<userId>` — an org with no row — and the dashboard renders empty while the org's projects sit intact under the real org id. This matches the `org-tenancy-model` history (#387/#389).

Fix: auto-activate the sole org when none is active, guarded by `sessionStorage` so the post-activation `window.location.reload()` can't loop if the active org fails to persist.

## Verification
- `bun run build` (dashboard) ✓
- Deployed to production; `/`, `/api`, `/dashboard/` all return 200
- Confirmed `class="block"` spans present in production landing HTML

## Notes
The data was never lost — 9 projects / 101 conversations remain under org `eHyHEJ4YQnplY5WHvJJjP` (Clerk `org_3B0cAAPs5mwolujADLk7UdIWHuI`). This makes single-org users land on their data instead of an empty personal scope.

Co-Authored-By: Duyet Le <me@duyet.net>
Co-Authored-By: duyetbot <bot@duyet.net>

## Summary by Sourcery

Fix landing page code tabs rendering and improve dashboard org activation behavior for single-org users.

Bug Fixes:
- Render each code-tab code line as a block so multi-line snippets display correctly in the landing hero.
- Restore visual highlighting of the active code tab without relying on dynamic CSS selectors.
- Auto-activate a user’s sole organization in the dashboard so they land on org-scoped data instead of an empty personal scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically activates the only available organization for eligible users, avoiding an empty personal-scope dashboard on first load.

* **Bug Fixes**
  * Improved code tab rendering and active-tab highlighting for more consistent display across tab selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->