### PR TITLE
feat(dashboard): restyle landing and app as a terminal TUI

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
         "@agentstate/shared": "workspace:*",
         "@base-ui/react": "^1.7.0",
         "@clerk/react": "^6.6.6",
-        "@fontsource-variable/inter": "^5.3.0",
+        "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@phosphor-icons/react": "^2.1.10",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -378,7 +378,7 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.12", "", {}, "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="],
 
-    "@fontsource-variable/inter": ["@fontsource-variable/inter@5.3.0", "", {}, "sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA=="],
+    "@fontsource-variable/jetbrains-mono": ["@fontsource-variable/jetbrains-mono@5.3.0", "", {}, "sha512-F32xpS2NsGYoQi2ADSkKTgpJj7ozajsGgDJ8woTnqjmIB+dxDIqImjl4pXZVEExu8UFZ2ndhmX18EBS/hdz3Lw=="],
 
     "@hono/node-server": ["@hono/node-server@2.0.3", "", { "peerDependencies": { "hono": "^4" } }, "sha512-a0jV+/HRe3G5zjFID3zObAQFdkl6zpxTuqktdDDXS3MJKcrZIkB8OkLpNBlY/WXFqv2HF4a0takPej+aNFczWA=="],
 

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -12,6 +12,7 @@ Durable notes for recurring maintenance. Keep this file small and update it inst
 - In sandboxed maintenance runs, set Bun and Wrangler writable paths when needed: `BUN_TMPDIR=/private/tmp/codex-bun-tmp`, `BUN_INSTALL_CACHE_DIR=/private/tmp/codex-bun-cache`, and `XDG_CONFIG_HOME=/private/tmp/codex-wrangler-config`.
 - Root `bun run deploy` should delegate to `cd packages/api && bun run deploy`, and the API deploy script must prepare `wrangler.deploy.jsonc` first so deploys can omit unavailable Vectorize or cron bindings without editing `wrangler.jsonc`.
 - Validate dashboard changes with `cd packages/dashboard && bun run build`; raw `bunx tsc --noEmit` can fail in fresh checkouts before Next generates route type files.
+- Dashboard + marketing share a terminal TUI: JetBrains Mono only, radius 0, GitHub-dark canvas `#0d1117`, green accent `#3fb950`. Landing copy reads like a README (`#` headings, `$` prompts, `[bracket]` links). Do not reintroduce Inter, rounded chrome, or the old vermilion accent.
 - Workers Cache is enabled (`"cache": { "enabled": true }` in `packages/api/wrangler.jsonc`). Only the public static GETs (`/api`, `/llms.txt`, `/agents.md`, `/openapi.json`) set `Cache-Control: public`; every Bearer-authed / per-project route stays uncacheable (and auto-bypasses on the `Authorization` header). Details + the rule: `docs/knowledge/workers-cache.md`.
 
 ## Review Memory

--- a/packages/dashboard/DESIGN.md
+++ b/packages/dashboard/DESIGN.md
@@ -6,14 +6,14 @@ scale, primitive components, and the rules that keep every page visually
 consistent.
 
 Source of truth:
-- **`src/styles/tokens.css`** — shadcn preset `b3mPJeumm` CSS variables (color/type/radius), plus legacy name aliases (`bg-panel` → card, `text-fg` → foreground). Inter is the only loaded webfont.
-- **`src/styles/global.css`** — imports `tokens.css`, the `@utility` spacing/padding helpers, base `@layer`, and keyframe animations.
+- **`src/styles/tokens.css`** — terminal TUI CSS variables (color/type/radius 0), plus legacy name aliases (`bg-panel` → card, `text-fg` → foreground). JetBrains Mono is the only loaded webfont.
+- **`src/styles/global.css`** — imports `tokens.css`, the `@utility` spacing/padding helpers, TUI utilities (`tui-hash`, `tui-key`, `tui-window`), base `@layer`, and keyframe animations.
 
 Both are imported transitively by every layout (`RootLayout` → `global.css` → `tokens.css`; `MarketingLayout` → `global.css` → `tokens.css`). You never need to import either stylesheet yourself in a page or component.
 
 ## Art direction
 
-Dark-first "state console": restrained neutral surfaces, one vermilion brand accent, mono for data/labels, generous but tight spacing. No gradients-as-decoration, no drop shadows beyond `Dialog`'s modal elevation, no more than one accent color on screen at a time.
+Dark-first terminal TUI: monospace type, square corners, GitHub-dark canvas (`#0d1117`), one green brand accent. No gradients, no drop shadows, no rounded chrome. Marketing pages read like a README in a terminal (`#` headings, `$` prompts, `[bracket]` links).
 
 ## Theme mechanism
 
@@ -31,20 +31,20 @@ Canonical names (defined in `tokens.css`, use these in new code):
 
 | Token | Dark | Light | Use |
 |---|---|---|---|
-| `--color-base` / `bg-base` | `#09090b` | `#fafafa` | App canvas |
-| `--color-panel` / `bg-panel` | `#111113` | `#ffffff` | Cards, table head |
-| `--color-panel2` / `bg-panel2` | `#161618` | `#f4f4f5` | Hover / elevated surface |
-| `--color-edge` / `border-edge` | `#262629` | `#e4e4e7` | Primary borders |
-| `--color-edge-soft` / `border-edge-soft` | `#1f1f22` | `#ededee` | Subtle borders (dividers) |
-| `--color-fg` / `text-fg` | `#fafafa` | `#18181b` | Headings, strong text |
-| `--color-fg-2` / `text-fg-2` | `#d4d4d8` | `#3f3f46` | Body text |
-| `--color-fg-3` / `text-fg-3` | `#a1a1aa` | `#71717a` | Muted text |
-| `--color-fg-4` / `text-fg-4` | `#71717a` | `#a1a1aa` | Faint text, placeholders |
-| `--color-accent` / `*-accent` | `#e2664d` | `#d9543a` | **The one brand accent** — vermilion. Primary buttons, links, active nav, focus rings |
-| `--color-accent-fg` | `#ffffff` | `#ffffff` | Text/icon on a solid accent fill |
-| `--color-pos` / `*-pos` | `#34d399` | `#059669` | Positive / live status |
-| `--color-warn` / `*-warn` | `#f59e0b` | `#d97706` | Warning / rate-limited status |
-| `--color-neg` / `*-neg` | `#f87171` | `#dc2626` | Negative / error / destructive |
+| `--color-base` / `bg-base` | `#0d1117` | `#f6f8fa` | App canvas |
+| `--color-panel` / `bg-panel` | `#0d1117` | `#ffffff` | Cards, windows |
+| `--color-panel2` / `bg-panel2` | `#161b22` | `#eaeef2` | Hover / elevated surface |
+| `--color-edge` / `border-edge` | `#30363d` | `#d0d7de` | Primary borders |
+| `--color-edge-soft` / `border-edge-soft` | `#30363d` | `#d0d7de` | Subtle borders (dividers) |
+| `--color-fg` / `text-fg` | `#e6edf3` | `#1f2328` | Headings, strong text |
+| `--color-fg-2` / `text-fg-2` | `#e6edf3` | `#1f2328` | Body text |
+| `--color-fg-3` / `text-fg-3` | `#8b949e` | `#656d76` | Muted text |
+| `--color-fg-4` / `text-fg-4` | `#8b949e` | `#656d76` | Faint text, placeholders |
+| `--color-accent` / `*-accent` | `#3fb950` | `#1a7f37` | **The one brand accent** — terminal green. Primary buttons, links, active nav, focus rings |
+| `--color-accent-fg` | `#0d1117` | `#f6f8fa` | Text/icon on a solid accent fill |
+| `--color-pos` / `*-pos` | `#3fb950` | `#1a7f37` | Positive / live status |
+| `--color-warn` / `*-warn` | `#d29922` | `#9a6700` | Warning / rate-limited status |
+| `--color-neg` / `*-neg` | `#f85149` | `#cf222e` | Negative / error / destructive |
 
 **Preset tokens win.** shadcn names (`bg-background`, `bg-card`, `text-foreground`, `text-muted-foreground`, `bg-primary`, `border-border`) are canonical. Legacy names (`bg-panel`, `text-fg`, `border-edge`, `bg-accent`) alias onto those variables so existing markup keeps compiling. New code should use the preset names.
 
@@ -52,15 +52,15 @@ Never hardcode a hex color in a component. If you need a color not covered above
 
 ## Type
 
-Preset `b3mPJeumm` (Rhea / Inter / orange / lucide) owns type. Inter is loaded via `@fontsource-variable/inter` in `tokens.css`.
+JetBrains Mono Variable is loaded via `@fontsource-variable/jetbrains-mono` in `tokens.css`. Sans, heading, display, and mono tokens all point at the same family.
 
 | Token | Family | Use |
 |---|---|---|
-| `font-heading` / `font-display` | Inter Variable | `h1`–`h5` (applied automatically by the base layer) |
-| `font-sans` (`--font-sans`, default body font) | Inter Variable | Body copy, UI labels, buttons, tab labels |
-| `font-mono` (`--font-mono`) | system ui-monospace | Data values, IDs, timestamps, table headers, badges, code |
+| `font-heading` / `font-display` | JetBrains Mono Variable | `h1`–`h5` (applied automatically by the base layer) |
+| `font-sans` (`--font-sans`, default body font) | JetBrains Mono Variable | Body copy, UI labels, buttons, tab labels |
+| `font-mono` (`--font-mono`) | JetBrains Mono Variable | Data values, IDs, timestamps, table headers, badges, code |
 
-Headings get `font-family: var(--font-display)`, `font-weight: 600`, `letter-spacing: -0.02em`, `line-height: 1.1`, `text-wrap: balance` automatically from the base layer — just use `<h1>`–`<h5>` or the equivalent Tailwind `text-*` size utility, don't reapply font/weight/tracking by hand.
+Headings get `font-family: var(--font-display)`, `font-weight: 500`, `letter-spacing: 0`, `line-height: 1.35`, `text-wrap: balance` automatically from the base layer — just use `<h1>`–`<h5>`. Marketing headings prefix with `#` / `##` via `.tui-hash`. Radius is `0` everywhere.
 
 Mono utility shortcuts (defined in `global.css`, prefer these over raw `font-mono text-[11px] uppercase tracking-...`):
 - `as-label` / `as-label-sm` / `as-label-xs` — uppercase mono eyebrow labels (section headers, group labels)

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -14,7 +14,7 @@
     "@agentstate/shared": "workspace:*",
     "@base-ui/react": "^1.7.0",
     "@clerk/react": "^6.6.6",
-    "@fontsource-variable/inter": "^5.3.0",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@phosphor-icons/react": "^2.1.10",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/packages/dashboard/src/components/app-shell.tsx
+++ b/packages/dashboard/src/components/app-shell.tsx
@@ -14,11 +14,9 @@ import {
   House,
   Key,
   List,
-  Moon,
   type Icon as PhosphorIcon,
   Plug,
   SquaresFour,
-  Sun,
   X,
 } from "@phosphor-icons/react";
 import { AnimatePresence, motion } from "motion/react";
@@ -124,8 +122,8 @@ function NavList({
     <nav className="flex flex-col gap-5 px-3">
       {groups.map((g) => (
         <div key={g.label}>
-          <div className="px-2 pb-1.5 font-mono text-[10.5px] uppercase tracking-[0.12em] text-fg-4">
-            {g.label}
+          <div className="tui-key px-2 pb-1.5 font-mono text-[11px]">
+            # {g.label.toLowerCase()}
           </div>
           <div className="space-y-0.5">
             {g.items.map((it) => {
@@ -137,14 +135,17 @@ function NavList({
                   href={it.url}
                   onClick={onNavigate}
                   aria-current={active ? "page" : undefined}
-                  className={`flex min-h-[36px] items-center gap-3 rounded-[var(--radius)] px-3 py-2 text-[14px] transition-[background-color,color] duration-150 ${
+                  className={`flex min-h-[32px] items-center gap-2 rounded-none px-2 py-1.5 font-mono text-[13px] transition-colors ${
                     active
-                      ? "bg-accent/10 font-medium text-accent"
-                      : "text-fg-3 hover:bg-panel2 hover:text-fg"
+                      ? "bg-muted font-medium text-primary"
+                      : "text-muted-foreground hover:bg-muted hover:text-foreground"
                   }`}
                 >
-                  <Icon size={16} weight={active ? "fill" : "regular"} />
-                  <span>{it.title}</span>
+                  <span className="w-3 shrink-0 text-primary" aria-hidden>
+                    {active ? ">" : " "}
+                  </span>
+                  <Icon size={14} weight={active ? "fill" : "regular"} />
+                  <span>{it.title.toLowerCase()}</span>
                 </a>
               );
             })}
@@ -213,7 +214,7 @@ function SecondaryLinks({ onNavigate }: { onNavigate?: () => void }) {
               key={it.url}
               href={it.url}
               onClick={onNavigate}
-              className="group flex min-h-[32px] items-center gap-2.5 rounded-[var(--radius)] px-3 py-1.5 text-[13px] text-fg-4 transition-colors hover:bg-panel2 hover:text-fg-2"
+              className="group flex min-h-[32px] items-center gap-2.5 rounded-none px-2 py-1.5 text-[13px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             >
               <Icon size={15} weight="regular" />
               <span>{it.title}</span>
@@ -361,7 +362,7 @@ function SidebarOrgScope() {
   if (!isLoaded) {
     return (
       <div className="border-b border-edge-soft px-3 py-2.5" aria-live="polite">
-        <div className="h-9 animate-pulse rounded-[var(--radius)] bg-panel2" aria-hidden="true" />
+        <div className="h-9 animate-pulse rounded-none bg-panel2" aria-hidden="true" />
         <span className="sr-only">Loading organizations…</span>
       </div>
     );
@@ -372,7 +373,7 @@ function SidebarOrgScope() {
       <div className="border-b border-edge-soft px-3 py-2.5">
         <a
           href="/dashboard/settings/organizations/"
-          className="flex items-center gap-2 rounded-[var(--radius)] border border-edge bg-panel px-2.5 py-2 text-[12.5px] text-fg-3 transition-colors hover:bg-panel2 hover:text-fg"
+          className="flex items-center gap-2 rounded-none border border-edge bg-panel px-2.5 py-2 text-[12.5px] text-fg-3 transition-colors hover:bg-panel2 hover:text-fg"
         >
           <Buildings size={14} className="shrink-0 text-fg-4" aria-hidden />
           <span>Create or join an organization to see projects</span>
@@ -415,7 +416,7 @@ function SidebarOrgScope() {
           disabled={switching}
           value={activeOrg?.id ?? ""}
           onChange={(e) => void handleChange(e.target.value)}
-          className="h-9 w-full appearance-none rounded-[var(--radius)] border border-edge bg-panel pl-8 pr-8 text-[13px] text-fg transition-colors hover:bg-panel2 focus-visible:bg-panel2 focus-visible:outline-none disabled:opacity-60"
+          className="h-9 w-full appearance-none rounded-none border border-edge bg-panel pl-8 pr-8 text-[13px] text-fg transition-colors hover:bg-panel2 focus-visible:bg-panel2 focus-visible:outline-none disabled:opacity-60"
         >
           {/* A session with no active org still has to render a selected value,
               otherwise the select silently shows the first org as if it were
@@ -447,7 +448,7 @@ function SidebarProjectScope() {
   if (loadingProjects) {
     return (
       <div className="border-b border-edge-soft px-3 py-2.5" aria-live="polite">
-        <div className="h-9 animate-pulse rounded-[var(--radius)] bg-panel2" aria-hidden="true" />
+        <div className="h-9 animate-pulse rounded-none bg-panel2" aria-hidden="true" />
         <span className="sr-only">Loading projects…</span>
       </div>
     );
@@ -471,7 +472,7 @@ function SidebarProjectScope() {
           aria-label="Active project"
           value={selectedProjectId}
           onChange={(e) => setSelectedProjectId(e.target.value)}
-          className="h-9 w-full appearance-none rounded-[var(--radius)] border border-edge bg-panel pl-8 pr-8 text-[13px] text-fg transition-colors hover:bg-panel2 focus-visible:bg-panel2 focus-visible:outline-none"
+          className="h-9 w-full appearance-none rounded-none border border-edge bg-panel pl-8 pr-8 text-[13px] text-fg transition-colors hover:bg-panel2 focus-visible:bg-panel2 focus-visible:outline-none"
         >
           {projects.map((p) => (
             <option key={p.id} value={p.id}>
@@ -522,10 +523,10 @@ export function AppShell({ children }: { children: ReactNode }) {
         <div className="flex min-h-[100dvh] bg-base">
           {/* sidebar (desktop) */}
           <aside className="hidden w-[244px] shrink-0 border-r border-edge lg:flex lg:flex-col">
-            <div className="flex h-14 items-center gap-2.5 border-b border-edge-soft px-5">
-              <a href="/dashboard/" className="flex items-center gap-2 text-fg">
-                <LogoMark size={20} />
-                <span className="text-[14.5px] font-semibold tracking-tight">AgentState</span>
+            <div className="flex h-11 items-center gap-2.5 border-b border-edge-soft px-4">
+              <a href="/dashboard/" className="flex items-center gap-2 font-mono text-[13px] text-fg">
+                <LogoMark size={16} />
+                <span><span className="text-muted-foreground">~/</span>agentstate</span>
               </a>
             </div>
             <SidebarOrgScope />
@@ -552,16 +553,16 @@ export function AppShell({ children }: { children: ReactNode }) {
                 menuOpen ? "translate-x-0" : "-translate-x-full"
               }`}
             >
-              <div className="flex h-14 items-center justify-between gap-2.5 border-b border-edge-soft px-5">
-                <a href="/dashboard/" className="flex items-center gap-2 text-fg">
-                  <LogoMark size={20} />
-                  <span className="text-[14.5px] font-semibold tracking-tight">AgentState</span>
+              <div className="flex h-11 items-center justify-between gap-2.5 border-b border-edge-soft px-4">
+                <a href="/dashboard/" className="flex items-center gap-2 font-mono text-[13px] text-fg">
+                  <LogoMark size={16} />
+                  <span><span className="text-muted-foreground">~/</span>agentstate</span>
                 </a>
                 <button
                   type="button"
                   onClick={() => setMenuOpen(false)}
                   aria-label="Close menu"
-                  className="grid size-9 place-items-center rounded-[var(--radius)] text-fg-3 transition-[background-color,color,transform] duration-150 hover:bg-panel2 hover:text-fg active:scale-[0.96]"
+                  className="grid size-8 place-items-center rounded-none text-fg-3 transition-colors hover:bg-panel2 hover:text-fg"
                 >
                   <X size={18} />
                 </button>
@@ -574,12 +575,12 @@ export function AppShell({ children }: { children: ReactNode }) {
 
           {/* main */}
           <div className="flex min-w-0 flex-1 flex-col">
-            <header className="sticky top-0 z-10 flex h-14 items-center gap-3 border-b border-edge bg-base/85 px-5 backdrop-blur sm:px-7">
+            <header className="sticky top-0 z-10 flex h-11 items-center gap-3 border-b border-edge bg-background px-4 sm:px-6">
               <button
                 type="button"
                 onClick={() => setMenuOpen(true)}
                 aria-label="Open menu"
-                className="grid size-9 shrink-0 place-items-center rounded-[var(--radius)] text-fg-3 transition-[background-color,color,transform] duration-150 hover:bg-panel2 hover:text-fg active:scale-[0.96] lg:hidden"
+                className="grid size-8 shrink-0 place-items-center rounded-none text-fg-3 transition-colors hover:bg-panel2 hover:text-fg lg:hidden"
               >
                 <List size={18} />
               </button>
@@ -589,18 +590,18 @@ export function AppShell({ children }: { children: ReactNode }) {
                   type="button"
                   onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
                   aria-label="Toggle color theme"
-                  className="relative grid size-9 place-items-center overflow-hidden rounded-[var(--radius)] border border-edge text-fg-3 transition-[background-color,color,transform] duration-150 hover:bg-panel2 hover:text-fg active:scale-[0.96]"
+                  className="relative grid h-8 place-items-center overflow-hidden rounded-none px-2 font-mono text-[12px] text-muted-foreground transition-colors hover:bg-panel2 hover:text-fg"
                 >
                   <AnimatePresence initial={false} mode="popLayout">
                     <motion.span
                       key={theme === "dark" ? "moon" : "sun"}
-                      initial={{ opacity: 0, scale: 0.25, filter: "blur(4px)" }}
-                      animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
-                      exit={{ opacity: 0, scale: 0.25, filter: "blur(4px)" }}
-                      transition={{ type: "spring", duration: 0.3, bounce: 0 }}
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      exit={{ opacity: 0 }}
+                      transition={{ duration: 0.15 }}
                       className="grid place-items-center"
                     >
-                      {theme === "dark" ? <Moon size={18} /> : <Sun size={18} />}
+                      [{theme === "dark" ? "theme" : "theme"}]
                     </motion.span>
                   </AnimatePresence>
                 </button>
@@ -612,7 +613,15 @@ export function AppShell({ children }: { children: ReactNode }) {
                 <UserButton />
               </div>
             </header>
-            <main className="flex-1 pt-7 pb-20 lg:pt-8">{children}</main>
+            <main className="flex-1 pt-6 pb-16 lg:pt-7">{children}</main>
+            <footer className="hidden border-t border-edge px-4 py-1.5 font-mono text-[11px] text-muted-foreground sm:flex sm:items-center sm:justify-between">
+              <span>
+                <span className="text-foreground">main</span>
+                <span className="px-2">·</span>
+                agentstate dashboard
+              </span>
+              <span>F1 commands · Ctrl+K keys · typescript</span>
+            </footer>
           </div>
         </div>
       </ProjectScopeProvider>
@@ -627,10 +636,11 @@ function Breadcrumb({ pathname }: { pathname: string }) {
     .filter(Boolean);
   const tail = seg.length > 1 ? seg[seg.length - 1] : (seg[0] ?? "");
   return (
-    <span className="font-mono text-[13px] text-fg-4">
-      <span className="text-fg-4">agentstate</span>
-      <span className="px-1.5 text-edge">/</span>
-      <span className="text-fg-2">{tail || "dashboard"}</span>
+    <span className="font-mono text-[13px] text-muted-foreground">
+      <span className="tui-key">~/agentstate</span>
+      <span className="px-1.5 text-border">/</span>
+      <span className="text-foreground">{tail || "dashboard"}</span>
+      <span className="px-1.5 text-muted-foreground">$</span>
     </span>
   );
 }

--- a/packages/dashboard/src/components/dashboard/page-header.tsx
+++ b/packages/dashboard/src/components/dashboard/page-header.tsx
@@ -51,8 +51,14 @@ export function PageHeader({ title, description, actions }: PageHeaderProps) {
   return (
     <header className="mb-[22px] flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
       <div className="flex max-w-2xl flex-col gap-1.5">
-        <h1 className="text-2xl font-semibold tracking-tight text-foreground">{title}</h1>
-        {description && <p className="text-sm text-muted-foreground">{description}</p>}
+        <h1 className="text-2xl font-medium tracking-tight text-foreground">
+          <span className="tui-hash">#</span> {title}
+        </h1>
+        {description && (
+          <p className="text-sm text-muted-foreground">
+            <span className="tui-hash">$</span> {description}
+          </p>
+        )}
       </div>
       {actions && <div className="flex flex-wrap items-center gap-2 sm:justify-end">{actions}</div>}
     </header>

--- a/packages/dashboard/src/components/docs/docs-nav.tsx
+++ b/packages/dashboard/src/components/docs/docs-nav.tsx
@@ -49,7 +49,7 @@ export function DocsNav() {
                 aria-current={active === id ? "true" : undefined}
                 onClick={() => setActive(id)}
                 className={cn(
-                  "rounded-[var(--radius)] px-2.5 py-1.5 text-left text-[13.5px] transition-colors",
+                  "rounded-none px-2.5 py-1.5 text-left text-[13px] transition-colors",
                   active === id
                     ? "bg-panel2 font-semibold text-fg"
                     : "font-medium text-fg-3 hover:text-fg",

--- a/packages/dashboard/src/components/home/code-tabs.astro
+++ b/packages/dashboard/src/components/home/code-tabs.astro
@@ -53,7 +53,7 @@ const highlighted = await Promise.all(
       />
       <div class="ct-panel">
         <script type="text/plain" id={`ct-src-${uid}-${i}`} set:html={t.code} />
-        <div class="as-shiki overflow-hidden bg-background p-4" set:html={t.html} />
+        <div class="as-shiki overflow-hidden bg-[#0d1117] p-4" set:html={t.html} />
       </div>
     </>
   ))}

--- a/packages/dashboard/src/components/home/code-tabs.astro
+++ b/packages/dashboard/src/components/home/code-tabs.astro
@@ -23,16 +23,16 @@ const highlighted = await Promise.all(
   })),
 );
 ---
-<div class={`codetabs overflow-hidden rounded-xl border border-border bg-card ${cls}`} data-codetabs={uid}>
-  <div class="ct-bar flex flex-wrap items-center gap-1 border-b border-border bg-muted px-2 py-1.5">
+<div class={`codetabs overflow-hidden rounded-none border border-border bg-background ${cls}`} data-codetabs={uid}>
+  <div class="ct-bar flex flex-wrap items-center gap-1 border-b border-border px-2 py-1">
     {highlighted.map((t, i) => (
-      <label for={`ct-${uid}-${i}`} class="ct-tab cursor-pointer select-none rounded-[var(--radius-sm)] px-3 py-1 font-sans text-[12px] font-medium transition-colors">{t.label}</label>
+      <label for={`ct-${uid}-${i}`} class="ct-tab cursor-pointer select-none px-3 py-1 font-mono text-[12px] transition-colors">{t.label}</label>
     ))}
-    <span class="ct-lang ml-auto shrink-0 font-sans text-[11px] text-muted-foreground" data-ct-lang>{highlighted[0]?.shikiLang}</span>
+    <span class="ct-lang ml-auto shrink-0 font-mono text-[11px] text-muted-foreground" data-ct-lang>{highlighted[0]?.shikiLang}</span>
     {copyable && (
       <button
         type="button"
-        class="ct-copy ml-1 inline-flex shrink-0 items-center gap-1 rounded-[var(--radius-sm)] px-2 py-1 font-sans text-[11px] text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
+        class="ct-copy ml-1 inline-flex shrink-0 items-center gap-1 px-2 py-1 font-mono text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
         data-ct-copy
         aria-label="Copy code"
       >
@@ -53,7 +53,7 @@ const highlighted = await Promise.all(
       />
       <div class="ct-panel">
         <script type="text/plain" id={`ct-src-${uid}-${i}`} set:html={t.code} />
-        <div class="as-shiki overflow-hidden bg-[#0c0c0e] p-4" set:html={t.html} />
+        <div class="as-shiki overflow-hidden bg-background p-4" set:html={t.html} />
       </div>
     </>
   ))}

--- a/packages/dashboard/src/components/home/how-it-works.astro
+++ b/packages/dashboard/src/components/home/how-it-works.astro
@@ -56,7 +56,7 @@ const lifecycle = [
                 aria-hidden="true"
               />
             )}
-            <span class="relative z-[1] grid size-8 shrink-0 place-items-center rounded-full border border-border bg-card font-mono text-[11px] text-accent">
+            <span class="relative z-[1] grid size-8 shrink-0 place-items-center rounded-none border border-border bg-background font-mono text-[11px] text-primary">
               {step.n}
             </span>
             <div class="pt-0.5">

--- a/packages/dashboard/src/components/home/hub-diagram.astro
+++ b/packages/dashboard/src/components/home/hub-diagram.astro
@@ -65,7 +65,7 @@ const ROW_GAP = 22;
       y={CARD.y}
       width={CARD.w}
       height={CARD.h}
-      rx="14"
+      rx="0"
       fill="var(--color-panel2)"
       stroke="var(--color-accent)"
       stroke-width="1.5"
@@ -75,7 +75,7 @@ const ROW_GAP = 22;
       y={CARD.y}
       width={CARD.w}
       height={CARD.h}
-      rx="14"
+      rx="0"
       fill="none"
       stroke="var(--color-accent)"
       stroke-width="1.5"
@@ -115,7 +115,7 @@ const ROW_GAP = 22;
     <!-- agents -->
     {agents.map((a, i) => (
       <g class="as-pulse" style={`animation-delay:${i * 0.3}s`}>
-        <circle cx={a.x} cy={a.y} r="30" fill="var(--color-panel2)" stroke="var(--color-edge)" stroke-width="1.5" />
+        <rect x={a.x - 32} y={a.y - 22} width="64" height="44" fill="var(--color-panel2)" stroke="var(--color-edge)" stroke-width="1.5" />
         <text
           x={a.x}
           y={a.y - 1}

--- a/packages/dashboard/src/components/home/packages-grid.astro
+++ b/packages/dashboard/src/components/home/packages-grid.astro
@@ -60,7 +60,7 @@ const packages = [
       <div class="font-mono text-[11px] uppercase tracking-wider text-muted-foreground">{pkg.ecosystem}</div>
       <h3 class="mt-2 font-mono text-[15px] font-medium text-foreground">{pkg.name}</h3>
       <p class="mt-2 flex-1 text-[13.5px] leading-relaxed text-muted-foreground">{pkg.body}</p>
-      <div class="mt-4 overflow-x-auto rounded-none border border-border bg-background px-3 py-2">
+      <div class="mt-4 overflow-x-auto rounded-none border border-border bg-[#0d1117] px-3 py-2">
         <code class="font-mono text-[12px] text-fg-2">{pkg.install}</code>
       </div>
       {pkg.extras.length > 0 && (

--- a/packages/dashboard/src/components/home/packages-grid.astro
+++ b/packages/dashboard/src/components/home/packages-grid.astro
@@ -56,11 +56,11 @@ const packages = [
 ---
 <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
   {packages.map((pkg) => (
-    <article class="flex flex-col rounded-xl border border-border bg-card p-6 transition-colors hover:bg-muted/40">
+    <article class="flex flex-col rounded-none border border-border bg-background p-5">
       <div class="font-mono text-[11px] uppercase tracking-wider text-muted-foreground">{pkg.ecosystem}</div>
       <h3 class="mt-2 font-mono text-[15px] font-medium text-foreground">{pkg.name}</h3>
       <p class="mt-2 flex-1 text-[13.5px] leading-relaxed text-muted-foreground">{pkg.body}</p>
-      <div class="mt-4 overflow-x-auto rounded-[var(--radius)] border border-border bg-[#0c0c0e] px-3 py-2">
+      <div class="mt-4 overflow-x-auto rounded-none border border-border bg-background px-3 py-2">
         <code class="font-mono text-[12px] text-fg-2">{pkg.install}</code>
       </div>
       {pkg.extras.length > 0 && (

--- a/packages/dashboard/src/components/home/tui-editor.astro
+++ b/packages/dashboard/src/components/home/tui-editor.astro
@@ -1,0 +1,74 @@
+---
+/**
+ * Decorative TUI editor mock — landing-page centerpiece, druk-style.
+ * Static HTML; not interactive. Screen readers get a short description.
+ */
+interface Props {
+  class?: string;
+}
+const { class: cls = "" } = Astro.props;
+
+const kw = "text-[#c678dd]";
+const fn = "text-[#61afef]";
+const ty = "text-[#e5c07b]";
+const str = "text-primary";
+const dim = "text-muted-foreground";
+const fg = "text-foreground";
+---
+<div
+  class={`tui-window overflow-hidden text-[12px] leading-[1.7] ${cls}`}
+  role="img"
+  aria-label="Terminal editor mockup showing AgentState TypeScript SDK: create a conversation, a folded openFile helper, and searchConversations, with a file tree and status bar."
+>
+  <div class="flex flex-wrap items-center gap-x-4 gap-y-1 border-b border-border px-3 py-1.5 text-muted-foreground">
+    <span class="text-foreground"><span class="mr-1.5 text-foreground">●</span>conversations.ts</span>
+    <span>leases.ts</span>
+    <span>mcp.ts</span>
+    <span>analytics.ts</span>
+  </div>
+
+  <div class="grid min-h-[280px] sm:grid-cols-[9.5rem_minmax(0,1fr)]">
+    <div class="hidden border-r border-border sm:block">
+      <div class="flex gap-3 border-b border-border px-3 py-1.5 text-[11px] text-muted-foreground">
+        <span class="text-foreground">Files</span>
+        <span>Git</span>
+        <span>Review</span>
+      </div>
+      <div class="space-y-0.5 px-3 py-2 font-mono text-[11.5px] text-muted-foreground">
+        <div>src/</div>
+        <div class="pl-3">api/</div>
+        <div class="pl-3 text-foreground">sdk/ <span class="text-[#58a6ff]">M</span></div>
+        <div class="pl-6 text-foreground">index.ts</div>
+        <div class="pl-6">client.ts</div>
+        <div class="pl-3">dashboard/</div>
+        <div class="pl-3">python-sdk/ <span class="text-primary">U</span></div>
+      </div>
+    </div>
+
+    <div class="min-w-0 overflow-x-auto bg-background px-2 py-2 sm:px-3">
+      <pre class="min-w-[36rem] font-mono text-[12px] leading-[1.75]"><code>
+<span class={dim}>  1 </span><span class={kw}>import</span> <span class={fg}>&#123; AgentState &#125;</span> <span class={kw}>from</span> <span class={str}>"@agentstate/sdk"</span><span class={dim}>;</span>
+<span class={dim}>  2 </span>
+<span class={dim}>  3 </span><span class={kw}>const</span> <span class={fn}>client</span> <span class={dim}>=</span> <span class={kw}>new</span> <span class={ty}>AgentState</span><span class={fg}>(&#123;</span>
+<span class={dim}>  4 </span>  apiKey: <span class={fn}>process</span>.env.<span class={ty}>AS_KEY</span>,
+<span class={dim}>  5 </span><span class={fg}>&#125;)</span><span class={dim}>;</span>
+<span class={dim}>  6 </span>
+<span class={dim}>  7 </span><span class={kw}>const</span> <span class={fn}>conv</span> <span class={dim}>=</span> <span class={kw}>await</span> client.<span class={fn}>createConversation</span><span class={fg}>(&#123;</span>
+<span class={dim}>  8 </span>  messages: <span class={fg}>[&#123;</span> role: <span class={str}>"user"</span>, content: <span class={str}>"Summarize findings"</span> <span class={fg}>&#125;]</span>,
+<span class={dim}>  9 </span><span class={fg}>&#125;)</span><span class={dim}>;</span>
+<span class={dim}> 18 </span><span class={kw}>function</span> <span class={fn}>openFile</span>(path: <span class={ty}>string</span>) <span class={fg}>&#123;</span> <span class={dim}>… 24 lines</span> <span class={dim}>Ctrl+Opt+E</span>
+<span class={dim}> 43 </span>
+<span class={dim}> 44 </span><span class={kw}>const</span> <span class={fn}>hits</span> <span class={dim}>=</span> <span class={kw}>await</span> client.<span class={fn}>searchConversations</span><span class={fg}>(&#123;</span>
+<span class={dim}> 45 </span>  query: <span class={str}>"lease"</span>,
+<span class={dim}> 46 </span><span class={fg}>&#125;)</span><span class={dim}>;</span>
+<span class={dim}>    </span><span class="ml-8 inline-flex items-center gap-2 border border-[#d29922]/50 bg-[#d29922]/10 px-2 py-0.5 text-[11px] text-[#d29922]"><span aria-hidden="true">▲</span> 'autosave' is deprecated · F8</span>
+</code></pre>
+    </div>
+  </div>
+
+  <div class="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 border-t border-border px-3 py-1 text-[11px] text-muted-foreground">
+    <span><span class="text-foreground">main</span> ↑1 ~3 <span class="ml-2 text-destructive">● 1</span> <span class="text-[#d29922]">▲ 2</span></span>
+    <span class="hidden sm:inline">F1 commands · Ctrl+K keys · Ctrl+P open</span>
+    <span>Ln 46, Col 41 · typescript</span>
+  </div>
+</div>

--- a/packages/dashboard/src/components/home/tui-editor.astro
+++ b/packages/dashboard/src/components/home/tui-editor.astro
@@ -45,7 +45,7 @@ const fg = "text-foreground";
       </div>
     </div>
 
-    <div class="min-w-0 overflow-x-auto bg-background px-2 py-2 sm:px-3">
+    <div class="min-w-0 overflow-x-auto bg-[#0d1117] px-2 py-2 sm:px-3">
       <pre class="min-w-[36rem] font-mono text-[12px] leading-[1.75]"><code>
 <span class={dim}>  1 </span><span class={kw}>import</span> <span class={fg}>&#123; AgentState &#125;</span> <span class={kw}>from</span> <span class={str}>"@agentstate/sdk"</span><span class={dim}>;</span>
 <span class={dim}>  2 </span>

--- a/packages/dashboard/src/components/providers.tsx
+++ b/packages/dashboard/src/components/providers.tsx
@@ -5,8 +5,9 @@ import { Toaster } from "sonner";
 // Keep Clerk's <SignIn/> and <UserButton/> aligned with the applied preset.
 const clerkAppearance = {
   variables: {
-    borderRadius: "var(--radius)",
-    fontFamily: "var(--font-sans)",
+    borderRadius: "0",
+    fontFamily: "var(--font-mono)",
+    colorPrimary: "var(--primary)",
   },
 };
 
@@ -24,7 +25,11 @@ export function Providers({ children }: { children: React.ReactNode }) {
     <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
       <ClerkProvider publishableKey={publishableKey} appearance={clerkAppearance}>
         {children}
-        <Toaster richColors position="bottom-right" />
+        <Toaster
+          richColors
+          position="bottom-right"
+          toastOptions={{ className: "rounded-none font-mono" }}
+        />
       </ClerkProvider>
     </ThemeProvider>
   );

--- a/packages/dashboard/src/components/providers.tsx
+++ b/packages/dashboard/src/components/providers.tsx
@@ -22,7 +22,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
     // `attribute="class"` keeps next-themes from fighting the inline script
     // by writing a separate data-theme attribute that global.css/tokens.css
     // don't key their color tokens off.
-    <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
+    <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
       <ClerkProvider publishableKey={publishableKey} appearance={clerkAppearance}>
         {children}
         <Toaster

--- a/packages/dashboard/src/components/theme-script.astro
+++ b/packages/dashboard/src/components/theme-script.astro
@@ -1,7 +1,9 @@
 ---
 /**
  * Inline (pre-hydration) theme script — included in <head> by both layouts.
- * 1. Applies the saved/system theme before paint (no FOUC).
+ * 1. Applies the saved theme before paint (no FOUC). Defaults to dark
+ *    (terminal TUI) when localStorage has no explicit choice.
+ * 2. Delegates clicks on any [data-theme-toggle] to flip + persist the theme.
  * 2. Delegates clicks on any [data-theme-toggle] to flip + persist the theme.
  * `is:inline` so it runs immediately and is not bundled/delayed.
  *
@@ -18,7 +20,8 @@
   is:inline
   set:html={`(function () {
   var el = document.documentElement;
-  var d = localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  var stored = localStorage.theme;
+  var d = stored ? stored === 'dark' : true;
   el.classList.toggle('dark', d);
   el.setAttribute('data-mode', d ? 'dark' : 'light');
   el.setAttribute('data-theme', d ? 'dark' : 'light');

--- a/packages/dashboard/src/components/ui/badge.astro
+++ b/packages/dashboard/src/components/ui/badge.astro
@@ -19,7 +19,7 @@ const dotColor: Record<NonNullable<Props["tone"]>, string> = {
   idle: "bg-fg-4",
 };
 ---
-<span class={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 font-mono text-[11px] ${tones[tone]} ${cls}`}>
+<span class={`inline-flex items-center gap-1.5 rounded-none border px-2 py-0.5 font-mono text-[11px] ${tones[tone]} ${cls}`}>
   {dot && <span class={`size-1.5 rounded-full ${dotColor[tone]}`}></span>}
   <slot />
 </span>

--- a/packages/dashboard/src/components/ui/badge.tsx
+++ b/packages/dashboard/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-2xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-none border border-transparent px-2 py-0.5 font-mono text-xs font-medium whitespace-nowrap transition-colors focus-visible:border-ring has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive [&>svg]:pointer-events-none [&>svg]:size-3!",
   {
     variants: {
       variant: {

--- a/packages/dashboard/src/components/ui/button.tsx
+++ b/packages/dashboard/src/components/ui/button.tsx
@@ -4,22 +4,22 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-2xl border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-none border border-transparent bg-clip-padding font-mono text-sm font-medium whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:outline focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/80",
-        primary: "bg-primary text-primary-foreground hover:bg-primary/80",
+        default: "border-primary bg-primary text-primary-foreground hover:opacity-90",
+        primary: "border-primary bg-primary text-primary-foreground hover:opacity-90",
         outline:
-          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:bg-transparent dark:hover:bg-input/30",
+          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+          "border-border bg-secondary text-secondary-foreground hover:bg-muted aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         ghost:
-          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground",
         destructive:
-          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+          "border-destructive/40 bg-destructive/10 text-destructive hover:bg-destructive/20",
         danger:
-          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+          "border-destructive/40 bg-destructive/10 text-destructive hover:bg-destructive/20",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/packages/dashboard/src/components/ui/card.astro
+++ b/packages/dashboard/src/components/ui/card.astro
@@ -4,6 +4,6 @@ interface Props {
 }
 const { class: cls = "" } = Astro.props;
 ---
-<div class={`rounded-[var(--radius-lg)] border border-edge bg-panel ${cls}`}>
+<div class={`rounded-none border border-edge bg-panel ${cls}`}>
   <slot />
 </div>

--- a/packages/dashboard/src/components/ui/card.tsx
+++ b/packages/dashboard/src/components/ui/card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-[min(var(--radius-4xl),24px)] bg-card py-(--card-spacing) text-sm text-card-foreground shadow-sm ring-1 ring-foreground/5 [--card-spacing:--spacing(5)] has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(4)] dark:ring-foreground/10 *:[img:first-child]:rounded-t-[min(var(--radius-4xl),24px)] *:[img:last-child]:rounded-b-[min(var(--radius-4xl),24px)]",
+        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-none border border-border bg-card py-(--card-spacing) font-mono text-sm text-card-foreground shadow-none [--card-spacing:--spacing(5)] has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(4)]",
         className
       )}
       {...props}
@@ -25,7 +25,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-header"
       className={cn(
-        "group/card-header @container/card-header grid auto-rows-min items-start gap-1.5 rounded-t-[min(var(--radius-4xl),24px)] px-(--card-spacing) has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)",
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1.5 rounded-none px-(--card-spacing) has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)",
         className
       )}
       {...props}
@@ -37,7 +37,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-title"
-      className={cn("font-heading text-base font-medium", className)}
+      className={cn("font-mono text-base font-medium", className)}
       {...props}
     />
   )
@@ -81,7 +81,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-footer"
       className={cn(
-        "flex items-center rounded-b-[min(var(--radius-4xl),24px)] px-(--card-spacing) [.border-t]:pt-(--card-spacing)",
+        "flex items-center rounded-none px-(--card-spacing) [.border-t]:pt-(--card-spacing)",
         className
       )}
       {...props}

--- a/packages/dashboard/src/components/ui/code-block.astro
+++ b/packages/dashboard/src/components/ui/code-block.astro
@@ -38,7 +38,7 @@ const label = filename ?? resolveLang(lang);
       </button>
     )}
   </div>
-  <div class="overflow-auto bg-background p-4" set:html={html} />
+  <div class="overflow-auto bg-[#0d1117] p-4" set:html={html} />
 </div>
 
 <script>

--- a/packages/dashboard/src/components/ui/code-block.astro
+++ b/packages/dashboard/src/components/ui/code-block.astro
@@ -24,7 +24,7 @@ const { code, lang, filename, copyable = true, class: cls = "" } = Astro.props;
 const html = await highlightCode(code, lang);
 const label = filename ?? resolveLang(lang);
 ---
-<div class={`overflow-hidden rounded-[var(--radius-lg)] border border-edge bg-panel ${cls}`}>
+<div class={`overflow-hidden rounded-none border border-edge bg-panel ${cls}`}>
   <div class="flex h-9 items-center justify-between border-b border-edge-soft px-4">
     <span class="font-mono text-[11px] text-fg-4">{label}</span>
     {copyable && (
@@ -38,7 +38,7 @@ const label = filename ?? resolveLang(lang);
       </button>
     )}
   </div>
-  <div class="overflow-auto bg-[#0c0c0e] p-4" set:html={html} />
+  <div class="overflow-auto bg-background p-4" set:html={html} />
 </div>
 
 <script>

--- a/packages/dashboard/src/components/ui/dialog.tsx
+++ b/packages/dashboard/src/components/ui/dialog.tsx
@@ -29,7 +29,7 @@ function DialogOverlay({
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 isolate z-50 bg-black/30 duration-100 supports-backdrop-filter:backdrop-blur-sm data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 isolate z-50 bg-black/50 duration-100 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className
       )}
       {...props}
@@ -55,7 +55,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-[min(var(--radius-4xl),24px)] bg-popover p-6 text-sm text-popover-foreground shadow-xl ring-1 ring-foreground/5 duration-100 outline-none sm:max-w-md dark:ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-none border border-border bg-popover p-6 font-mono text-sm text-popover-foreground shadow-none duration-100 outline-none sm:max-w-md data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
           className
         )}
         {...props}
@@ -130,7 +130,7 @@ function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
     <DialogPrimitive.Title
       data-slot="dialog-title"
       className={cn(
-        "font-heading text-base leading-none font-medium",
+        "font-mono text-base leading-none font-medium",
         className
       )}
       {...props}

--- a/packages/dashboard/src/components/ui/input.tsx
+++ b/packages/dashboard/src/components/ui/input.tsx
@@ -41,7 +41,7 @@ function Input({
         aria-describedby={describedBy}
         aria-invalid={error ? true : undefined}
         className={cn(
-          "h-8 w-full min-w-0 rounded-2xl border border-transparent bg-input/50 px-2.5 py-1 text-base transition-[color,box-shadow] duration-200 outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+          "h-8 w-full min-w-0 rounded-none border border-border bg-background px-2.5 py-1 font-mono text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-primary disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive md:text-sm",
           mono && "font-mono",
           className
         )}
@@ -90,7 +90,7 @@ const Textarea = React.forwardRef<
         aria-describedby={describedBy}
         aria-invalid={error ? true : undefined}
         className={cn(
-          "flex min-h-[80px] w-full resize-y rounded-2xl border border-transparent bg-input/50 px-2.5 py-2 text-[13px] text-foreground outline-none transition-[color,box-shadow] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex min-h-[80px] w-full resize-y rounded-none border border-border bg-background px-2.5 py-2 font-mono text-[13px] text-foreground outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-primary disabled:cursor-not-allowed disabled:opacity-50",
           mono && "font-mono",
           className
         )}
@@ -158,7 +158,7 @@ const Select = React.forwardRef<
             aria-describedby={describedBy}
             aria-invalid={error ? true : undefined}
             className={cn(
-              "flex h-8 w-full appearance-none rounded-2xl border border-transparent bg-input/50 px-2.5 py-1 pr-10 text-[13px] text-foreground outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50",
+              "flex h-8 w-full appearance-none rounded-none border border-border bg-background px-2.5 py-1 pr-10 font-mono text-[13px] text-foreground outline-none transition-colors focus-visible:border-primary disabled:cursor-not-allowed disabled:opacity-50",
               mono && "font-mono",
               className
             )}

--- a/packages/dashboard/src/components/ui/toggle.tsx
+++ b/packages/dashboard/src/components/ui/toggle.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const toggleVariants = cva(
-  "group/toggle inline-flex items-center justify-center gap-1 rounded-2xl text-sm font-medium whitespace-nowrap transition-colors outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/30 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-none font-mono text-sm font-medium whitespace-nowrap transition-colors outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:outline focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-pressed:bg-muted [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/packages/dashboard/src/layouts/MarketingLayout.astro
+++ b/packages/dashboard/src/layouts/MarketingLayout.astro
@@ -1,6 +1,5 @@
 ---
 import "../styles/global.css";
-import Logo from "../components/logo.astro";
 import RevealScript from "../components/reveal-script.astro";
 import ThemeScript from "../components/theme-script.astro";
 import { GITHUB_URL, SITE_URL } from "../lib/site";
@@ -31,10 +30,10 @@ const canonicalUrl = new URL(canonical ?? Astro.url.pathname, SITE).href;
 // 307 hop through Workers Assets.
 // biome-ignore lint/correctness/noUnusedVariables: used in the template below
 const navLinks = [
-  { href: "/docs/", label: "Docs", external: false },
-  { href: "/compare/", label: "Compare", external: false },
-  { href: "/pricing/", label: "Pricing", external: false },
-  { href: GITHUB_URL, label: "GitHub", external: true },
+  { href: "/docs/", label: "docs", external: false },
+  { href: "/compare/", label: "compare", external: false },
+  { href: "/pricing/", label: "pricing", external: false },
+  { href: GITHUB_URL, label: "github", external: true },
 ] as const;
 ---
 <!doctype html>
@@ -63,56 +62,48 @@ const navLinks = [
     <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png" />
     <ThemeScript />
   </head>
-  <body class="min-h-screen bg-background text-foreground">
-    <!-- top nav -->
-    <header class="sticky top-0 z-40 border-b border-border bg-background/85 backdrop-blur">
-      <div class="mx-auto flex h-16 w-full max-w-6xl items-center gap-2.5 px-6">
-        <a href="/" class="flex items-center gap-2 text-foreground"><Logo size={20} /><span class="text-[15px] font-semibold tracking-tight">AgentState</span></a>
-        <nav class="ml-8 hidden items-center gap-6 text-[13.5px] text-muted-foreground sm:flex">
+  <body class="min-h-screen bg-background font-mono text-foreground">
+    <header class="sticky top-0 z-40 border-b border-border bg-background">
+      <div class="mx-auto flex h-11 w-full max-w-[920px] items-center gap-3 px-5 sm:px-8">
+        <a href="/" class="shrink-0 text-[13px] text-foreground hover:text-primary">
+          <span class="tui-prompt">~/</span>agentstate
+        </a>
+        <nav class="ml-auto hidden items-center gap-3 text-[13px] sm:flex">
           {navLinks.map((l) => (
             <a
               href={l.href}
-              class="hover:text-foreground"
+              class="text-muted-foreground hover:text-foreground"
               {...(l.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
-            >{l.label}</a>
+            ><span class="tui-bracket">[</span>{l.label}<span class="tui-bracket">]</span></a>
           ))}
         </nav>
-        <div class="ml-auto flex items-center gap-2">
+        <div class="ml-auto flex items-center gap-3 sm:ml-3">
           <button
             type="button"
             data-theme-toggle
             aria-label="Toggle color theme"
-            class="grid size-8 place-items-center rounded-[var(--radius)] border border-border text-muted-foreground transition-[background-color,color] hover:bg-muted hover:text-foreground"
+            class="text-[13px] text-muted-foreground hover:text-foreground"
           >
-            <span class="icon-moon"
-              ><svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path
-                  d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8z" /></svg></span
-            >
-            <span class="icon-sun"
-              ><svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle
-                  cx="12"
-                  cy="12"
-                  r="4" /><path
-                  d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" /></svg></span
-            >
+            <span class="icon-moon">[theme]</span>
+            <span class="icon-sun">[theme]</span>
           </button>
-          <a href="/dashboard/" class="rounded-[var(--radius)] bg-primary px-3.5 py-1.5 text-[13px] font-medium text-primary-foreground transition-opacity hover:opacity-90">Start for free</a>
-          <!-- mobile nav: the inline <nav> above is sm+ only, so without this
-               Docs/Compare/Pricing/GitHub are unreachable on phones. -->
+          <a href="/dashboard/" class="text-[13px] text-primary hover:opacity-80">
+            <span class="tui-bracket">[</span>start<span class="tui-bracket">]</span>
+          </a>
           <details class="relative sm:hidden" data-nav-menu>
             <summary
-              class="grid size-8 cursor-pointer list-none place-items-center rounded-[var(--radius)] border border-border text-muted-foreground transition-[background-color,color] hover:bg-muted hover:text-foreground [&::-webkit-details-marker]:hidden"
+              class="cursor-pointer list-none text-[13px] text-muted-foreground hover:text-foreground [&::-webkit-details-marker]:hidden"
               aria-label="Open navigation menu"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
+              [menu]
             </summary>
-            <nav class="absolute right-0 top-[calc(100%+0.5rem)] z-50 flex w-44 flex-col rounded-[var(--radius)] border border-border bg-background p-1.5 shadow-lg">
+            <nav class="absolute right-0 top-[calc(100%+0.5rem)] z-50 flex w-44 flex-col border border-border bg-background p-2">
               {navLinks.map((l) => (
                 <a
                   href={l.href}
-                  class="rounded-[calc(var(--radius)-2px)] px-3 py-2 text-[13.5px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  class="px-2 py-1.5 text-[13px] text-muted-foreground hover:bg-muted hover:text-foreground"
                   {...(l.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
-                >{l.label}</a>
+                ><span class="tui-bracket">[</span>{l.label}<span class="tui-bracket">]</span></a>
               ))}
             </nav>
           </details>
@@ -134,38 +125,41 @@ const navLinks = [
     </script>
     <slot />
     <footer class="border-t border-border">
-      <div class="mx-auto w-full max-w-6xl px-6 py-16">
-        <div class="grid grid-cols-2 gap-8 sm:grid-cols-4">
+      <div class="mx-auto flex w-full max-w-[920px] flex-col gap-6 px-5 py-8 sm:px-8">
+        <div class="grid grid-cols-2 gap-6 text-[13px] sm:grid-cols-4">
           <div class="col-span-2 sm:col-span-1">
-            <a href="/" class="flex items-center gap-1.5 text-foreground"><Logo size={16} /><span class="text-[14px] font-semibold tracking-tight">AgentState</span></a>
-            <p class="mt-3 max-w-[220px] text-[13px] leading-relaxed text-muted-foreground">Conversation history &amp; coordination database for AI agent fleets.</p>
+            <a href="/" class="text-foreground"><span class="tui-prompt">~/</span>agentstate</a>
+            <p class="mt-2 max-w-[240px] text-[12px] leading-relaxed text-muted-foreground">
+              Conversation history &amp; coordination database for AI agent fleets.
+            </p>
           </div>
           <div>
-            <div class="text-[12px] font-medium text-foreground">Product</div>
-            <ul class="mt-3 flex flex-col gap-2 text-[13px] text-muted-foreground">
-              <li><a href="/docs/" class="hover:text-foreground">Docs</a></li>
-              <li><a href="/compare/" class="hover:text-foreground">Compare</a></li>
-              <li><a href="/pricing/" class="hover:text-foreground">Pricing</a></li>
-              <li><a href="/dashboard/" class="hover:text-foreground">Dashboard</a></li>
+            <div class="tui-key">product</div>
+            <ul class="mt-2 flex flex-col gap-1 text-muted-foreground">
+              <li><a href="/docs/" class="hover:text-foreground">[docs]</a></li>
+              <li><a href="/compare/" class="hover:text-foreground">[compare]</a></li>
+              <li><a href="/pricing/" class="hover:text-foreground">[pricing]</a></li>
+              <li><a href="/dashboard/" class="hover:text-foreground">[dashboard]</a></li>
             </ul>
           </div>
           <div>
-            <div class="text-[12px] font-medium text-foreground">Company</div>
-            <ul class="mt-3 flex flex-col gap-2 text-[13px] text-muted-foreground">
-              <li><a href={GITHUB_URL} class="hover:text-foreground" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-              <li><a href={`${GITHUB_URL}/blob/main/LICENSE`} class="hover:text-foreground" target="_blank" rel="noopener noreferrer">License (MIT)</a></li>
+            <div class="tui-key">company</div>
+            <ul class="mt-2 flex flex-col gap-1 text-muted-foreground">
+              <li><a href={GITHUB_URL} class="hover:text-foreground" target="_blank" rel="noopener noreferrer">[github]</a></li>
+              <li><a href={`${GITHUB_URL}/blob/main/LICENSE`} class="hover:text-foreground" target="_blank" rel="noopener noreferrer">[license]</a></li>
             </ul>
           </div>
           <div>
-            <div class="text-[12px] font-medium text-foreground">Resources</div>
-            <ul class="mt-3 flex flex-col gap-2 text-[13px] text-muted-foreground">
-              <li><a href="/llms.txt" class="hover:text-foreground">/llms.txt</a></li>
-              <li><a href="/openapi.json" class="hover:text-foreground">/openapi.json</a></li>
+            <div class="tui-key">resources</div>
+            <ul class="mt-2 flex flex-col gap-1 text-muted-foreground">
+              <li><a href="/llms.txt" class="hover:text-foreground">[/llms.txt]</a></li>
+              <li><a href="/openapi.json" class="hover:text-foreground">[/openapi.json]</a></li>
             </ul>
           </div>
         </div>
-        <div class="mt-12 flex flex-col items-center justify-between gap-3 border-t border-border pt-6 text-[12px] text-muted-foreground sm:flex-row">
-          <span>© 2026 AgentState · MIT · built on Cloudflare D1</span>
+        <div class="flex flex-col gap-1 border-t border-border pt-4 text-[12px] text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+          <span>© 2026 AgentState · MIT · Cloudflare D1</span>
+          <span class="hidden sm:inline">F1 help · Ctrl+K keys · typescript</span>
         </div>
       </div>
     </footer>

--- a/packages/dashboard/src/layouts/RootLayout.astro
+++ b/packages/dashboard/src/layouts/RootLayout.astro
@@ -17,7 +17,7 @@ const {
 ---
 
 <!doctype html>
-<html lang="en" class="dark font-sans">
+<html lang="en" class="dark font-mono">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/dashboard/src/lib/preset-stack.test.ts
+++ b/packages/dashboard/src/lib/preset-stack.test.ts
@@ -9,8 +9,8 @@ function read(rel: string): string {
   return readFileSync(join(root, rel), "utf8");
 }
 
-describe("shadcn preset b3mPJeumm stack", () => {
-  test("components.json records the applied rhea/inter/lucide preset", () => {
+describe("terminal TUI stack", () => {
+  test("components.json still records the shadcn style metadata", () => {
     const config = JSON.parse(read("components.json")) as {
       style: string;
       iconLibrary: string;
@@ -22,18 +22,20 @@ describe("shadcn preset b3mPJeumm stack", () => {
     expect(config.tailwind.css).toBe("src/styles/tokens.css");
   });
 
-  test("tokens load Inter and do not declare the old grotesk/jetbrains stack", () => {
+  test("tokens load JetBrains Mono and pin a square terminal palette", () => {
     const tokens = read("src/styles/tokens.css");
-    expect(tokens).toContain('@import "@fontsource-variable/inter"');
-    expect(tokens).toContain("Inter Variable");
+    expect(tokens).toContain('@import "@fontsource-variable/jetbrains-mono"');
+    expect(tokens).toContain("JetBrains Mono Variable");
+    expect(tokens).not.toContain("Inter Variable");
     expect(tokens).not.toContain("Space Grotesk");
     expect(tokens).not.toContain("Hanken Grotesk");
-    expect(tokens).not.toContain("JetBrains Mono");
     expect(tokens).toContain("--font-heading");
     expect(tokens).toContain("var(--primary)");
+    expect(tokens).toContain("#0d1117");
+    expect(tokens).toContain("--radius: 0px");
   });
 
-  test("layouts that serve / do not import the old font packages", () => {
+  test("layouts that serve / do not import the old grotesk/inter packages", () => {
     for (const file of [
       "src/layouts/RootLayout.astro",
       "src/layouts/MarketingLayout.astro",
@@ -41,22 +43,24 @@ describe("shadcn preset b3mPJeumm stack", () => {
       const src = read(file);
       expect(src).not.toContain("@fontsource-variable/space-grotesk");
       expect(src).not.toContain("@fontsource-variable/hanken-grotesk");
-      expect(src).not.toContain("@fontsource-variable/jetbrains-mono");
+      expect(src).not.toContain("@fontsource-variable/inter");
     }
     const pkg = read("package.json");
-    expect(pkg).toContain("@fontsource-variable/inter");
+    expect(pkg).toContain("@fontsource-variable/jetbrains-mono");
     expect(pkg).not.toContain("space-grotesk");
     expect(pkg).not.toContain("hanken-grotesk");
-    expect(pkg).not.toContain("jetbrains-mono");
+    expect(pkg).not.toContain("@fontsource-variable/inter");
   });
 
-  test("homepage code-tabs tab row wraps instead of painting a scrollbar", () => {
+  test("homepage is a terminal document with code-tabs that wrap", () => {
     const home = read("src/pages/index.astro");
     expect(home).toContain("TypeScript");
     expect(home).toContain("Vercel AI");
     expect(home).toContain("LangGraph");
     expect(home).toContain("Python");
     expect(home).toContain("REST");
+    expect(home).toContain("what's inside");
+    expect(home).toContain("TuiEditor");
     const tabs = read("src/components/home/code-tabs.astro");
     expect(tabs).toMatch(/data-ct-copy/);
     expect(tabs).toContain("flex-wrap");

--- a/packages/dashboard/src/pages/brand.astro
+++ b/packages/dashboard/src/pages/brand.astro
@@ -8,25 +8,25 @@ import { SITE_URL } from "../lib/site";
 
 // Color tokens — sourced from src/styles/tokens.css (single source of truth).
 const surfaces = [
-  { name: "base", hex: "#09090b", note: "app canvas" },
-  { name: "panel", hex: "#111113", note: "cards, table head" },
-  { name: "panel2", hex: "#161618", note: "hover / elevated" },
-  { name: "edge", hex: "#262629", note: "primary borders" },
-  { name: "edge-soft", hex: "#1f1f22", note: "subtle borders" },
+  { name: "base", hex: "#0d1117", note: "app canvas" },
+  { name: "panel", hex: "#0d1117", note: "cards, windows" },
+  { name: "panel2", hex: "#161b22", note: "hover / elevated" },
+  { name: "edge", hex: "#30363d", note: "primary borders" },
+  { name: "edge-soft", hex: "#30363d", note: "subtle borders" },
 ] as const;
 
 const textColors = [
-  { name: "fg", hex: "#fafafa", note: "headings / strong" },
-  { name: "fg-2", hex: "#d4d4d8", note: "body" },
-  { name: "fg-3", hex: "#a1a1aa", note: "muted" },
-  { name: "fg-4", hex: "#71717a", note: "faint" },
+  { name: "fg", hex: "#e6edf3", note: "headings / strong" },
+  { name: "fg-2", hex: "#e6edf3", note: "body" },
+  { name: "fg-3", hex: "#8b949e", note: "muted" },
+  { name: "fg-4", hex: "#8b949e", note: "faint" },
 ] as const;
 
 const accents = [
-  { name: "accent", hex: "#e2664d", note: "primary interactive" },
-  { name: "pos", hex: "#34d399", note: "positive / live" },
-  { name: "warn", hex: "#f59e0b", note: "warn / rate-limited" },
-  { name: "neg", hex: "#f87171", note: "negative / over-budget" },
+  { name: "accent", hex: "#3fb950", note: "primary interactive" },
+  { name: "pos", hex: "#3fb950", note: "positive / live" },
+  { name: "warn", hex: "#d29922", note: "warn / rate-limited" },
+  { name: "neg", hex: "#f85149", note: "negative / over-budget" },
 ] as const;
 
 const sizes = [16, 20, 28, 40, 56];
@@ -279,27 +279,27 @@ const iconAssets = [
       <div class="mb-6 font-mono text-[11px] uppercase tracking-[0.15em] text-fg-4">Typography</div>
       <div class="grid grid-cols-1 gap-3 lg:grid-cols-3">
         <Card class="p-6">
-          <div class="font-mono text-[10.5px] uppercase tracking-wider text-fg-4">Display · Inter</div>
-          <div class="mt-3 font-display text-[40px] font-semibold leading-[1.02] tracking-[-0.03em] text-fg">Any state, anywhere</div>
-          <div class="mt-2 font-display text-[17px] text-fg-3">Aa Bb Cc Dd · 0123456789</div>
+          <div class="font-mono text-[10.5px] uppercase tracking-wider text-fg-4">Display · JetBrains Mono</div>
+          <div class="mt-3 text-[22px] font-medium leading-relaxed text-fg"># any state, anywhere</div>
+          <div class="mt-2 text-[15px] text-fg-3">Aa Bb Cc Dd · 0123456789</div>
           <p class="mt-4 max-w-[52ch] text-[13.5px] leading-relaxed text-fg-3">
-            Inter sets headings and display type — the shadcn preset heading stack, inherited from the body sans.
+            JetBrains Mono is the only typeface — headings, UI, and code share the same terminal stack.
           </p>
         </Card>
         <Card class="p-6">
-          <div class="font-mono text-[10.5px] uppercase tracking-wider text-fg-4">Sans · Inter</div>
-          <div class="mt-3 text-[40px] font-semibold leading-[1.02] tracking-[-0.03em] text-fg">Any state, anywhere</div>
-          <div class="mt-2 text-[17px] text-fg-3">Aa Bb Cc Dd · 0123456789</div>
+          <div class="font-mono text-[10.5px] uppercase tracking-wider text-fg-4">UI · JetBrains Mono</div>
+          <div class="mt-3 text-[22px] font-medium leading-relaxed text-fg">$ agentstate init .</div>
+          <div class="mt-2 text-[15px] text-fg-3">Aa Bb Cc Dd · 0123456789</div>
           <p class="mt-4 max-w-[52ch] text-[13.5px] leading-relaxed text-fg-3">
-            Inter carries running UI text and body copy — the applied b3mPJeumm preset family.
+            Running UI text, nav, and body copy use the same monospace family as the landing page.
           </p>
         </Card>
         <Card class="p-6">
-          <div class="font-mono text-[10.5px] uppercase tracking-wider text-fg-4">Mono · system</div>
+          <div class="font-mono text-[10.5px] uppercase tracking-wider text-fg-4">Mono · JetBrains Mono</div>
           <div class="mt-3 font-mono text-[18px] text-fg">POST /api/v1/conversations</div>
           <div class="mt-2 font-mono text-[14px] text-fg-3">as_live_3DqrVIvIfxttEkYiAz1V</div>
           <p class="mt-4 max-w-[52ch] text-[13.5px] leading-relaxed text-fg-3">
-            The preset leaves mono on the system stack — used for endpoints, keys, tokens, and code.
+            Endpoints, keys, tokens, and code blocks inherit the same family — no second stack.
           </p>
         </Card>
       </div>
@@ -311,19 +311,19 @@ const iconAssets = [
       <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
         <Card class="p-6">
           <div class="flex h-16 items-center justify-center rounded-[var(--radius-sm)] border border-edge bg-panel2"></div>
-          <div class="mt-3 flex items-baseline justify-between"><span class="font-mono text-[12px] text-fg">radius-sm</span><span class="font-mono text-[11px] text-fg-4">6px</span></div>
+          <div class="mt-3 flex items-baseline justify-between"><span class="font-mono text-[12px] text-fg">radius-sm</span><span class="font-mono text-[11px] text-fg-4">0px</span></div>
         </Card>
         <Card class="p-6">
           <div class="flex h-16 items-center justify-center rounded-[var(--radius)] border border-edge bg-panel2"></div>
-          <div class="mt-3 flex items-baseline justify-between"><span class="font-mono text-[12px] text-fg">radius</span><span class="font-mono text-[11px] text-fg-4">9px</span></div>
+          <div class="mt-3 flex items-baseline justify-between"><span class="font-mono text-[12px] text-fg">radius</span><span class="font-mono text-[11px] text-fg-4">0px</span></div>
         </Card>
         <Card class="p-6">
           <div class="flex h-16 items-center justify-center rounded-[var(--radius-lg)] border border-edge bg-panel2"></div>
-          <div class="mt-3 flex items-baseline justify-between"><span class="font-mono text-[12px] text-fg">radius-lg</span><span class="font-mono text-[11px] text-fg-4">12px</span></div>
+          <div class="mt-3 flex items-baseline justify-between"><span class="font-mono text-[12px] text-fg">radius-lg</span><span class="font-mono text-[11px] text-fg-4">0px</span></div>
         </Card>
         <Card class="p-6">
           <div class="flex h-16 items-center justify-center rounded-[var(--radius-xl)] border border-edge bg-panel2"></div>
-          <div class="mt-3 flex items-baseline justify-between"><span class="font-mono text-[12px] text-fg">radius-xl</span><span class="font-mono text-[11px] text-fg-4">14px</span></div>
+          <div class="mt-3 flex items-baseline justify-between"><span class="font-mono text-[12px] text-fg">radius-xl</span><span class="font-mono text-[11px] text-fg-4">0px</span></div>
         </Card>
       </div>
     </section>
@@ -342,7 +342,7 @@ const iconAssets = [
               <li>Use the mark in its original proportions.</li>
               <li>Give it clear space equal to one layer height.</li>
               <li>Let it inherit <span class="font-mono text-fg-3">currentColor</span> — recolor via parent text.</li>
-              <li>Use the vermilion accent to highlight interactive moments.</li>
+              <li>Use the green accent to highlight interactive moments.</li>
             </ul>
           </Card>
           <Card class="p-6">

--- a/packages/dashboard/src/pages/compare.astro
+++ b/packages/dashboard/src/pages/compare.astro
@@ -43,39 +43,38 @@ const rows = [
 >
   <main>
     <section data-reveal>
-      <div class="mx-auto w-full max-w-6xl px-6 py-24 md:py-32">
-        <span class="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 text-[12.5px] text-muted-foreground"><span class="size-1.5 rounded-full bg-accent"></span>why AgentState</span>
-        <h1 class="mt-6 max-w-2xl text-3xl font-semibold leading-tight tracking-tight text-foreground md:text-4xl">
-          More than memory — coordination included.
+      <div class="mx-auto w-full max-w-[920px] px-5 py-12 sm:px-8 sm:py-16">
+        <h1 class="text-[16px] leading-relaxed text-foreground sm:text-[18px]">
+          <span class="tui-hash">#</span> more than memory — coordination included.
         </h1>
-        <p class="mt-4 max-w-xl text-[15px] leading-relaxed text-muted-foreground">
+        <p class="mt-4 max-w-[62ch] text-[14px] leading-relaxed text-muted-foreground">
           Memory and history tools store what happened. AgentState also coordinates what happens next — distributed locks, scoped delegation, and verifiable evidence baked in.
         </p>
 
-        <div class="mt-12 overflow-hidden overflow-x-auto rounded-xl border border-border bg-card">
-          <table class="w-full text-left text-[13.5px]">
+        <div class="mt-10 overflow-x-auto border border-border">
+          <table class="w-full text-left text-[13px]">
             <thead>
-              <tr class="border-b border-border font-mono text-[11px] uppercase text-muted-foreground">
-                <th class="px-5 py-3 font-medium">Capability</th>
-                <th class="px-5 py-3 font-medium">Memory-only / roll your own</th>
-                <th class="px-5 py-3 font-medium">AgentState</th>
+              <tr class="border-b border-border text-[12px] text-muted-foreground">
+                <th class="px-4 py-2 font-medium">capability</th>
+                <th class="px-4 py-2 font-medium">memory-only / roll your own</th>
+                <th class="px-4 py-2 font-medium">agentstate</th>
               </tr>
             </thead>
             <tbody>
               {rows.map((r) => (
                 <tr class="border-b border-border last:border-0 hover:bg-muted">
-                  <td class="px-5 py-3.5 text-foreground">{r.capability}</td>
-                  <td class="px-5 py-3.5 text-muted-foreground">{r.diy}</td>
-                  <td class="px-5 py-3.5 text-pos">{r.agentstate}</td>
+                  <td class="px-4 py-2.5 text-foreground">{r.capability}</td>
+                  <td class="px-4 py-2.5 text-muted-foreground">{r.diy}</td>
+                  <td class="px-4 py-2.5 text-primary">{r.agentstate}</td>
                 </tr>
               ))}
             </tbody>
           </table>
         </div>
 
-        <div class="mt-10 flex flex-wrap items-center gap-3">
-          <a href="/dashboard/" class="inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-[opacity,transform] duration-150 hover:opacity-90 active:scale-[0.96]">Start for free →</a>
-          <a href="/docs/" class="inline-flex items-center gap-1.5 rounded-[var(--radius)] border border-border px-5 py-2.5 text-sm font-medium text-foreground transition-[background-color,transform] duration-150 hover:bg-muted active:scale-[0.96]">View docs</a>
+        <div class="mt-8 flex flex-wrap items-center gap-4 text-[14px]">
+          <a href="/dashboard/" class="text-primary hover:opacity-80"><span class="tui-bracket">[</span>start<span class="tui-bracket">]</span></a>
+          <a href="/docs/" class="text-muted-foreground hover:text-foreground"><span class="tui-bracket">[</span>docs<span class="tui-bracket">]</span></a>
         </div>
       </div>
     </section>

--- a/packages/dashboard/src/pages/docs.astro
+++ b/packages/dashboard/src/pages/docs.astro
@@ -196,7 +196,7 @@ const permissionScopes: [scope: string, grants: string][] = [
                       <a
                         href={`#${id}`}
                         data-nav={id}
-                        class="block rounded-[var(--radius)] px-2.5 py-1.5 text-[13px] text-fg-3 hover:bg-panel2 hover:text-fg"
+                        class="block rounded-none px-2.5 py-1.5 text-[13px] text-fg-3 hover:bg-panel2 hover:text-fg"
                         aria-current="false"
                       >
                         {label}
@@ -212,39 +212,36 @@ const permissionScopes: [scope: string, grants: string][] = [
 
       <!-- main prose -->
       <article class="min-w-0 max-w-[680px]">
-        <div class="mb-4 flex items-center gap-2 font-mono text-[12px] text-fg-4">
-          <span>Docs</span>
+        <div class="mb-4 flex items-center gap-2 font-mono text-[12px] text-muted-foreground">
+          <span class="tui-key">~/docs</span>
           <span aria-hidden="true">/</span>
-          <span class="text-fg-3">Getting started</span>
+          <span>getting started</span>
         </div>
 
-        <h1 id="overview" class="scroll-mt-20 text-[34px] font-semibold leading-[1.05] tracking-[-0.03em] text-fg sm:text-[40px]">
-          Persist agent state in two minutes
+        <h1 id="overview" class="scroll-mt-20 text-[18px] font-medium leading-relaxed text-fg sm:text-[20px]">
+          <span class="tui-hash">#</span> persist agent state in two minutes
         </h1>
-        <p class="mt-4 max-w-[62ch] text-[17px] leading-[1.6] text-fg-3">
+        <p class="mt-4 max-w-[62ch] text-[14px] leading-[1.65] text-fg-3">
           AgentState is a state layer for AI agents. Store conversations, UI messages and graph
           checkpoints behind one REST API, then resume them from any runtime with a drop-in adapter.
         </p>
 
-        <div class="mt-7 flex flex-wrap gap-2.5">
+        <div class="mt-6 flex flex-wrap gap-4 text-[14px]">
           <a
             href="https://github.com/duyet/agentstate"
             target="_blank"
             rel="noreferrer"
-            class="inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-fg px-4 py-2 text-[13px] font-medium text-[var(--color-base)] hover:opacity-90"
+            class="text-primary hover:opacity-80"
           >
-            GitHub ↗
+            <span class="tui-bracket">[</span>github<span class="tui-bracket">]</span>
           </a>
-          <a
-            href="/dashboard/"
-            class="inline-flex items-center gap-1.5 rounded-[var(--radius)] border border-edge px-4 py-2 text-[13px] text-fg hover:bg-panel2"
-          >
-            Open dashboard
+          <a href="/dashboard/" class="text-muted-foreground hover:text-foreground">
+            <span class="tui-bracket">[</span>dashboard<span class="tui-bracket">]</span>
           </a>
         </div>
 
         <!-- Use with your AI agent -->
-        <h2 id="agent-prompt" class="mt-12 mb-1.5 scroll-mt-20 text-[22px] font-semibold tracking-[-0.02em] text-fg">Use with your AI agent</h2>
+        <h2 id="agent-prompt" class="mt-12 mb-1.5 scroll-mt-20 text-[16px] font-medium text-fg"><span class="tui-hash">##</span> Use with your AI agent</h2>
         <p class="mt-2 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
           Copy this prompt into Claude Code, Cursor, or any coding agent. It will discover the API and wire up AgentState for you.
         </p>
@@ -258,7 +255,7 @@ const permissionScopes: [scope: string, grants: string][] = [
         <CodeBlock class="mt-3" code={installSkillCode} lang="bash" filename="terminal" />
 
         <!-- Quickstart -->
-        <h2 id="quickstart" class="mt-12 mb-1.5 scroll-mt-20 text-[22px] font-semibold tracking-[-0.02em] text-fg">Quickstart</h2>
+        <h2 id="quickstart" class="mt-12 mb-1.5 scroll-mt-20 text-[16px] font-medium text-fg"><span class="tui-hash">##</span> Quickstart</h2>
         <p class="mt-2 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
           Install the SDK, create a project key in the dashboard, and store your first conversation.
         </p>
@@ -266,7 +263,7 @@ const permissionScopes: [scope: string, grants: string][] = [
         <CodeBlock class="mt-2.5" code={quickCode} lang="ts" filename="quickstart.ts" />
 
         <!-- Authentication -->
-        <h2 id="auth" class="mt-12 mb-1.5 scroll-mt-20 text-[22px] font-semibold tracking-[-0.02em] text-fg">Authentication</h2>
+        <h2 id="auth" class="mt-12 mb-1.5 scroll-mt-20 text-[16px] font-medium text-fg"><span class="tui-hash">##</span> Authentication</h2>
         <p class="mt-2 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
           Every request is authenticated with a project-scoped bearer key. Keys are SHA-256 hashed
           at rest and can be rotated or revoked from the dashboard.
@@ -280,7 +277,7 @@ const permissionScopes: [scope: string, grants: string][] = [
         </div>
 
         <!-- API surface -->
-        <h2 id="api-surface" class="mt-12 mb-1.5 scroll-mt-20 text-[22px] font-semibold tracking-[-0.02em] text-fg">API surface</h2>
+        <h2 id="api-surface" class="mt-12 mb-1.5 scroll-mt-20 text-[16px] font-medium text-fg"><span class="tui-hash">##</span> API surface</h2>
         <p class="mt-2 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
           Small enough for agents and humans to keep in context. A representative slice across
           state, leases, conversations, and analytics — see the sections below for the full list.
@@ -303,7 +300,7 @@ const permissionScopes: [scope: string, grants: string][] = [
         </Card>
 
         <!-- Conversations -->
-        <h2 id="conversations" class="mt-12 mb-1.5 scroll-mt-20 text-[22px] font-semibold tracking-[-0.02em] text-fg">Conversations</h2>
+        <h2 id="conversations" class="mt-12 mb-1.5 scroll-mt-20 text-[16px] font-medium text-fg"><span class="tui-hash">##</span> Conversations</h2>
         <p class="mt-2 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
           The core resource. Create with optional messages, append turns, then retrieve the full
           thread later with <code class="font-mono text-fg">?include=messages</code>.
@@ -323,7 +320,7 @@ const permissionScopes: [scope: string, grants: string][] = [
         </Card>
 
         <!-- Adapters -->
-        <h2 id="ai-sdk" class="mt-12 mb-1.5 scroll-mt-20 text-[22px] font-semibold tracking-[-0.02em] text-fg">Adapters</h2>
+        <h2 id="ai-sdk" class="mt-12 mb-1.5 scroll-mt-20 text-[16px] font-medium text-fg"><span class="tui-hash">##</span> Adapters</h2>
         <p class="mt-2 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
           Skip the wiring. Adapters map your framework's native state shape onto AgentState v2
           state — the same store powers Vercel AI SDK, TanStack, LangGraph and Cloudflare Agents.
@@ -343,7 +340,7 @@ const permissionScopes: [scope: string, grants: string][] = [
         </div>
 
         <!-- Remote MCP -->
-        <h2 id="mcp" class="mt-12 mb-1.5 scroll-mt-20 text-[22px] font-semibold tracking-[-0.02em] text-fg">Remote MCP</h2>
+        <h2 id="mcp" class="mt-12 mb-1.5 scroll-mt-20 text-[16px] font-medium text-fg"><span class="tui-hash">##</span> Remote MCP</h2>
         <p class="mt-2 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
           Connect Cursor, Claude Desktop, Windsurf, and any MCP client to the hosted server at
           <code class="font-mono text-fg">{MCP_URL}</code> — no install. Authenticate with a Bearer
@@ -358,7 +355,7 @@ const permissionScopes: [scope: string, grants: string][] = [
         </div>
 
         <!-- OAuth -->
-        <h2 id="oauth" class="mt-12 mb-1.5 scroll-mt-20 text-[22px] font-semibold tracking-[-0.02em] text-fg">OAuth</h2>
+        <h2 id="oauth" class="mt-12 mb-1.5 scroll-mt-20 text-[16px] font-medium text-fg"><span class="tui-hash">##</span> OAuth</h2>
         <p class="mt-2 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
           OAuth 2.1 + PKCE lets MCP clients connect without pasting a key. The user signs in, picks a
           project, and approves scopes on a consent screen. AgentState is both the authorization and
@@ -378,7 +375,7 @@ const permissionScopes: [scope: string, grants: string][] = [
         </Card>
 
         <!-- Permissions -->
-        <h2 id="permissions" class="mt-12 mb-1.5 scroll-mt-20 text-[22px] font-semibold tracking-[-0.02em] text-fg">Permissions</h2>
+        <h2 id="permissions" class="mt-12 mb-1.5 scroll-mt-20 text-[16px] font-medium text-fg"><span class="tui-hash">##</span> Permissions</h2>
         <p class="mt-2 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
           Keys and tokens carry scopes. A key created without scopes (or any legacy key) has full
           access. A key can only mint child keys with a subset of its own scopes; out-of-scope
@@ -398,7 +395,7 @@ const permissionScopes: [scope: string, grants: string][] = [
         </Card>
 
         <!-- Analytics -->
-        <h2 id="analytics" class="mt-12 mb-1.5 scroll-mt-20 text-[22px] font-semibold tracking-[-0.02em] text-fg">Analytics</h2>
+        <h2 id="analytics" class="mt-12 mb-1.5 scroll-mt-20 text-[16px] font-medium text-fg"><span class="tui-hash">##</span> Analytics</h2>
         <p class="mt-2 max-w-[62ch] text-[15px] leading-[1.65] text-fg-3">
           Usage is tracked per key. Query summaries and time-series for conversations, messages,
           tokens and cost.

--- a/packages/dashboard/src/pages/index.astro
+++ b/packages/dashboard/src/pages/index.astro
@@ -6,7 +6,7 @@ import HowItWorks from "../components/home/how-it-works.astro";
 // biome-ignore lint/correctness/noUnusedImports: Astro component imports are used in the template below
 import PackagesGrid from "../components/home/packages-grid.astro";
 // biome-ignore lint/correctness/noUnusedImports: Astro component imports are used in the template below
-import PrimitiveIcon from "../components/home/primitive-icon.astro";
+import TuiEditor from "../components/home/tui-editor.astro";
 // biome-ignore lint/correctness/noUnusedImports: Astro component imports are used in the template below
 import MarketingLayout from "../layouts/MarketingLayout.astro";
 import { API_BASE_URL, MCP_URL } from "../lib/site";
@@ -77,6 +77,22 @@ const features = [
     title: "Scoped API keys",
     body: "SHA-256-hashed bearer keys with subset delegation — issue a key that can only do what a sub-agent needs.",
   },
+] as const;
+
+// biome-ignore lint/correctness/noUnusedVariables: used in the template below
+const inside = [
+  { key: "state", desc: "versioned key/value with an append-only event log" },
+  { key: "leases", desc: "exactly-one-writer locks across N concurrent agents" },
+  { key: "claims", desc: "attach evidence to decisions so you can audit later" },
+  { key: "tokens", desc: "scoped, revocable, time-bounded delegation" },
+  { key: "conversations", desc: "CRUD, search, tags, bulk export, AI-generated titles" },
+  { key: "rest", desc: "cursor-paginated snake_case JSON, bearer-token auth" },
+  { key: "sdks", desc: "TypeScript, Python, Vercel AI SDK, LangGraph adapters" },
+  { key: "mcp", desc: "remote streamable-HTTP for Claude, Cursor, and Windsurf" },
+  { key: "search", desc: "project-wide full-text with snippets and tag filters" },
+  { key: "analytics", desc: "summaries and time-series across agents and tags" },
+  { key: "keys", desc: "SHA-256 hashed bearer keys with subset delegation" },
+  { key: "self-host", desc: "MIT forever — same Worker + D1 stack on your account" },
 ] as const;
 
 // biome-ignore lint/correctness/noUnusedVariables: used in the template below
@@ -340,166 +356,168 @@ curl https://agentstate.app/openapi.json`,
 >
   <script type="application/ld+json" set:html={JSON.stringify(softwareJsonLd)} />
   <script type="application/ld+json" set:html={JSON.stringify(organizationJsonLd)} />
-  <main>
-    <!-- hero -->
-    <section class="border-b border-border">
-      <div class="mx-auto grid w-full max-w-6xl gap-12 px-6 py-24 md:grid-cols-2 md:items-center md:py-32">
-        <div class="min-w-0" data-reveal>
-          <span class="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 text-[12.5px] text-muted-foreground"><span class="size-1.5 rounded-full bg-accent"></span>open source · MIT · free to start</span>
-          <h1 class="mt-6 text-4xl font-semibold leading-[1.05] tracking-tight text-foreground lg:text-6xl">
-            Conversation history for <span class="text-accent">AI agent fleets</span>.
-          </h1>
-          <p class="mt-6 max-w-[520px] text-lg leading-relaxed text-muted-foreground">
-            You're building AI agents — not a database backend. AgentState stores, searches, and coordinates every conversation and lock your fleet needs, behind one simple API.
-          </p>
-          <div class="mt-8 flex flex-wrap items-center gap-3">
-            <a href="/dashboard/" class="inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-[opacity,transform] duration-150 hover:opacity-90 active:scale-[0.96]">Start for free →</a>
-            <a href="/docs/" class="inline-flex items-center gap-1.5 rounded-[var(--radius)] border border-border px-5 py-2.5 text-sm font-medium text-foreground transition-[background-color,transform] duration-150 hover:bg-muted active:scale-[0.96]">View docs</a>
+  <main class="mx-auto w-full max-w-[920px] px-5 py-12 sm:px-8 sm:py-16">
+    <section data-reveal>
+      <h1 class="text-[16px] leading-relaxed text-foreground sm:text-[18px]">
+        <span class="tui-hash">#</span> agentstate — conversation history that lives at the edge.
+      </h1>
+      <p class="mt-1 text-[16px] leading-relaxed text-foreground sm:text-[18px]">
+        <span class="tui-hash">#</span> one api. five primitives. no redis, no postgres, no glue.
+      </p>
+      <p class="mt-8 text-[14px]">
+        <span class="tui-key">~/fleet</span>
+        <span class="text-muted-foreground"> $ </span>
+        <span class="text-foreground">agentstate init .</span>
+      </p>
+      <div class="mt-4 flex flex-wrap gap-x-4 gap-y-2 text-[14px]">
+        <a href="/dashboard/" class="text-primary hover:opacity-80"><span class="tui-bracket">[</span>start<span class="tui-bracket">]</span></a>
+        <a href="/docs/" class="text-muted-foreground hover:text-foreground"><span class="tui-bracket">[</span>docs<span class="tui-bracket">]</span></a>
+        <a href="/compare/" class="text-muted-foreground hover:text-foreground"><span class="tui-bracket">[</span>compare<span class="tui-bracket">]</span></a>
+        <a href="https://github.com/duyet/agentstate" class="text-muted-foreground hover:text-foreground" target="_blank" rel="noopener noreferrer"><span class="tui-bracket">[</span>github<span class="tui-bracket">]</span></a>
+      </div>
+      <TuiEditor class="mt-10" />
+    </section>
+
+    <section data-reveal class="mt-14" id="inside">
+      <p class="text-[14px]">
+        <span class="tui-key">$</span>
+        <span class="text-muted-foreground"> # what's inside</span>
+      </p>
+      <dl class="mt-4 space-y-1.5 text-[13.5px] sm:text-[14px]">
+        {inside.map((item) => (
+          <div class="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
+            <dt class="tui-key w-[11.5rem] shrink-0">{item.key}</dt>
+            <dd class="text-muted-foreground">— {item.desc}</dd>
           </div>
-          <p class="mt-5 text-[12.5px] text-muted-foreground">Open source · free to start · no credit card</p>
-        </div>
-        <!-- min-w-0: grid items default to min-width:auto, so the code panel's
-             widest line stretches the track past the viewport on mobile. -->
-        <div class="min-w-0" data-reveal style="--reveal-delay:120ms">
-          <CodeTabs tabs={heroTabs} />
-        </div>
+        ))}
+      </dl>
+    </section>
+
+    <section data-reveal class="mt-14" id="how-it-works">
+      <p class="text-[14px]">
+        <span class="tui-key">$</span>
+        <span class="text-muted-foreground"> # how it works</span>
+      </p>
+      <p class="mt-3 max-w-[62ch] text-[14px] leading-relaxed text-muted-foreground">
+        Agents talk to one edge API. Five coordination primitives share auth, projects, and durable storage — so you never wire Redis locks, custom memory tables, and chat logs separately.
+      </p>
+      <div class="mt-8">
+        <HowItWorks />
       </div>
     </section>
 
-    <!-- how it works -->
-    <section data-reveal class="border-b border-border" id="how-it-works">
-      <div class="mx-auto w-full max-w-6xl px-6 py-24 md:py-32">
-        <h2 class="max-w-xl text-3xl font-semibold leading-tight tracking-tight text-foreground md:text-4xl">
-          How AgentState works.
-        </h2>
-        <p class="mt-4 max-w-lg text-[15px] leading-relaxed text-muted-foreground">
-          Agents talk to one edge API. Five coordination primitives share auth, projects, and durable storage — so you never wire Redis locks, custom memory tables, and chat logs separately.
-        </p>
-        <div class="mt-12">
-          <HowItWorks />
-        </div>
-      </div>
-    </section>
-
-    <!-- five primitives -->
-    <section data-reveal class="border-b border-border">
-      <div class="mx-auto w-full max-w-6xl px-6 py-24 md:py-32">
-        <h2 class="max-w-xl text-3xl font-semibold leading-tight tracking-tight text-foreground md:text-4xl">
-          Five primitives, one API.
-        </h2>
-        <p class="mt-4 max-w-lg text-[15px] leading-relaxed text-muted-foreground">Conversation history is the flagship, but every fleet also gets versioned state, distributed leases, verifiable claims, and scoped capability tokens — sharing the same auth, projects, and analytics.</p>
-        <div class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {primitives.map((p) => (
-            <div class="rounded-xl border border-border bg-card p-6 transition-colors hover:bg-muted">
-              <div class="grid size-9 place-items-center rounded-[var(--radius)] border border-border text-muted-foreground">
-                <PrimitiveIcon name={p.name} class="size-[18px]" />
-              </div>
-              <div class="mt-4 font-mono text-[11px] uppercase tracking-wider text-muted-foreground">{p.eyebrow}</div>
-              <div class="mt-1.5 text-[15px] font-medium text-foreground">{p.title}</div>
-              <p class="mt-1.5 text-[13.5px] leading-relaxed text-muted-foreground">{p.body}</p>
-            </div>
-          ))}
-          <div class="flex flex-col justify-center rounded-xl border border-border bg-card p-6">
-            <div class="text-[15px] font-medium text-foreground">Why not just memory?</div>
-            <p class="mt-1.5 text-[13.5px] leading-relaxed text-muted-foreground">See how these primitives stack up against a roll-your-own memory store.</p>
-            <a href="/compare/" class="mt-3 inline-flex items-center gap-1 text-[13px] font-medium text-accent hover:opacity-80">Compare →</a>
+    <section data-reveal class="mt-14">
+      <p class="text-[14px]">
+        <span class="tui-key">$</span>
+        <span class="text-muted-foreground"> # five primitives</span>
+      </p>
+      <dl class="mt-4 space-y-1.5 text-[13.5px] sm:text-[14px]">
+        {primitives.map((p) => (
+          <div class="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
+            <dt class="tui-key w-[11.5rem] shrink-0">{p.name}</dt>
+            <dd class="text-muted-foreground">— {p.title.toLowerCase()}. {p.body}</dd>
           </div>
-        </div>
+        ))}
+      </dl>
+      <p class="mt-4 text-[14px] text-muted-foreground">
+        why not just memory?
+        <a href="/compare/" class="ml-2 text-primary hover:opacity-80">[compare]</a>
+      </p>
+    </section>
+
+    <section data-reveal class="mt-14" id="install">
+      <p class="text-[14px]">
+        <span class="tui-key">$</span>
+        <span class="text-muted-foreground"> # install</span>
+      </p>
+      <p class="mt-3 max-w-[62ch] text-[14px] leading-relaxed text-muted-foreground">
+        Copy a recipe for your stack. Same API from TypeScript, Python, AI SDK, LangGraph, or raw REST.
+      </p>
+      <div class="mt-6 min-w-0">
+        <CodeTabs tabs={heroTabs} />
       </div>
     </section>
 
-    <!-- expanded examples -->
-    <section data-reveal class="border-b border-border" id="examples">
-      <div class="mx-auto w-full max-w-6xl px-6 py-24 md:py-32">
-        <h2 class="max-w-xl text-3xl font-semibold leading-tight tracking-tight text-foreground md:text-4xl">
-          Examples that ship.
-        </h2>
-        <p class="mt-4 max-w-lg text-[15px] leading-relaxed text-muted-foreground">
-          Copy a recipe for your stack. Syntax-highlighted snippets for TypeScript, Python, AI SDK, LangGraph, leases, MCP, and raw REST.
-        </p>
-        <div class="mt-12">
-          <CodeTabs tabs={exampleTabs} />
-        </div>
-        <p class="mt-6 text-[13.5px] text-muted-foreground">
-          Full guides in <a href="/docs/" class="font-medium text-accent hover:opacity-80">docs</a>
-          · runnable samples on
-          <a href="https://github.com/duyet/agentstate/tree/main/examples" class="font-medium text-accent hover:opacity-80" target="_blank" rel="noopener noreferrer">GitHub examples</a>
-        </p>
+    <section data-reveal class="mt-14" id="examples">
+      <p class="text-[14px]">
+        <span class="tui-key">$</span>
+        <span class="text-muted-foreground"> # examples that ship</span>
+      </p>
+      <div class="mt-6 min-w-0">
+        <CodeTabs tabs={exampleTabs} />
+      </div>
+      <p class="mt-4 text-[13.5px] text-muted-foreground">
+        full guides in <a href="/docs/" class="text-primary hover:opacity-80">[docs]</a>
+        · runnable samples on
+        <a href="https://github.com/duyet/agentstate/tree/main/examples" class="text-primary hover:opacity-80" target="_blank" rel="noopener noreferrer">[github/examples]</a>
+      </p>
+    </section>
+
+    <section data-reveal class="mt-14" id="packages">
+      <p class="text-[14px]">
+        <span class="tui-key">$</span>
+        <span class="text-muted-foreground"> # packages</span>
+      </p>
+      <p class="mt-3 max-w-[62ch] text-[14px] leading-relaxed text-muted-foreground">
+        Install the client for your language, wire MCP into your IDE, or call the REST API directly.
+      </p>
+      <div class="mt-6">
+        <PackagesGrid />
       </div>
     </section>
 
-    <!-- packages / SDKs -->
-    <section data-reveal class="border-b border-border" id="packages">
-      <div class="mx-auto w-full max-w-6xl px-6 py-24 md:py-32">
-        <h2 class="max-w-xl text-3xl font-semibold leading-tight tracking-tight text-foreground md:text-4xl">
-          Packages &amp; SDKs.
-        </h2>
-        <p class="mt-4 max-w-lg text-[15px] leading-relaxed text-muted-foreground">
-          Install the client for your language, wire MCP into your IDE, or call the REST API directly. Every package links to detailed setup.
-        </p>
-        <div class="mt-12">
-          <PackagesGrid />
-        </div>
-      </div>
-    </section>
-
-    <!-- feature grid -->
-    <section data-reveal class="border-b border-border">
-      <div class="mx-auto w-full max-w-6xl px-6 py-24 md:py-32">
-        <h2 class="max-w-xl text-3xl font-semibold leading-tight tracking-tight text-foreground md:text-4xl">
-          Everything a fleet needs to remember.
-        </h2>
-        <p class="mt-4 max-w-lg text-[15px] leading-relaxed text-muted-foreground">Beyond storage, AgentState ships auth, search, observability, and integrations — so you ship the agent, not the backend.</p>
-        <div class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {features.map((f) => (
-            <div class="rounded-xl border border-border bg-card p-6">
-              <div class="grid size-9 place-items-center rounded-[var(--radius)] border border-border text-muted-foreground">
-                <PrimitiveIcon name={f.icon} class="size-[18px]" />
-              </div>
-              <div class="mt-4 text-[15px] font-medium text-foreground">{f.title}</div>
-              <p class="mt-1.5 text-[13.5px] leading-relaxed text-muted-foreground">{f.body}</p>
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-
-    <!-- pricing teaser -->
-    <section data-reveal class="border-b border-border" id="pricing">
-      <div class="mx-auto w-full max-w-6xl px-6 py-24 md:py-32">
-        <div class="grid gap-10 md:grid-cols-2 md:items-center">
-          <div>
-            <h2 class="max-w-xl text-3xl font-semibold leading-tight tracking-tight text-foreground md:text-4xl">
-              AgentState is free.
-            </h2>
-            <p class="mt-4 max-w-lg text-[15px] leading-relaxed text-muted-foreground">
-              No paid tier. Use the hosted cloud without a credit card, or run the full MIT-licensed stack on your own Cloudflare account forever. Core primitives are never gated.
-            </p>
-            <a href="/pricing/" class="mt-8 inline-flex items-center gap-1.5 rounded-[var(--radius)] border border-border px-5 py-2.5 text-sm font-medium text-foreground transition-[background-color,transform] duration-150 hover:bg-muted active:scale-[0.96]">See pricing →</a>
+    <section data-reveal class="mt-14">
+      <p class="text-[14px]">
+        <span class="tui-key">$</span>
+        <span class="text-muted-foreground"> # also</span>
+      </p>
+      <dl class="mt-4 space-y-1.5 text-[13.5px] sm:text-[14px]">
+        {features.map((f) => (
+          <div class="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
+            <dt class="tui-key w-[11.5rem] shrink-0">{f.title.toLowerCase()}</dt>
+            <dd class="text-muted-foreground">— {f.body}</dd>
           </div>
-          <div class="grid gap-3 sm:grid-cols-2">
-            <div class="rounded-xl border border-border bg-card p-5">
-              <div class="font-mono text-[11px] uppercase tracking-wider text-accent">Cloud</div>
-              <div class="mt-2 text-2xl font-semibold tracking-tight text-foreground">$0</div>
-              <p class="mt-2 text-[13px] leading-relaxed text-muted-foreground">All five primitives · dashboard · SDKs · remote MCP</p>
-            </div>
-            <div class="rounded-xl border border-border bg-card p-5">
-              <div class="font-mono text-[11px] uppercase tracking-wider text-muted-foreground">Self-host</div>
-              <div class="mt-2 text-2xl font-semibold tracking-tight text-foreground">$0</div>
-              <p class="mt-2 text-[13px] leading-relaxed text-muted-foreground">MIT forever · your D1 · your limits</p>
-            </div>
-          </div>
-        </div>
-      </div>
+        ))}
+      </dl>
     </section>
 
-    <!-- CTA band -->
-    <section data-reveal class="py-24 text-center md:py-32">
-      <div class="mx-auto w-full max-w-2xl px-6">
-        <h2 class="text-3xl font-semibold tracking-tight text-foreground md:text-4xl">Ship the agent,<br />not the backend.</h2>
-        <p class="mx-auto mt-4 max-w-md text-muted-foreground">Spin up a project, grab a key, and persist your first conversation in two minutes. No credit card required.</p>
-        <a href="/dashboard/" class="mt-8 inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-[opacity,transform] duration-150 hover:opacity-90 active:scale-[0.96]">Start for free →</a>
+    <section data-reveal class="mt-14" id="pricing">
+      <p class="text-[14px]">
+        <span class="tui-key">$</span>
+        <span class="text-muted-foreground"> # pricing</span>
+      </p>
+      <p class="mt-3 max-w-[62ch] text-[14px] leading-relaxed text-muted-foreground">
+        AgentState is free. No paid tier. Use the hosted cloud without a credit card, or run the full MIT-licensed stack on your own Cloudflare account forever.
+      </p>
+      <div class="mt-6 grid gap-px border border-border bg-border sm:grid-cols-2">
+        <div class="bg-background p-5">
+          <div class="tui-key">cloud</div>
+          <div class="mt-2 text-[22px] text-foreground">$0</div>
+          <p class="mt-2 text-[13px] text-muted-foreground">all five primitives · dashboard · sdks · remote mcp</p>
+        </div>
+        <div class="bg-background p-5">
+          <div class="text-muted-foreground">self-host</div>
+          <div class="mt-2 text-[22px] text-foreground">$0</div>
+          <p class="mt-2 text-[13px] text-muted-foreground">mit forever · your d1 · your limits</p>
+        </div>
       </div>
+      <p class="mt-4 text-[14px]">
+        <a href="/pricing/" class="text-muted-foreground hover:text-foreground"><span class="tui-bracket">[</span>see pricing<span class="tui-bracket">]</span></a>
+      </p>
+    </section>
+
+    <section data-reveal class="mt-16 pb-8">
+      <p class="text-[16px] leading-relaxed text-foreground sm:text-[18px]">
+        <span class="tui-hash">#</span> ship the agent, not the backend.
+      </p>
+      <p class="mt-2 max-w-[52ch] text-[14px] text-muted-foreground">
+        Spin up a project, grab a key, and persist your first conversation in two minutes. no credit card.
+      </p>
+      <p class="mt-5 text-[14px]">
+        <span class="tui-key">~/fleet</span>
+        <span class="text-muted-foreground"> $ </span>
+        <a href="/dashboard/" class="text-primary hover:opacity-80">agentstate start</a>
+      </p>
     </section>
   </main>
 </MarketingLayout>

--- a/packages/dashboard/src/pages/pricing.astro
+++ b/packages/dashboard/src/pages/pricing.astro
@@ -91,50 +91,39 @@ const cell = (v: boolean | string) => {
 >
   <main>
     <section data-reveal>
-      <div class="mx-auto w-full max-w-6xl px-6 py-24 md:py-32">
-        <span class="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 text-[12.5px] text-muted-foreground"><span class="size-1.5 rounded-full bg-accent"></span>pricing</span>
-        <h1 class="mt-6 max-w-2xl text-3xl font-semibold leading-tight tracking-tight text-foreground md:text-4xl">
-          AgentState is free.
+      <div class="mx-auto w-full max-w-[920px] px-5 py-12 sm:px-8 sm:py-16">
+        <h1 class="text-[16px] leading-relaxed text-foreground sm:text-[18px]">
+          <span class="tui-hash">#</span> agentstate is free.
         </h1>
-        <p class="mt-4 max-w-xl text-[15px] leading-relaxed text-muted-foreground">
+        <p class="mt-4 max-w-[62ch] text-[14px] leading-relaxed text-muted-foreground">
           There is no paid tier and no upgrade path to sell you. Use the hosted cloud without a credit card, or run the same MIT-licensed stack on your own Cloudflare account. Every primitive is included in both.
         </p>
 
-        <div class="mt-14 grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div class="mt-10 grid grid-cols-1 gap-px border border-border bg-border md:grid-cols-2">
           {tiers.map((t) => (
-            <div
-              class:list={[
-                "flex flex-col rounded-xl border bg-card p-6",
-                t.featured ? "border-accent/50 ring-1 ring-accent/30" : "border-border",
-              ]}
-            >
-              <div class="font-mono text-[11px] uppercase tracking-wider text-muted-foreground">{t.name}</div>
+            <div class="flex flex-col bg-background p-5">
+              <div class="tui-key">{t.name.toLowerCase()}</div>
               <div class="mt-3 flex items-baseline gap-2">
-                <span class="text-3xl font-semibold tracking-tight text-foreground">{t.price}</span>
+                <span class="text-[22px] text-foreground">{t.price}</span>
                 <span class="text-[13px] text-muted-foreground">{t.period}</span>
               </div>
               <p class="mt-3 text-[13.5px] leading-relaxed text-muted-foreground">{t.blurb}</p>
-              <ul class="mt-6 flex-1 space-y-2.5">
+              <ul class="mt-6 flex-1 space-y-2">
                 {t.features.map((f) => (
-                  <li class="flex gap-2 text-[13.5px] text-foreground">
-                    <span class="mt-1.5 size-1.5 shrink-0 rounded-full bg-accent" aria-hidden="true" />
-                    <span class="text-muted-foreground">{f}</span>
+                  <li class="flex gap-2 text-[13.5px] text-muted-foreground">
+                    <span class="tui-key shrink-0">—</span>
+                    <span>{f}</span>
                   </li>
                 ))}
               </ul>
               <a
                 href={t.cta.href}
-                class:list={[
-                  "mt-8 inline-flex items-center justify-center rounded-[var(--radius)] px-4 py-2.5 text-sm font-medium transition-[opacity,background-color,transform] duration-150 active:scale-[0.96]",
-                  t.cta.primary
-                    ? "bg-primary text-primary-foreground hover:opacity-90"
-                    : "border border-border text-foreground hover:bg-muted",
-                ]}
+                class="mt-8 text-[14px] text-primary hover:opacity-80"
                 {...("external" in t.cta && t.cta.external
                   ? { target: "_blank", rel: "noopener noreferrer" }
                   : {})}
               >
-                {t.cta.label}
+                <span class="tui-bracket">[</span>{t.cta.label.replace(" →", "")}<span class="tui-bracket">]</span>
               </a>
             </div>
           ))}
@@ -143,23 +132,25 @@ const cell = (v: boolean | string) => {
     </section>
 
     <section data-reveal class="border-t border-border">
-      <div class="mx-auto w-full max-w-6xl px-6 py-24 md:py-32">
-        <h2 class="text-2xl font-semibold tracking-tight text-foreground md:text-3xl">Compare options</h2>
-        <div class="mt-10 overflow-hidden overflow-x-auto rounded-xl border border-border bg-card">
-          <table class="w-full text-left text-[13.5px]">
+      <div class="mx-auto w-full max-w-[920px] px-5 py-12 sm:px-8 sm:py-16">
+        <h2 class="text-[16px] text-foreground">
+          <span class="tui-hash">##</span> compare options
+        </h2>
+        <div class="mt-8 overflow-x-auto border border-border">
+          <table class="w-full text-left text-[13px]">
             <thead>
-              <tr class="border-b border-border font-mono text-[11px] uppercase text-muted-foreground">
-                <th class="px-5 py-3 font-medium">Feature</th>
-                <th class="px-5 py-3 font-medium">Cloud</th>
-                <th class="px-5 py-3 font-medium">Self-host</th>
+              <tr class="border-b border-border text-[12px] text-muted-foreground">
+                <th class="px-4 py-2 font-medium">feature</th>
+                <th class="px-4 py-2 font-medium">cloud</th>
+                <th class="px-4 py-2 font-medium">self-host</th>
               </tr>
             </thead>
             <tbody>
               {comparison.map((row) => (
                 <tr class="border-b border-border last:border-0 hover:bg-muted">
-                  <td class="px-5 py-3.5 text-foreground">{row.feature}</td>
-                  <td class="px-5 py-3.5 text-muted-foreground">{cell(row.cloud)}</td>
-                  <td class="px-5 py-3.5 text-muted-foreground">{cell(row.self)}</td>
+                  <td class="px-4 py-2.5 text-foreground">{row.feature}</td>
+                  <td class="px-4 py-2.5 text-muted-foreground">{cell(row.cloud)}</td>
+                  <td class="px-4 py-2.5 text-muted-foreground">{cell(row.self)}</td>
                 </tr>
               ))}
             </tbody>
@@ -169,34 +160,38 @@ const cell = (v: boolean | string) => {
     </section>
 
     <section data-reveal class="border-t border-border">
-      <div class="mx-auto w-full max-w-6xl px-6 py-24 md:py-32">
-        <h2 class="text-2xl font-semibold tracking-tight text-foreground md:text-3xl">FAQ</h2>
-        <div class="mt-10 grid gap-6 md:grid-cols-2">
+      <div class="mx-auto w-full max-w-[920px] px-5 py-12 sm:px-8 sm:py-16">
+        <h2 class="text-[16px] text-foreground">
+          <span class="tui-hash">##</span> faq
+        </h2>
+        <div class="mt-8 grid gap-6 md:grid-cols-2">
           {faqs.map((item) => (
-            <div class="rounded-xl border border-border bg-card p-6">
-              <h3 class="text-[15px] font-medium text-foreground">{item.q}</h3>
+            <div class="border border-border p-5">
+              <h3 class="text-[14px] text-foreground">{item.q}</h3>
               <p class="mt-2 text-[13.5px] leading-relaxed text-muted-foreground">{item.a}</p>
             </div>
           ))}
         </div>
         <p class="mt-10 text-[13.5px] text-muted-foreground">
-          More detail:
-          <a href="/docs/" class="text-accent hover:opacity-80">Docs</a>
+          more detail:
+          <a href="/docs/" class="text-primary hover:opacity-80">[docs]</a>
           ·
-          <a href="https://github.com/duyet/agentstate/blob/main/docs/data-handling.md" class="text-accent hover:opacity-80" target="_blank" rel="noopener noreferrer">Data handling</a>
+          <a href="https://github.com/duyet/agentstate/blob/main/docs/data-handling.md" class="text-primary hover:opacity-80" target="_blank" rel="noopener noreferrer">[data handling]</a>
           ·
-          <a href="https://github.com/duyet/agentstate/blob/main/ROADMAP.md" class="text-accent hover:opacity-80" target="_blank" rel="noopener noreferrer">Roadmap principles</a>
+          <a href="https://github.com/duyet/agentstate/blob/main/ROADMAP.md" class="text-primary hover:opacity-80" target="_blank" rel="noopener noreferrer">[roadmap]</a>
         </p>
       </div>
     </section>
 
-    <section data-reveal class="border-t border-border py-24 text-center md:py-32">
-      <div class="mx-auto w-full max-w-2xl px-6">
-        <h2 class="text-3xl font-semibold tracking-tight text-foreground md:text-4xl">Ready in two minutes.</h2>
-        <p class="mx-auto mt-4 max-w-md text-muted-foreground">Create a project, grab a key, persist a conversation. No card required.</p>
-        <div class="mt-8 flex flex-wrap items-center justify-center gap-3">
-          <a href="/dashboard/" class="inline-flex items-center gap-1.5 rounded-[var(--radius)] bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-[opacity,transform] duration-150 hover:opacity-90 active:scale-[0.96]">Start for free →</a>
-          <a href="/docs/" class="inline-flex items-center gap-1.5 rounded-[var(--radius)] border border-border px-5 py-2.5 text-sm font-medium text-foreground transition-[background-color,transform] duration-150 hover:bg-muted active:scale-[0.96]">View docs</a>
+    <section data-reveal class="border-t border-border py-12 sm:py-16">
+      <div class="mx-auto w-full max-w-[920px] px-5 sm:px-8">
+        <h2 class="text-[16px] leading-relaxed text-foreground sm:text-[18px]">
+          <span class="tui-hash">#</span> ready in two minutes.
+        </h2>
+        <p class="mt-3 max-w-[52ch] text-[14px] text-muted-foreground">Create a project, grab a key, persist a conversation. no card required.</p>
+        <div class="mt-6 flex flex-wrap items-center gap-4 text-[14px]">
+          <a href="/dashboard/" class="text-primary hover:opacity-80"><span class="tui-bracket">[</span>start<span class="tui-bracket">]</span></a>
+          <a href="/docs/" class="text-muted-foreground hover:text-foreground"><span class="tui-bracket">[</span>docs<span class="tui-bracket">]</span></a>
         </div>
       </div>
     </section>

--- a/packages/dashboard/src/styles/global.css
+++ b/packages/dashboard/src/styles/global.css
@@ -1,5 +1,5 @@
 /*
- * Dashboard stylesheet. tokens.css owns the shadcn preset (b3mPJeumm) plus
+ * Dashboard stylesheet. tokens.css owns the terminal TUI palette plus
  * legacy name aliases. This file adds utilities and motion only.
  */
 @import "./tokens.css";
@@ -9,7 +9,7 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground font-sans;
+    @apply bg-background text-foreground font-mono;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
   }
@@ -20,15 +20,48 @@
   h4,
   h5 {
     font-family: var(--font-display);
-    font-weight: 600;
-    letter-spacing: -0.02em;
-    line-height: 1.1;
+    font-weight: 500;
+    letter-spacing: 0;
+    line-height: 1.35;
     text-wrap: balance;
   }
 
   ::selection {
-    background: color-mix(in oklch, var(--primary) 30%, transparent);
+    background: color-mix(in srgb, var(--primary) 30%, transparent);
   }
+}
+
+@utility tui-hash {
+  color: var(--muted-foreground);
+  font-weight: 400;
+  user-select: none;
+}
+
+@utility tui-key {
+  color: var(--tui-key);
+}
+
+@utility tui-prompt {
+  color: var(--muted-foreground);
+}
+
+@utility tui-bracket {
+  color: var(--muted-foreground);
+}
+
+@utility tui-window {
+  border: 1px solid var(--border);
+  background: var(--background);
+}
+
+@utility tui-status {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem 1.25rem;
+  border-top: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--muted-foreground);
 }
 
 @utility as-label {

--- a/packages/dashboard/src/styles/tokens.css
+++ b/packages/dashboard/src/styles/tokens.css
@@ -1,8 +1,9 @@
 /*
- * Design tokens. shadcn preset b3mPJeumm (Rhea / Inter / orange / lucide)
- * is the source of truth for color, type, and radius. Legacy AgentState
- * names (base/panel/fg/edge/accent) alias onto those variables so existing
- * markup keeps working without a parallel palette.
+ * Design tokens — terminal TUI.
+ *
+ * Dark canvas, monospace type, square corners, no chrome depth.
+ * Legacy AgentState names (base/panel/fg/edge/accent) alias onto these
+ * variables so existing markup keeps working without a parallel palette.
  *
  * Imported by global.css so both RootLayout and MarketingLayout resolve
  * the same tokens.
@@ -10,15 +11,15 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
-@import "@fontsource-variable/inter";
+@import "@fontsource-variable/jetbrains-mono";
 
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-  --font-sans: "Inter Variable", ui-sans-serif, system-ui, sans-serif;
+  --font-sans: "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   --font-heading: var(--font-sans);
   --font-display: var(--font-sans);
-  --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --font-mono: var(--font-sans);
 
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -73,105 +74,108 @@
   --color-ink-2: var(--foreground);
   --color-faint: var(--muted-foreground);
   --color-line-soft: var(--border);
+  --color-tui-key: var(--tui-key);
 
-  --radius-sm: calc(var(--radius) * 0.6);
-  --radius-md: calc(var(--radius) * 0.8);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) * 1.4);
-  --radius-2xl: calc(var(--radius) * 1.8);
-  --radius-3xl: calc(var(--radius) * 2.2);
-  --radius-4xl: calc(var(--radius) * 2.6);
+  --radius-sm: 0px;
+  --radius-md: 0px;
+  --radius-lg: 0px;
+  --radius-xl: 0px;
+  --radius-2xl: 0px;
+  --radius-3xl: 0px;
+  --radius-4xl: 0px;
 }
 
 @theme {
   /* Functional status — not a chrome palette. */
-  --color-pos: #34d399;
-  --color-warn: #f59e0b;
+  --color-pos: #3fb950;
+  --color-warn: #d29922;
 
   /* Brand-asset swatches stay theme-fixed. */
-  --color-swatch-light: #f4f4f5;
-  --color-swatch-light-fg: #18181b;
-  --color-swatch-dark: #09090b;
-  --color-swatch-dark2: #0f0f11;
+  --color-swatch-light: #f6f8fa;
+  --color-swatch-light-fg: #1f2328;
+  --color-swatch-dark: #0d1117;
+  --color-swatch-dark2: #161b22;
 }
 
 :root {
   color-scheme: light;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.553 0.195 38.402);
-  --primary-foreground: oklch(0.98 0.016 73.684);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.837 0.128 66.29);
-  --chart-2: oklch(0.705 0.213 47.604);
-  --chart-3: oklch(0.646 0.222 41.116);
-  --chart-4: oklch(0.553 0.195 38.402);
-  --chart-5: oklch(0.47 0.157 37.304);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.646 0.222 41.116);
-  --sidebar-primary-foreground: oklch(0.98 0.016 73.684);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
-  --brand-soft: color-mix(in oklch, var(--primary) 12%, transparent);
-  --brand-line: color-mix(in oklch, var(--primary) 28%, transparent);
-  --color-pos: #059669;
-  --color-warn: #d97706;
+  --background: #f6f8fa;
+  --foreground: #1f2328;
+  --card: #ffffff;
+  --card-foreground: #1f2328;
+  --popover: #ffffff;
+  --popover-foreground: #1f2328;
+  --primary: #1a7f37;
+  --primary-foreground: #f6f8fa;
+  --secondary: #eaeef2;
+  --secondary-foreground: #1f2328;
+  --muted: #eaeef2;
+  --muted-foreground: #656d76;
+  --accent: #eaeef2;
+  --accent-foreground: #1f2328;
+  --destructive: #cf222e;
+  --border: #d0d7de;
+  --input: #d0d7de;
+  --ring: #1a7f37;
+  --chart-1: #1a7f37;
+  --chart-2: #0969da;
+  --chart-3: #8250df;
+  --chart-4: #bf3989;
+  --chart-5: #d29922;
+  --radius: 0px;
+  --sidebar: #ffffff;
+  --sidebar-foreground: #1f2328;
+  --sidebar-primary: #1a7f37;
+  --sidebar-primary-foreground: #f6f8fa;
+  --sidebar-accent: #eaeef2;
+  --sidebar-accent-foreground: #1f2328;
+  --sidebar-border: #d0d7de;
+  --sidebar-ring: #1a7f37;
+  --brand-soft: color-mix(in srgb, var(--primary) 12%, transparent);
+  --brand-line: color-mix(in srgb, var(--primary) 28%, transparent);
+  --tui-key: #576b3d;
+  --color-pos: #1a7f37;
+  --color-warn: #9a6700;
 }
 
 .dark {
   color-scheme: dark;
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.47 0.157 37.304);
-  --primary-foreground: oklch(0.98 0.016 73.684);
-  --secondary: oklch(0.274 0.006 286.033);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.837 0.128 66.29);
-  --chart-2: oklch(0.705 0.213 47.604);
-  --chart-3: oklch(0.646 0.222 41.116);
-  --chart-4: oklch(0.553 0.195 38.402);
-  --chart-5: oklch(0.47 0.157 37.304);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.705 0.213 47.604);
-  --sidebar-primary-foreground: oklch(0.98 0.016 73.684);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
-  --brand-soft: color-mix(in oklch, var(--primary) 18%, transparent);
-  --brand-line: color-mix(in oklch, var(--primary) 34%, transparent);
-  --color-pos: #34d399;
-  --color-warn: #f59e0b;
+  --background: #0d1117;
+  --foreground: #e6edf3;
+  --card: #0d1117;
+  --card-foreground: #e6edf3;
+  --popover: #161b22;
+  --popover-foreground: #e6edf3;
+  --primary: #3fb950;
+  --primary-foreground: #0d1117;
+  --secondary: #161b22;
+  --secondary-foreground: #e6edf3;
+  --muted: #161b22;
+  --muted-foreground: #8b949e;
+  --accent: #161b22;
+  --accent-foreground: #e6edf3;
+  --destructive: #f85149;
+  --border: #30363d;
+  --input: #30363d;
+  --ring: #3fb950;
+  --chart-1: #3fb950;
+  --chart-2: #58a6ff;
+  --chart-3: #d2a8ff;
+  --chart-4: #ff7b72;
+  --chart-5: #d29922;
+  --sidebar: #0d1117;
+  --sidebar-foreground: #e6edf3;
+  --sidebar-primary: #3fb950;
+  --sidebar-primary-foreground: #0d1117;
+  --sidebar-accent: #161b22;
+  --sidebar-accent-foreground: #e6edf3;
+  --sidebar-border: #30363d;
+  --sidebar-ring: #3fb950;
+  --brand-soft: color-mix(in srgb, var(--primary) 18%, transparent);
+  --brand-line: color-mix(in srgb, var(--primary) 34%, transparent);
+  --tui-key: #8b9a6b;
+  --color-pos: #3fb950;
+  --color-warn: #d29922;
 }
 
 [data-theme-toggle] .icon-sun {
@@ -191,16 +195,18 @@ html,
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-sans);
+  font-family: var(--font-mono);
+  font-feature-settings: "liga" 1, "calt" 1;
   -webkit-font-smoothing: antialiased;
 }
 ::selection {
-  background: color-mix(in oklch, var(--primary) 30%, transparent);
+  background: color-mix(in srgb, var(--primary) 30%, transparent);
 }
 h1,
 h2,
 h3 {
   font-family: var(--font-heading);
+  font-weight: 500;
   text-wrap: balance;
 }
 p {
@@ -212,10 +218,10 @@ p {
 
 [data-reveal] {
   opacity: 0;
-  transform: translateY(14px);
+  transform: translateY(8px);
   transition:
-    opacity 0.5s cubic-bezier(0, 0, 0.2, 1) var(--reveal-delay, 0ms),
-    transform 0.5s cubic-bezier(0, 0, 0.2, 1) var(--reveal-delay, 0ms);
+    opacity 0.4s ease var(--reveal-delay, 0ms),
+    transform 0.4s ease var(--reveal-delay, 0ms);
 }
 [data-reveal].in {
   opacity: 1;
@@ -237,6 +243,6 @@ p {
     @apply bg-background text-foreground;
   }
   html {
-    @apply font-sans;
+    @apply font-mono;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Restyles the marketing site and dashboard into a terminal-like TUI, matching a druk-style landing: dark canvas, monospace type, square corners, markdown headings, and bracket links.

## What changed
- Design tokens: GitHub-dark `#0d1117` canvas, green `#3fb950` accent, radius `0`, JetBrains Mono as the only typeface
- Landing page: `#` headings, `$` prompts, `[start]` / `[docs]` links, and a TUI editor mockup
- Marketing pages (docs, pricing, compare, brand) and dashboard shell follow the same chrome
- UI primitives (button, card, input, dialog, badge) drop rounded/shadow chrome
- Default theme is dark (terminal) even when the OS prefers light; `[theme]` still toggles

## Validation
- `bun test src/lib` in `packages/dashboard` — 6 pass
- `PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_placeholder bun run build` — 17 pages built
- Local preview visual QA: dark canvas `#0d1117`, editor mock readable, docs/pricing/dashboard chrome consistent

Production still deploys from `main` via CI after merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01abc-c162-774e-8447-6b1fbd2fdba2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01abc-c162-774e-8447-6b1fbd2fdba2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Restyle the marketing experience and dashboard as a cohesive terminal-inspired TUI.

New Features:
- Add a terminal-style editor mockup and README-like content structure to the landing page.
- Present product capabilities, packages, examples, pricing, and navigation using terminal-inspired headings, prompts, and bracket links.

Enhancements:
- Rebrand the marketing site and dashboard around a shared terminal TUI visual system with GitHub-dark colors, green accents, JetBrains Mono typography, square corners, and flatter UI chrome.
- Restyle the dashboard shell, documentation, comparison, pricing, and brand pages to use the new terminal presentation.
- Update shared UI primitives and authentication/toast styling to remove rounded and shadowed chrome and align with the TUI theme.
- Document and test the terminal design system, including its typography, palette, radius, and homepage structure.

Build:
- Replace the Inter font dependency with JetBrains Mono Variable.

Documentation:
- Update dashboard design guidance and maintenance notes to describe the terminal TUI design system.

Tests:
- Update dashboard stack tests to validate JetBrains Mono, the terminal palette, square corners, and terminal landing-page content.